### PR TITLE
[SSHD-108] Implemented callback for successful file uploads

### DIFF
--- a/sshd-core/src/main/java/org/apache/sshd/common/file/FileUploadAware.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/file/FileUploadAware.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sshd.common.file;
+
+import java.io.IOException;
+
+/**
+ * Interface that can be implemented by a server-side file's OutputStream to be
+ * aware of successful uploads.
+ */
+public interface FileUploadAware {
+    /**
+     * Handle a successful upload, called immediately before the stream is
+     * closed. This method will not be called if the upload halted, for example
+     * due to being aborted, suffering a lost connection or pausing.
+     * <p>
+     * Note that if the stream throws an exception while being written it is
+     * undefined whether this method will be called.
+     * @throws IOException
+     */
+    void handleSuccess() throws IOException;
+}

--- a/sshd-core/src/main/java/org/apache/sshd/common/file/SshFile.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/file/SshFile.java
@@ -24,7 +24,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * This is the file abstraction used by the server.
@@ -211,7 +210,10 @@ public interface SshFile {
      * @param offset The number of bytes at where to start writing.
      *      If the file is not random accessible,
      *      any offset other than zero will throw an exception.
-     * @return An {@link java.io.OutputStream} used to write to the {@link SshFile}
+     * @return An {@link java.io.OutputStream} used to write to the
+     * {@link SshFile}. On the server-side, the returned stream may optionally
+     * implement {@link org.apache.sshd.common.file.FileUploadAware} to receive
+     * a notification when the upload has completed successfully.
      * @throws java.io.IOException 
      */
     OutputStream createOutputStream(long offset) throws IOException;

--- a/sshd-core/src/main/java/org/apache/sshd/common/scp/ScpHelper.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/scp/ScpHelper.java
@@ -30,6 +30,7 @@ import java.util.Map;
 
 import org.apache.sshd.common.SshException;
 import org.apache.sshd.common.file.FileSystemView;
+import org.apache.sshd.common.file.FileUploadAware;
 import org.apache.sshd.common.file.SshFile;
 import org.apache.sshd.common.util.DirectoryScanner;
 import org.slf4j.Logger;
@@ -256,6 +257,9 @@ public class ScpHelper {
                 }
                 os.write(buffer, 0, len);
                 length -= len;
+            }
+            if (os instanceof FileUploadAware) {
+                ((FileUploadAware) os).handleSuccess();
             }
         } finally {
             os.close();

--- a/sshd-core/src/test/java/org/apache/sshd/SftpTest.java
+++ b/sshd-core/src/test/java/org/apache/sshd/SftpTest.java
@@ -31,8 +31,15 @@ import java.util.Vector;
 
 import com.jcraft.jsch.ChannelSftp;
 import com.jcraft.jsch.JSch;
+import java.util.List;
+import java.util.Map;
 import org.apache.sshd.client.SftpClient;
 import org.apache.sshd.common.NamedFactory;
+import org.apache.sshd.common.Session;
+import org.apache.sshd.common.file.FileSystemFactory;
+import org.apache.sshd.common.file.FileSystemView;
+import org.apache.sshd.common.file.FileUploadAware;
+import org.apache.sshd.common.file.SshFile;
 import org.apache.sshd.common.util.Buffer;
 import org.apache.sshd.common.util.OsUtils;
 import org.apache.sshd.server.Command;
@@ -66,6 +73,7 @@ public class SftpTest extends BaseTest {
         sshd = SshServer.setUpDefaultServer();
         sshd.setKeyPairProvider(Utils.createTestHostKeyProvider());
         sshd.setSubsystemFactories(Arrays.<NamedFactory<Command>>asList(new SftpSubsystem.Factory()));
+        sshd.setFileSystemFactory(new TestFileSystemFactory(sshd.getFileSystemFactory()));
         sshd.setCommandFactory(new ScpCommandFactory());
         sshd.setShellFactory(new EchoShellFactory());
         sshd.setPasswordAuthenticator(new BogusPasswordAuthenticator());
@@ -291,6 +299,35 @@ public class SftpTest extends BaseTest {
         client.stop();
     }
 
+    @Test
+    public void testUploadNotification() throws Exception {
+        SshClient client = SshClient.setUpDefaultClient();
+        client.start();
+        ClientSession session = client.connect("x", "localhost", port).await().getSession();
+        session.addPasswordIdentity("x");
+        session.auth().verify();
+
+        Utils.deleteRecursive(new File("target/sftp"));
+        new File("target/sftp").mkdirs();
+        new File("target/sftp/state_aware_client").delete();
+
+        SftpClient sftp = session.createSftpClient();
+
+        sftp.mkdir("target/sftp/state_aware_client");
+
+        uploadAndVerifyStateAwareFile(session, 0, "emptySuccessfulFile.txt", false);
+        uploadAndVerifyStateAwareFile(session, 1000, "smallSuccessfulFile.txt", false);
+        uploadAndVerifyStateAwareFile(session, 0, "emptyUnsuccessfulFile.txt", true);
+        uploadAndVerifyStateAwareFile(session, 1000, "smallUnsuccessfulFile.txt", true);
+        uploadAndVerifyStateAwareFile(session, Buffer.MAX_LEN + 1, "BufferedSuccessfulFile.txt", false);
+        uploadAndVerifyStateAwareFile(session, Buffer.MAX_LEN + 1, "BufferedUnsuccessfulFile.txt", true);
+
+        // cleanup
+        sftp.rmdir("target/sftp/state_aware_client");
+        sftp.close();
+        client.stop();
+    }
+
     private void testInvalidParams(SftpClient sftp) throws Exception {
         // generate random file and upload it
         final String filePath = "target/sftp/client/invalid";
@@ -348,6 +385,32 @@ public class SftpTest extends BaseTest {
 
         // cleanup
         sftp.remove(filePath);
+        assertFalse("file should have been removed", resultFile.exists());
+    }
+
+    private void uploadAndVerifyStateAwareFile(ClientSession session, int size, String filename, boolean abort) throws Exception {
+        SftpClient sftp = session.createSftpClient();
+        // generate random file and upload it
+        final String filePath = "target/sftp/state_aware_client/" + filename;
+        SftpClient.Handle handle = sftp.open(filePath, EnumSet.of(SftpClient.OpenMode.Write, SftpClient.OpenMode.Create));
+        final String randomData = randomString(size);
+        sftp.write(handle, 0, randomData.getBytes(), 0, randomData.length());
+        if (!abort) {
+            sftp.close(handle);
+        }
+        sftp.close();
+
+        final String check = randomData + (abort ? "" : " success!");
+
+        // verify results
+        File resultFile = new File(filePath);
+        assertTrue("file should exist on disk", resultFile.exists());
+        assertTrue("file contents should match", check.equals(readFile(filePath)));
+
+        // cleanup
+        sftp = session.createSftpClient();
+        sftp.remove(filePath);
+        sftp.close();
         assertFalse("file should have been removed", resultFile.exists());
     }
 
@@ -521,4 +584,201 @@ public class SftpTest extends BaseTest {
         return sb.toString();
     }
 
+    private static class TestFileSystemFactory implements FileSystemFactory {
+        private final FileSystemFactory wrap;
+
+        TestFileSystemFactory(final FileSystemFactory wrap) {
+            this.wrap = wrap;
+        }
+
+        public FileSystemView createFileSystemView(Session session) throws IOException {
+            return new TestFileSystemView(wrap.createFileSystemView(session));
+        }
+    }
+
+    private static class TestFileSystemView implements FileSystemView {
+        private final FileSystemView wrap;
+
+        TestFileSystemView(final FileSystemView wrap) {
+            this.wrap = wrap;
+        }
+
+        public SshFile getFile(String file) {
+            return new TestSshFile(wrap.getFile(file));
+        }
+
+        public SshFile getFile(SshFile baseDir, String file) {
+            return new TestSshFile(wrap.getFile(baseDir, file));
+        }
+
+        public FileSystemView getNormalizedView() {
+            return new TestFileSystemView(wrap.getNormalizedView());
+        }
+    }
+
+    private static class TestSshFile implements SshFile {
+        private final SshFile wrap;
+
+        TestSshFile(final SshFile wrap) {
+            this.wrap = wrap;
+        }
+
+        public String getAbsolutePath() {
+            return wrap.getAbsolutePath();
+        }
+
+        public String getName() {
+            return wrap.getName();
+        }
+
+        public Map<Attribute, Object> getAttributes(boolean followLinks) throws IOException {
+            return wrap.getAttributes(followLinks);
+        }
+
+        public void setAttributes(Map<Attribute, Object> attributes) throws IOException {
+            wrap.setAttributes(attributes);
+        }
+
+        public Object getAttribute(Attribute attribute, boolean followLinks) throws IOException {
+            return wrap.getAttribute(attribute, followLinks);
+        }
+
+        public void setAttribute(Attribute attribute, Object value) throws IOException {
+            wrap.setAttribute(attribute, value);
+        }
+
+        public String readSymbolicLink() throws IOException {
+            return wrap.readSymbolicLink();
+        }
+
+        public void createSymbolicLink(SshFile destination) throws IOException {
+            wrap.createSymbolicLink(destination);
+        }
+
+        public String getOwner() {
+            return wrap.getOwner();
+        }
+
+        public boolean isDirectory() {
+            return wrap.isDirectory();
+        }
+
+        public boolean isFile() {
+            return wrap.isFile();
+        }
+
+        public boolean doesExist() {
+            return wrap.doesExist();
+        }
+
+        public boolean isReadable() {
+            return wrap.isReadable();
+        }
+
+        public boolean isWritable() {
+            return wrap.isWritable();
+        }
+
+        public boolean isExecutable() {
+            return wrap.isExecutable();
+        }
+
+        public boolean isRemovable() {
+            return wrap.isRemovable();
+        }
+
+        public SshFile getParentFile() {
+            return wrap.getParentFile();
+        }
+
+        public long getLastModified() {
+            return wrap.getLastModified();
+        }
+
+        public boolean setLastModified(long time) {
+            return wrap.setLastModified(time);
+        }
+
+        public long getSize() {
+            return wrap.getSize();
+        }
+
+        public boolean mkdir() {
+            return wrap.mkdir();
+        }
+
+        public boolean delete() {
+            return wrap.delete();
+        }
+
+        public boolean create() throws IOException {
+            return wrap.create();
+        }
+
+        public void truncate() throws IOException {
+            wrap.truncate();
+        }
+
+        public boolean move(SshFile destination) {
+            return wrap.move(destination);
+        }
+
+        public List<SshFile> listSshFiles() {
+            return wrap.listSshFiles();
+        }
+
+        public OutputStream createOutputStream(long offset) throws IOException {
+            final OutputStream result = wrap.createOutputStream(offset);
+            if (getAbsolutePath().contains("state_aware_client")) {
+                return new TestOutputStream(result);
+            }
+            return result;
+        }
+
+        public InputStream createInputStream(long offset) throws IOException {
+            return wrap.createInputStream(offset);
+        }
+
+        public void handleClose() throws IOException {
+            wrap.handleClose();
+        }
+    }
+
+    private static class TestOutputStream extends OutputStream implements FileUploadAware {
+        private final OutputStream wrap;
+
+        TestOutputStream(final OutputStream wrap) {
+            this.wrap = wrap;
+        }
+
+        @Override
+        public void write(int b) throws IOException {
+            wrap.write(b);
+        }
+
+        @Override
+        public void write(byte[] b) throws IOException {
+            wrap.write(b);
+        }
+
+        @Override
+        public void write(byte[] b, int off, int len) throws IOException {
+            wrap.write(b, off, len);
+        }
+
+        @Override
+        public void flush() throws IOException {
+            wrap.flush();
+        }
+
+        @Override
+        public void close() throws IOException {
+            wrap.close();
+        }
+
+        @Override
+        public void handleSuccess() throws IOException {
+            wrap.write( " success!".getBytes("UTF-8") );
+        }
+    }
 }


### PR DESCRIPTION
Implements the behaviour I suggested here: https://issues.apache.org/jira/browse/SSHD-108?focusedCommentId=14330308&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-14330308 to allow successful uploads to be distinguished from aborted or failed uploads. This version is the non-API breaking version (optional interface), which seems to be better all-round. The majority of the new code is for the unit test, which required wrapping the file system factory, view and file to provide a custom stream for the test.

The test org.apache.sshd.ServerTest.testServerIdleTimeoutWithForce(ServerTest.java:246) fails on my machine, but this is unrelated to the patch.
