### PR TITLE
[SSHD-584] Closer to OpenSSH file permissions checks

### DIFF
--- a/sshd-core/src/main/java/org/apache/sshd/client/SshClient.java
+++ b/sshd-core/src/main/java/org/apache/sshd/client/SshClient.java
@@ -89,6 +89,7 @@ import org.apache.sshd.common.keyprovider.AbstractFileKeyPairProvider;
 import org.apache.sshd.common.keyprovider.KeyPairProvider;
 import org.apache.sshd.common.session.AbstractSession;
 import org.apache.sshd.common.util.GenericUtils;
+import org.apache.sshd.common.util.OsUtils;
 import org.apache.sshd.common.util.SecurityUtils;
 import org.apache.sshd.common.util.ValidateUtils;
 import org.apache.sshd.common.util.io.IoUtils;
@@ -661,7 +662,7 @@ public class SshClient extends AbstractFactoryManager implements ClientFactoryMa
         }
 
         if (login == null) {
-            login = System.getProperty("user.name");
+            login = OsUtils.getCurrentUser();
         }
 
         if (port <= 0) {

--- a/sshd-core/src/main/java/org/apache/sshd/client/config/hosts/DefaultConfigFileHostEntryResolver.java
+++ b/sshd-core/src/main/java/org/apache/sshd/client/config/hosts/DefaultConfigFileHostEntryResolver.java
@@ -23,10 +23,9 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.LinkOption;
 import java.nio.file.Path;
-import java.nio.file.attribute.PosixFilePermission;
 import java.util.List;
 
-import org.apache.sshd.common.config.keys.KeyUtils;
+import org.apache.sshd.common.util.Pair;
 import org.apache.sshd.common.util.ValidateUtils;
 import org.apache.sshd.common.util.io.IoUtils;
 
@@ -75,12 +74,13 @@ public class DefaultConfigFileHostEntryResolver extends ConfigFileHostEntryResol
                 log.debug("reloadHostConfigEntries({}@{}:{}) check permissions of {}", username, host, port, path);
             }
 
-            PosixFilePermission violation = KeyUtils.validateStrictKeyFilePermissions(path);
+            Pair<String, Object> violation = validateStrictConfigFilePermissions(path);
             if (violation != null) {
-                throw new IOException("String permission violation (" + violation + ") for " + path);
+                throw new IOException(String.format("%s for %s", violation.getFirst(), path));
             }
         }
 
         return super.reloadHostConfigEntries(path, host, port, username);
     }
+
 }

--- a/sshd-core/src/main/java/org/apache/sshd/client/config/hosts/HostConfigEntry.java
+++ b/sshd-core/src/main/java/org/apache/sshd/client/config/hosts/HostConfigEntry.java
@@ -54,6 +54,7 @@ import org.apache.sshd.common.config.SshConfigFileReader;
 import org.apache.sshd.common.config.keys.IdentityUtils;
 import org.apache.sshd.common.config.keys.PublicKeyEntry;
 import org.apache.sshd.common.util.GenericUtils;
+import org.apache.sshd.common.util.OsUtils;
 import org.apache.sshd.common.util.Pair;
 import org.apache.sshd.common.util.ValidateUtils;
 import org.apache.sshd.common.util.io.IoUtils;
@@ -1364,7 +1365,7 @@ public class HostConfigEntry implements UsernameHolder {
                             appendUserHome(sb);
                             break;
                         case LOCAL_USER_MACRO:
-                            sb.append(ValidateUtils.checkNotNullAndNotEmpty(System.getProperty("user.name"), "No local user name value"));
+                            sb.append(ValidateUtils.checkNotNullAndNotEmpty(OsUtils.getCurrentUser(), "No local user name value"));
                             break;
                         case LOCAL_HOST_MACRO:
                         {

--- a/sshd-core/src/main/java/org/apache/sshd/client/config/keys/ClientIdentity.java
+++ b/sshd-core/src/main/java/org/apache/sshd/client/config/keys/ClientIdentity.java
@@ -23,7 +23,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
 import java.nio.file.Path;
-import java.nio.file.attribute.PosixFilePermission;
 import java.security.GeneralSecurityException;
 import java.security.KeyPair;
 import java.util.Collection;
@@ -293,6 +292,7 @@ public final class ClientIdentity {
      * <U>insensitive</U>), value=the {@link Path} of the file holding the key
      * @throws IOException If failed to access the file system
      * @see KeyUtils#validateStrictKeyFilePermissions(Path, LinkOption...)
+     * @see KeyUtils#validateStrictKeyFileOwner(Path, LinkOption...)
      */
     public static Map<String, Path> scanIdentitiesFolder(
             Path dir, boolean strict, Collection<String> types, Transformer<String, String> idGenerator, LinkOption... options)
@@ -316,8 +316,7 @@ public final class ClientIdentity {
             }
 
             if (strict) {
-                PosixFilePermission perm = KeyUtils.validateStrictKeyFilePermissions(p, options);
-                if (perm != null) {
+                if (KeyUtils.validateStrictKeyFilePermissions(p, options) != null) {
                     continue;
                 }
             }

--- a/sshd-core/src/main/java/org/apache/sshd/client/config/keys/ClientIdentityFileWatcher.java
+++ b/sshd-core/src/main/java/org/apache/sshd/client/config/keys/ClientIdentityFileWatcher.java
@@ -21,13 +21,13 @@ package org.apache.sshd.client.config.keys;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.nio.file.attribute.PosixFilePermission;
 import java.security.GeneralSecurityException;
 import java.security.KeyPair;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.sshd.common.config.keys.FilePasswordProvider;
 import org.apache.sshd.common.config.keys.KeyUtils;
+import org.apache.sshd.common.util.Pair;
 import org.apache.sshd.common.util.ValidateUtils;
 import org.apache.sshd.common.util.io.IoUtils;
 import org.apache.sshd.common.util.io.ModifiableFileWatcher;
@@ -91,10 +91,10 @@ public class ClientIdentityFileWatcher extends ModifiableFileWatcher implements 
 
     protected KeyPair reloadClientIdentity(Path path) throws IOException, GeneralSecurityException {
         if (isStrict()) {
-            PosixFilePermission violation = KeyUtils.validateStrictKeyFilePermissions(path, IoUtils.EMPTY_LINK_OPTIONS);
+            Pair<String, Object> violation = KeyUtils.validateStrictKeyFilePermissions(path, IoUtils.EMPTY_LINK_OPTIONS);
             if (violation != null) {
                 if (log.isDebugEnabled()) {
-                    log.debug("reloadClientIdentity({}) ignore due to permission violation: {}", path, violation);
+                    log.debug("reloadClientIdentity({}) ignore due to {}", path, violation.getFirst());
                 }
                 return null;
             }

--- a/sshd-core/src/main/java/org/apache/sshd/common/util/io/IoUtils.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/util/io/IoUtils.java
@@ -32,6 +32,7 @@ import java.nio.file.LinkOption;
 import java.nio.file.OpenOption;
 import java.nio.file.Path;
 import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.UserPrincipal;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -254,6 +255,23 @@ public final class IoUtils {
                         || perms.contains(PosixFilePermission.GROUP_EXECUTE)
                         || perms.contains(PosixFilePermission.OTHERS_EXECUTE));
         f.setExecutable(executable, false);
+    }
+
+    /**
+     * <P>Get file owner.</P>
+     *
+     * @param path  The {@link Path}
+     * @param options The {@link LinkOption}s to use when querying the owner
+     * @return Owner of the file or null if unsupported
+     * @throws IOException If failed to access the file system
+     */
+    public static String getFileOwner(Path path, LinkOption... options) throws IOException {
+        try {
+            UserPrincipal principal = Files.getOwner(path, options);
+            return (principal == null) ? null : principal.getName();
+        } catch (UnsupportedOperationException e) {
+            return null;
+        }
     }
 
     /**

--- a/sshd-core/src/main/java/org/apache/sshd/server/config/keys/DefaultAuthorizedKeysAuthenticator.java
+++ b/sshd-core/src/main/java/org/apache/sshd/server/config/keys/DefaultAuthorizedKeysAuthenticator.java
@@ -29,6 +29,8 @@ import java.util.Collection;
 
 import org.apache.sshd.common.auth.UsernameHolder;
 import org.apache.sshd.common.config.keys.KeyUtils;
+import org.apache.sshd.common.util.OsUtils;
+import org.apache.sshd.common.util.Pair;
 import org.apache.sshd.common.util.ValidateUtils;
 import org.apache.sshd.common.util.io.IoUtils;
 import org.apache.sshd.server.session.ServerSession;
@@ -57,7 +59,7 @@ public class DefaultAuthorizedKeysAuthenticator extends AuthorizedKeysAuthentica
      *               does not check these permissions
      */
     public DefaultAuthorizedKeysAuthenticator(boolean strict) {
-        this(System.getProperty("user.name"), strict);
+        this(OsUtils.getCurrentUser(), strict);
     }
 
     public DefaultAuthorizedKeysAuthenticator(String user, boolean strict) {
@@ -73,7 +75,7 @@ public class DefaultAuthorizedKeysAuthenticator extends AuthorizedKeysAuthentica
     }
 
     public DefaultAuthorizedKeysAuthenticator(Path path, boolean strict, LinkOption... options) {
-        this(System.getProperty("user.name"), path, strict, options);
+        this(OsUtils.getCurrentUser(), path, strict, options);
     }
 
     public DefaultAuthorizedKeysAuthenticator(String user, Path path, boolean strict, LinkOption... options) {
@@ -108,9 +110,9 @@ public class DefaultAuthorizedKeysAuthenticator extends AuthorizedKeysAuthentica
                 log.debug("reloadAuthorizedKeys({})[{}] check permissions of {}", username, session, path);
             }
 
-            PosixFilePermission violation = KeyUtils.validateStrictKeyFilePermissions(path);
+            Pair<String, Object> violation = KeyUtils.validateStrictKeyFilePermissions(path);
             if (violation != null) {
-                throw new IOException("String permission violation (" + violation + ") for " + path);
+                throw new IOException(String.format("%s for %s", violation.getFirst(), path));
             }
         }
 

--- a/sshd-core/src/test/java/org/apache/sshd/common/util/io/IoUtilsTest.java
+++ b/sshd-core/src/test/java/org/apache/sshd/common/util/io/IoUtilsTest.java
@@ -19,7 +19,10 @@
 
 package org.apache.sshd.common.util.io;
 
+import java.io.IOException;
 import java.nio.file.LinkOption;
+import java.util.Arrays;
+import java.util.Collection;
 
 import org.apache.sshd.common.util.GenericUtils;
 import org.apache.sshd.util.test.BaseTestSupport;
@@ -54,4 +57,5 @@ public class IoUtilsTest extends BaseTestSupport {
             assertArrayEquals("Mismatched bytes at iteration " + index, expected, actual);
         }
     }
+
 }

--- a/sshd-core/src/test/java/org/apache/sshd/server/ServerTest.java
+++ b/sshd-core/src/test/java/org/apache/sshd/server/ServerTest.java
@@ -48,8 +48,8 @@ import org.apache.sshd.client.session.ClientSession;
 import org.apache.sshd.client.session.ClientSessionImpl;
 import org.apache.sshd.client.session.SessionFactory;
 import org.apache.sshd.common.FactoryManager;
-import org.apache.sshd.common.PropertyResolverUtils;
 import org.apache.sshd.common.NamedFactory;
+import org.apache.sshd.common.PropertyResolverUtils;
 import org.apache.sshd.common.channel.Channel;
 import org.apache.sshd.common.channel.TestChannelListener;
 import org.apache.sshd.common.channel.WindowClosedException;
@@ -60,6 +60,7 @@ import org.apache.sshd.common.session.AbstractSession;
 import org.apache.sshd.common.session.Session;
 import org.apache.sshd.common.session.SessionListener;
 import org.apache.sshd.common.util.GenericUtils;
+import org.apache.sshd.common.util.OsUtils;
 import org.apache.sshd.common.util.ValidateUtils;
 import org.apache.sshd.deprecated.ClientUserAuthServiceOld;
 import org.apache.sshd.server.command.ScpCommandFactory;
@@ -529,7 +530,7 @@ public class ServerTest extends BaseTestSupport {
             {
                 put("test", getCurrentTestName());
                 put("port", Integer.toString(port));
-                put("user", System.getProperty("user.name"));
+                put("user", OsUtils.getCurrentUser());
             }
         };
 

--- a/sshd-core/src/test/java/org/apache/sshd/server/config/keys/DefaultAuthorizedKeysAuthenticatorTest.java
+++ b/sshd-core/src/test/java/org/apache/sshd/server/config/keys/DefaultAuthorizedKeysAuthenticatorTest.java
@@ -27,6 +27,7 @@ import java.nio.file.Path;
 import java.security.PublicKey;
 import java.util.Collection;
 
+import org.apache.sshd.common.util.OsUtils;
 import org.apache.sshd.common.util.io.IoUtils;
 import org.apache.sshd.server.auth.pubkey.PublickeyAuthenticator;
 import org.apache.sshd.util.test.BaseTestSupport;
@@ -57,7 +58,7 @@ public class DefaultAuthorizedKeysAuthenticatorTest extends BaseTestSupport {
         Collection<AuthorizedKeyEntry> entries = AuthorizedKeyEntry.readAuthorizedKeys(file);
         Collection<PublicKey> keySet = AuthorizedKeyEntry.resolveAuthorizedKeys(entries);
         PublickeyAuthenticator auth = new DefaultAuthorizedKeysAuthenticator(file, false);
-        String thisUser = System.getProperty("user.name");
+        String thisUser = OsUtils.getCurrentUser();
         for (String username : new String[]{null, "", thisUser, getClass().getName() + "#" + getCurrentTestName()}) {
             boolean expected = thisUser.equals(username);
             for (PublicKey key : keySet) {


### PR DESCRIPTION
1. Owner can be either running user or root in *NIX.
2. Config file have less restrictive requirements than keys.

I can probably remove duplicate code, but thought first to get some feedback.