### PR TITLE
Builder: supress heap pollution vararg warning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -803,6 +803,7 @@
                     <target>${javac.target}</target>
                     <compilerArgument>-g</compilerArgument>
                     <compilerArgument>-Xlint:-serial</compilerArgument>
+                    <compilerArgument>-Xlint:unchecked</compilerArgument>
                 </configuration>
             </plugin>
             <plugin>

--- a/sshd-core/src/main/java/org/apache/sshd/common/util/closeable/Builder.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/util/closeable/Builder.java
@@ -62,7 +62,8 @@ public final class Builder implements ObjectBuilder<Closeable> {
     }
 
     @SuppressWarnings("rawtypes")
-    public <T extends SshFuture> Builder when(@SuppressWarnings("unchecked") SshFuture<T>... futures) {
+    @SafeVarargs
+    public final <T extends SshFuture> Builder when(@SuppressWarnings("unchecked") SshFuture<T>... futures) {
         return when(Arrays.asList(futures));
     }
 


### PR DESCRIPTION
This warning was always annoying.
I hope this is the right solution.