### PR TITLE
SSHD-254 Suppress 'Authentication with partial success' message on authentication

### DIFF
--- a/sshd-core/src/main/java/org/apache/sshd/server/session/ServerSession.java
+++ b/sshd-core/src/main/java/org/apache/sshd/server/session/ServerSession.java
@@ -538,7 +538,7 @@ public class ServerSession extends AbstractSession {
                     }
                 }
                 buffer.putString(sb.toString());
-                buffer.putByte((byte) 1);
+                buffer.putByte((byte) 0);
                 writePacket(buffer);
 
                 if (currentAuth != null) {


### PR DESCRIPTION
Version 0.9.0 incorrectly sends back a 'partial success true' flag when a client requests
authentication using the "none" method.
