### PR TITLE
[SSH-584] Closer to OpenSSH file permissions checks

### DIFF
--- a/sshd-core/src/main/java/org/apache/sshd/client/config/hosts/DefaultConfigFileHostEntryResolver.java
+++ b/sshd-core/src/main/java/org/apache/sshd/client/config/hosts/DefaultConfigFileHostEntryResolver.java
@@ -21,12 +21,19 @@ package org.apache.sshd.client.config.hosts;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.nio.file.attribute.PosixFilePermission;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
-import org.apache.sshd.common.config.keys.KeyUtils;
+import org.apache.sshd.common.util.GenericUtils;
+import org.apache.sshd.common.util.OsUtils;
 import org.apache.sshd.common.util.ValidateUtils;
 import org.apache.sshd.common.util.io.IoUtils;
 
@@ -43,6 +50,14 @@ public class DefaultConfigFileHostEntryResolver extends ConfigFileHostEntryResol
      * The default instance that enforces the same permissions regime as {@code OpenSSH}
      */
     public static final DefaultConfigFileHostEntryResolver INSTANCE = new DefaultConfigFileHostEntryResolver(true);
+
+    /**
+     * The {@link Set} of {@link PosixFilePermission} <U>not</U> allowed if strict
+     * permissions are enforced on key files
+     */
+    public static final Set<PosixFilePermission> STRICTLY_PROHIBITED_FILE_PERMISSION =
+            Collections.unmodifiableSet(
+                    EnumSet.of(PosixFilePermission.GROUP_WRITE, PosixFilePermission.OTHERS_WRITE));
 
     private final boolean strict;
 
@@ -75,12 +90,105 @@ public class DefaultConfigFileHostEntryResolver extends ConfigFileHostEntryResol
                 log.debug("reloadHostConfigEntries({}@{}:{}) check permissions of {}", username, host, port, path);
             }
 
-            PosixFilePermission violation = KeyUtils.validateStrictKeyFilePermissions(path);
+            PosixFilePermission violation = validateStrictConfigFilePermissions(path);
             if (violation != null) {
                 throw new IOException("String permission violation (" + violation + ") for " + path);
+            }
+
+            String ownerViolation = validateStrictConfigFileOwner(path);
+            if (ownerViolation != null) {
+                throw new IOException("String owner violation (" + ownerViolation + ") for " + path);
             }
         }
 
         return super.reloadHostConfigEntries(path, host, port, username);
     }
+
+    /**
+     * <P>Checks if a path has strict permissions</P>
+     * <UL>
+     *
+     * <LI><P>
+     * (For {@code Unix}) The path may not have group or others write permissions
+     * </P></LI>
+     *
+     * </UL>
+     *
+     * @param path    The {@link Path} to be checked - ignored if {@code null}
+     *                or does not exist
+     * @param options The {@link LinkOption}s to use to query the file's permissions
+     * @return The violated {@link PosixFilePermission} - {@code null} if
+     * no violations detected
+     * @throws IOException If failed to retrieve the permissions
+     * @see #STRICTLY_PROHIBITED_FILE_PERMISSION
+     */
+    public static PosixFilePermission validateStrictConfigFilePermissions(Path path, LinkOption... options) throws IOException {
+        if ((path == null) || (!Files.exists(path, options))) {
+            return null;
+        }
+
+        Collection<PosixFilePermission> perms = IoUtils.getPermissions(path, options);
+        if (GenericUtils.isEmpty(perms)) {
+            return null;
+        }
+
+        if (OsUtils.isUNIX()) {
+            PosixFilePermission p = IoUtils.validateExcludedPermissions(perms, STRICTLY_PROHIBITED_FILE_PERMISSION);
+            if (p != null) {
+                return p;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * <P>Checks if a path has strict ownership</P>
+     * <UL>
+     *
+     * <LI><P>
+     * The path must be owned by current user.
+     * </P></LI>
+     *
+     * <LI><P>
+     * (For {@code Unix}) The path may be owned by root.
+     * </P></LI>
+     *
+     * </UL>
+     *
+     * @param path    The {@link Path} to be checked - ignored if {@code null}
+     *                or does not exist
+     * @param options The {@link LinkOption}s to use to query the file's permissions
+     * @return The violated owner - {@code null} if
+     * no violations detected
+     * @throws IOException If failed to retrieve the ownership
+     */
+    public static String validateStrictConfigFileOwner(Path path, LinkOption... options) throws IOException {
+        if ((path == null) || (!Files.exists(path, options))) {
+            return null;
+        }
+
+        String current = IoUtils.getCurrentUser();
+        String owner = IoUtils.getFileOwner(path, options);
+
+        if (current == null &&  owner == null) {
+            // we cannot detect permissions
+            return null;
+        }
+
+        Set<String> expected = new HashSet<>();
+        if (current != null) {
+            expected.add(current);
+        }
+        if (OsUtils.isUNIX()) {
+            expected.add(OsUtils.ROOT_USER);
+        }
+
+        if (!expected.contains(owner)) {
+            return owner;
+        }
+
+        return null;
+    }
+
 }

--- a/sshd-core/src/main/java/org/apache/sshd/client/config/keys/ClientIdentity.java
+++ b/sshd-core/src/main/java/org/apache/sshd/client/config/keys/ClientIdentity.java
@@ -293,6 +293,7 @@ public final class ClientIdentity {
      * <U>insensitive</U>), value=the {@link Path} of the file holding the key
      * @throws IOException If failed to access the file system
      * @see KeyUtils#validateStrictKeyFilePermissions(Path, LinkOption...)
+     * @see KeyUtils#validateStrictKeyFileOwner(Path, LinkOption...)
      */
     public static Map<String, Path> scanIdentitiesFolder(
             Path dir, boolean strict, Collection<String> types, Transformer<String, String> idGenerator, LinkOption... options)
@@ -318,6 +319,10 @@ public final class ClientIdentity {
             if (strict) {
                 PosixFilePermission perm = KeyUtils.validateStrictKeyFilePermissions(p, options);
                 if (perm != null) {
+                    continue;
+                }
+                String owner = KeyUtils.validateStrictKeyFileOwner(p, options);
+                if (owner != null) {
                     continue;
                 }
             }

--- a/sshd-core/src/main/java/org/apache/sshd/client/config/keys/ClientIdentityFileWatcher.java
+++ b/sshd-core/src/main/java/org/apache/sshd/client/config/keys/ClientIdentityFileWatcher.java
@@ -98,6 +98,13 @@ public class ClientIdentityFileWatcher extends ModifiableFileWatcher implements 
                 }
                 return null;
             }
+            String ownerViolation = KeyUtils.validateStrictKeyFileOwner(path, IoUtils.EMPTY_LINK_OPTIONS);
+            if (ownerViolation != null) {
+                if (log.isDebugEnabled()) {
+                    log.debug("reloadClientIdentity({}) ignore due to owner violation: {}", path, ownerViolation);
+                }
+                return null;
+            }
         }
 
         String location = path.toString();

--- a/sshd-core/src/main/java/org/apache/sshd/common/util/OsUtils.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/util/OsUtils.java
@@ -31,6 +31,8 @@ public final class OsUtils {
     public static final String WINDOWS_SHELL_COMMAND_NAME = "cmd.exe";
     public static final String LINUX_SHELL_COMMAND_NAME = "/bin/sh";
 
+    public static final String ROOT_USER = "root";
+
     public static final List<String> LINUX_COMMAND =
             Collections.unmodifiableList(Arrays.asList(LINUX_SHELL_COMMAND_NAME, "-i", "-l"));
     public static final List<String> WINDOWS_COMMAND =

--- a/sshd-core/src/main/java/org/apache/sshd/server/config/keys/DefaultAuthorizedKeysAuthenticator.java
+++ b/sshd-core/src/main/java/org/apache/sshd/server/config/keys/DefaultAuthorizedKeysAuthenticator.java
@@ -112,6 +112,11 @@ public class DefaultAuthorizedKeysAuthenticator extends AuthorizedKeysAuthentica
             if (violation != null) {
                 throw new IOException("String permission violation (" + violation + ") for " + path);
             }
+
+            String ownerViolation = KeyUtils.validateStrictKeyFileOwner(path);
+            if (ownerViolation != null) {
+                throw new IOException("String owner violation (" + ownerViolation + ") for " + path);
+            }
         }
 
         return super.reloadAuthorizedKeys(path, username, session);

--- a/sshd-core/src/test/java/org/apache/sshd/common/util/io/IoUtilsTest.java
+++ b/sshd-core/src/test/java/org/apache/sshd/common/util/io/IoUtilsTest.java
@@ -19,7 +19,10 @@
 
 package org.apache.sshd.common.util.io;
 
+import java.io.IOException;
 import java.nio.file.LinkOption;
+import java.util.Arrays;
+import java.util.Collection;
 
 import org.apache.sshd.common.util.GenericUtils;
 import org.apache.sshd.util.test.BaseTestSupport;
@@ -53,5 +56,13 @@ public class IoUtilsTest extends BaseTestSupport {
             assertNotSame("Same bytes received at iteration " + index, expected, actual);
             assertArrayEquals("Mismatched bytes at iteration " + index, expected, actual);
         }
+    }
+
+    @Test
+    public void testGetCurrentUser() throws IOException {
+        // system may be unsupportable, hence the null
+        Collection expected = Arrays.asList(null, System.getProperty("user.name"));
+        String user = IoUtils.getCurrentUser();
+        assertTrue(String.format("Incorrect user got from file owner, expected '%s' got %s", expected, user), expected.contains(user));
     }
 }


### PR DESCRIPTION
1. Owner can be either running user or root in *NIX.
2. Config file have less restrictive requirements than keys.

I can probably remove some of the duplicate code, but wanted first to get a feedback of what you want/need.

Thanks!