### PR TITLE
SSHD-256 Remove workaround for PuTTY SSH_MSG_CHANNEL_REQUEST

### DIFF
--- a/sshd-core/src/main/java/org/apache/sshd/server/channel/ChannelSession.java
+++ b/sshd-core/src/main/java/org/apache/sshd/server/channel/ChannelSession.java
@@ -310,11 +310,6 @@ public class ChannelSession extends AbstractServerChannel {
         if ("x11-req".equals(type)) {
             return handleX11Forwarding(buffer);
         }
-        if (type != null && type.endsWith("@putty.projects.tartarus.org")) {
-            // Ignore but accept, more doc at
-            // http://tartarus.org/~simon/putty-snapshots/htmldoc/AppendixF.html
-            return true;
-        }
         return false;
     }
 


### PR DESCRIPTION
PuTTY sends a SSH_MSG_CHANNEL_REQUEST of type winadj@putty.projects.tartarus.org
along with some SSH_MSG_CHANNEL_WINDOW_ADJUST messages as part of its
window-size tuning. PuTTY expects the server to respond with
SSH_MSG_CHANNEL_FAILURE as described by the SSH protocol specification.

The workaround in ChannelSession however recognizes and ignores the invalid
request, thereby violating the SSH protocol and causing PuTTY to hang after the
command terminates.
