### PR TITLE
SSHD-388 - SSH server fails during bundle update

### DIFF
--- a/sshd-core/src/main/java/org/apache/sshd/common/io/DefaultIoServiceFactoryFactory.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/io/DefaultIoServiceFactoryFactory.java
@@ -68,10 +68,14 @@ public class DefaultIoServiceFactoryFactory implements IoServiceFactoryFactory {
     }
 
     private static <T> T tryLoad(ServiceLoader<T> loader) {
+        Iterator<T> it = loader.iterator();
         try {
-            Iterator<T> it = loader.iterator();
             while (it.hasNext()) {
-               return it.next();
+                try {
+                    return it.next();
+                } catch (Throwable t) {
+                    LOGGER.trace("Exception while loading factory from ServiceLoader", t);
+                }
             }
         } catch (Throwable t) {
             LOGGER.trace("Exception while loading factory from ServiceLoader", t);

--- a/sshd-core/src/main/java/org/apache/sshd/common/io/DefaultIoServiceFactoryFactory.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/io/DefaultIoServiceFactoryFactory.java
@@ -68,13 +68,13 @@ public class DefaultIoServiceFactoryFactory implements IoServiceFactoryFactory {
     }
 
     private static <T> T tryLoad(ServiceLoader<T> loader) {
-        Iterator<T> it = loader.iterator();
-        while (it.hasNext()) {
-            try {
-                return it.next();
-            } catch (Throwable t) {
-                LOGGER.trace("Exception while loading factory from ServiceLoader", t);
+        try {
+            Iterator<T> it = loader.iterator();
+            while (it.hasNext()) {
+               return it.next();
             }
+        } catch (Throwable t) {
+            LOGGER.trace("Exception while loading factory from ServiceLoader", t);
         }
         return null;
     }


### PR DESCRIPTION
Simple fix is the catch the NPE coming from the updating felix framework. The server seems to be able to gracefully handle this condition.