### PR TITLE
Fix frozen ssh output stream on window adjust

### DIFF
--- a/sshd-core/src/main/java/org/apache/sshd/server/channel/ChannelSession.java
+++ b/sshd-core/src/main/java/org/apache/sshd/server/channel/ChannelSession.java
@@ -190,6 +190,15 @@ public class ChannelSession extends AbstractServerChannel {
     }
 
     @Override
+    public void handleWindowAdjust(Buffer buffer) throws IOException {
+        super.handleWindowAdjust(buffer);
+
+        if (asyncOut != null) {
+            asyncOut.onWindowExpanded();
+        }
+    }
+
+    @Override
     protected Closeable getInnerCloseable() {
         return builder()
                 .sequential(new CommandCloseable(), new GracefulChannelCloseable())


### PR DESCRIPTION
When server output stream delayed write it did not resume it after the window was adjusted
Resume writes the same way client ssh channel does

Signed-off-by: Marian Dubai mdubai@cisco.com
