### PR TITLE
SSHD-253 Improve performance on ServerSession auth and idle timeout chec...

### DIFF
--- a/sshd-core/src/main/java/org/apache/sshd/SshServer.java
+++ b/sshd-core/src/main/java/org/apache/sshd/SshServer.java
@@ -98,9 +98,12 @@ import org.apache.sshd.server.keyprovider.SimpleGeneratorHostKeyProvider;
 import org.apache.sshd.server.session.ServerSession;
 import org.apache.sshd.server.session.SessionFactory;
 import org.apache.sshd.server.sftp.SftpSubsystem;
+import org.apache.sshd.server.session.ServerSessionTimeoutListener;
 import org.apache.sshd.server.shell.ProcessShellFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.*;
 
 /**
  * The SshServer class is the main entry point for the server side of the SSH protocol.
@@ -140,6 +143,8 @@ public class SshServer extends AbstractFactoryManager implements ServerFactoryMa
     protected PasswordAuthenticator passwordAuthenticator;
     protected PublickeyAuthenticator publickeyAuthenticator;
     protected GSSAuthenticator gssAuthenticator;
+    protected ServerSessionTimeoutListener sessionTimeoutListener;
+    protected ScheduledFuture<?> timeoutListenerFuture;
 
     public SshServer() {
     }
@@ -300,6 +305,13 @@ public class SshServer extends AbstractFactoryManager implements ServerFactoryMa
         sessionFactory.setServer(this);
         acceptor = createAcceptor();
 
+        // set up the the session timeout listener and schedule it
+        sessionTimeoutListener = createSessionTimeoutListener();
+        sessionFactory.addListener(sessionTimeoutListener);
+
+        timeoutListenerFuture = getScheduledExecutorService()
+                .scheduleAtFixedRate(sessionTimeoutListener, 1, 1, TimeUnit.SECONDS);
+
         if (host != null) {
             String[] hosts = host.split(",");
             LinkedList<InetSocketAddress> addresses = new LinkedList<InetSocketAddress>();
@@ -344,6 +356,9 @@ public class SshServer extends AbstractFactoryManager implements ServerFactoryMa
         for (AbstractSession session : sessions) {
             session.close(immediately).addListener(listener);
         }
+
+        stopSessionTimeoutListener();
+
         if (!immediately) {
             latch.await();
         }
@@ -377,6 +392,25 @@ public class SshServer extends AbstractFactoryManager implements ServerFactoryMa
 
     protected SessionFactory createSessionFactory() {
         return new SessionFactory();
+    }
+
+    protected ServerSessionTimeoutListener createSessionTimeoutListener() {
+        return new ServerSessionTimeoutListener();
+    }
+
+    protected void stopSessionTimeoutListener() {
+        // cancel the timeout monitoring task
+        if (timeoutListenerFuture != null) {
+            timeoutListenerFuture.cancel(true);
+            timeoutListenerFuture = null;
+        }
+
+        // remove the sessionTimeoutListener completely; should the SSH server be restarted, a new one
+        // will be created.
+        if (sessionFactory != null && sessionTimeoutListener != null) {
+            sessionFactory.removeListener(sessionTimeoutListener);
+        }
+        sessionTimeoutListener = null;
     }
 
     public static SshServer setUpDefaultServer() {

--- a/sshd-core/src/main/java/org/apache/sshd/client/session/ClientSessionImpl.java
+++ b/sshd-core/src/main/java/org/apache/sshd/client/session/ClientSessionImpl.java
@@ -323,7 +323,7 @@ public class ClientSessionImpl extends AbstractSession implements ClientSession 
                 switch (getState()) {
                     case ReceiveKexInit:
                         if (cmd != SshConstants.Message.SSH_MSG_KEXINIT) {
-                            log.error("Ignoring command " + cmd + " while waiting for " + SshConstants.Message.SSH_MSG_KEXINIT);
+                            log.error("Ignoring command {} while waiting for {}", cmd, SshConstants.Message.SSH_MSG_KEXINIT);
                             break;
                         }
                         log.info("Received SSH_MSG_KEXINIT");
@@ -369,8 +369,7 @@ public class ClientSessionImpl extends AbstractSession implements ClientSession 
                         }
                         if (cmd == SshConstants.Message.SSH_MSG_USERAUTH_BANNER) {
                             String welcome = buffer.getString();
-                            String lang = buffer.getString();
-                            log.debug("Welcome banner: " + welcome);
+                            log.debug("Welcome banner: {}", welcome);
                             UserInteraction ui = getClientFactoryManager().getUserInteraction();
                             if (ui != null) {
                                 ui.welcome(welcome);

--- a/sshd-core/src/main/java/org/apache/sshd/common/session/AbstractSession.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/session/AbstractSession.java
@@ -534,7 +534,7 @@ public abstract class AbstractSession implements Session {
                     // need more data
                     break;
                 }
-            // We have received the beinning of the packet
+            // We have received the beginning of the packet
             } else if (decoderState == 1) {
                 // The read position should always be 4 at this point
                 assert decoderBuffer.rpos() == 4;
@@ -556,8 +556,7 @@ public abstract class AbstractSession implements Session {
                         inMac.doFinal(inMacResult, 0);
                         // Check the computed result with the received mac (just after the packet data)
                         if (!BufferUtils.equals(inMacResult, 0, data, decoderLength + 4, macSize)) {
-                            throw new SshException(SshConstants.SSH2_DISCONNECT_MAC_ERROR,
-                                                   "MAC Error");
+                            throw new SshException(SshConstants.SSH2_DISCONNECT_MAC_ERROR, "MAC Error");
                         }
                     }
                     // Increment incoming packet sequence number

--- a/sshd-core/src/main/java/org/apache/sshd/server/session/ServerSessionTimeoutListener.java
+++ b/sshd-core/src/main/java/org/apache/sshd/server/session/ServerSessionTimeoutListener.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sshd.server.session;
+
+import org.apache.mina.util.ConcurrentHashSet;
+import org.apache.sshd.common.Session;
+import org.apache.sshd.common.SessionListener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Set;
+
+/**
+ * Task that iterates over all currently open {@link ServerSession}s and checks each of them for timeouts. If 
+ * the {@link ServerSession} has timed out (either auth or idle timeout), the session will be disconnected.
+ *
+ * @see org.apache.sshd.server.session.ServerSession#checkForTimeouts()
+ */
+public class ServerSessionTimeoutListener implements SessionListener, Runnable {
+    private final Logger log = LoggerFactory.getLogger(ServerSessionTimeoutListener.class);
+    
+    private final Set<ServerSession> sessions = new ConcurrentHashSet<ServerSession>();
+
+    public void sessionCreated(Session session) {
+        if (session instanceof ServerSession) {
+            sessions.add((ServerSession) session);
+        }
+        
+    }
+
+    public void sessionChanged(Session session) {
+        // ignore
+    }
+
+    public void sessionClosed(Session s) {
+        sessions.remove(s);
+    }
+
+    public void run() {
+        for (ServerSession session : sessions) {
+            try {
+                session.checkForTimeouts();
+            } catch (Exception e) {
+                log.warn("An error occurred while checking session timeouts", e);
+            }
+        }
+    }
+}

--- a/sshd-core/src/test/java/org/apache/sshd/CompressionTest.java
+++ b/sshd-core/src/test/java/org/apache/sshd/CompressionTest.java
@@ -121,18 +121,21 @@ public class CompressionTest {
         });
         s.connect();
         com.jcraft.jsch.Channel c = s.openChannel("shell");
-        c.connect();
-        OutputStream os = c.getOutputStream();
-        InputStream is = c.getInputStream();
-        for (int i = 0; i < 10; i++) {
-            os.write("this is my command\n".getBytes());
-            os.flush();
-            byte[] data = new byte[512];
-            int len = is.read(data);
-            String str = new String(data, 0, len);
-            assertEquals("this is my command\n", str);
+        try {
+            c.connect();
+            OutputStream os = c.getOutputStream();
+            InputStream is = c.getInputStream();
+            for (int i = 0; i < 10; i++) {
+                os.write("this is my command\n".getBytes());
+                os.flush();
+                byte[] data = new byte[512];
+                int len = is.read(data);
+                String str = new String(data, 0, len);
+                assertEquals("this is my command\n", str);
+            }
+        } finally {
+            c.disconnect();
+            s.disconnect();
         }
-        c.disconnect();
-        s.disconnect();
     }
 }


### PR DESCRIPTION
Refactoring of the way ServerSession checks for auth and idle timeouts. The
original version was creating, scheduling and unscheduling many Runnable
instances while the ServerSession is active. This refactored version creates an
'idle ping' Runnable that checks each of the currently running ServerSessions
for timeouts. This check is run once every second.
