### PR TITLE
Candidate fix for SSHD-557

### DIFF
--- a/sshd-core/src/main/java/org/apache/sshd/common/channel/ChannelOutputStream.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/channel/ChannelOutputStream.java
@@ -123,7 +123,7 @@ public class ChannelOutputStream extends OutputStream implements Channel {
             while (bufferLength > 0) {
                 Buffer buf = buffer;
                 int total = bufferLength;
-                int length = Math.min(Math.min(remoteWindow.waitForSpace(), total), remoteWindow.getPacketSize());
+                int length = Math.min(Math.min(remoteWindow.getSize(), total), remoteWindow.getPacketSize());
                 int pos = buf.wpos();
                 buf.wpos((cmd == SshConstants.SSH_MSG_CHANNEL_EXTENDED_DATA) ? 14 : 10);
                 buf.putInt(length);


### PR DESCRIPTION
Fixes whole-server hang by removing blocking waitForSpace() call and replacing it with getSize(). In the case that there is no space available, flush() will not block any more and will simply try again - a zero-length buffer will be passed to waitAndConsume(), but that method will immediately return.
