### PR TITLE
SSHD-642

### DIFF
--- a/sshd-core/src/main/java/org/apache/sshd/common/signature/AbstractSignature.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/signature/AbstractSignature.java
@@ -19,6 +19,7 @@
 package org.apache.sshd.common.signature;
 
 import java.nio.charset.StandardCharsets;
+import java.security.GeneralSecurityException;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.SignatureException;
@@ -48,16 +49,19 @@ public abstract class AbstractSignature implements Signature {
         return algorithm;
     }
 
+    protected java.security.Signature doInitSignature() throws GeneralSecurityException {
+        return SecurityUtils.getSignature(getAlgorithm());
+    }
 
     @Override
     public void initVerifier(PublicKey key) throws Exception {
-        signature = SecurityUtils.getSignature(getAlgorithm());
+        signature = doInitSignature();
         signature.initVerify(ValidateUtils.checkNotNull(key, "No public key provided"));
     }
 
     @Override
     public void initSigner(PrivateKey key) throws Exception {
-        signature = SecurityUtils.getSignature(getAlgorithm());
+        signature = doInitSignature();
         signature.initSign(ValidateUtils.checkNotNull(key, "No private key provided"));
     }
 

--- a/sshd-core/src/test/java/org/apache/sshd/common/signature/SignatureRSATest.java
+++ b/sshd-core/src/test/java/org/apache/sshd/common/signature/SignatureRSATest.java
@@ -1,0 +1,54 @@
+package org.apache.sshd.common.signature;
+
+import org.apache.mina.util.Base64;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.math.BigInteger;
+import java.security.*;
+import java.security.Signature;
+import java.security.spec.RSAPublicKeySpec;
+
+/**
+ * Created by eugene.petrenko@gmail.com
+ */
+public class SignatureRSATest {
+    @Test
+    public void testLeadingZeroes_BC() throws Throwable {
+        byte[] msg = Base64.decodeBase64("AAAAFPHgK1MeV9zNnok3pwNJhCd8SONqMgAAAAlidWlsZHVzZXIAAAAOc3NoLWNvbm5lY3Rpb24AAAAJcHVibGlja2V5AQAAAAdzc2gtcnNhAAABFQAAAAdzc2gtcnNhAAAAASMAAAEBAMs9HO/NH/Now+6fSnESebaG4wzaYQWA1b/q1TGV1wHNtCg9fGFGVSKs0VxKF4cfVyrSLtgLjnlXQTn+Lm7xiYKGbBbsTQWOqEDaBVBsRbAkxIkpuvr6/EBxwrtDbKmSQYTJZVJSD2bZRYjGsR9gpZXPorOOKFd5EPCMHXsqnhp2hidTGH7cK6RuLk7MNnPISsY0Nbx8/ZvikiPROGcoTZ8bzUv4IaLr3veW6epSeQem8tJqhnrpTHhbLU99zf045M0Gsnk/azjjlBM+qrHZ5FNdC1kowJnLtf2Oy/rUQNpkGJtcBPT8xvreV0wLsn9t3hSxzsc0+VkDNTQRlfU+o3M=".getBytes("utf-8"));
+        byte[] sig = Base64.decodeBase64("AAAAB3NzaC1yc2EAAAD/+Ntnf4qfr2J1voDS6I+u3VRjtMn+LdWJsAZfkLDxRkK1rQxP7QAjLdNqpT4CkWHp8dtoTGFlBFt6NieNJCMTA2KSOxJMZKsX7e/lHkh7C+vhQvJ9eLTKWjCxSFUrcM0NvFhmwbRCffwXSHvAKak4wbmofxQMpd+G4jZkNMz5kGpmeICBcNjRLPb7oXzuGr/g4x/3ge5Qaawqrg/gcZr/sKN6SdE8SszgKYO0SB320N4gcUoShVdLYr9uwdJ+kJoobfkUK6Or171JCctP/cu2nM79lDqVnJw/2jOG8OnTc8zRDXAh0RKoR5rOU8cOHm0Ls2MATsFdnyRU5FGUxqZ+".getBytes("utf-8"));
+
+        byte[] exp = Base64.decodeBase64("Iw==".getBytes("utf-8"));
+        byte[] mod = Base64.decodeBase64("AMs9HO/NH/Now+6fSnESebaG4wzaYQWA1b/q1TGV1wHNtCg9fGFGVSKs0VxKF4cfVyrSLtgLjnlXQTn+Lm7xiYKGbBbsTQWOqEDaBVBsRbAkxIkpuvr6/EBxwrtDbKmSQYTJZVJSD2bZRYjGsR9gpZXPorOOKFd5EPCMHXsqnhp2hidTGH7cK6RuLk7MNnPISsY0Nbx8/ZvikiPROGcoTZ8bzUv4IaLr3veW6epSeQem8tJqhnrpTHhbLU99zf045M0Gsnk/azjjlBM+qrHZ5FNdC1kowJnLtf2Oy/rUQNpkGJtcBPT8xvreV0wLsn9t3hSxzsc0+VkDNTQRlfU+o3M=".getBytes("utf-8"));
+
+        final PublicKey publicKey = KeyFactory.getInstance("RSA").generatePublic(new RSAPublicKeySpec(new BigInteger(mod), new BigInteger(exp)));
+
+        final SignatureRSA rsa = new SignatureRSA();
+        rsa.initVerifier(publicKey);
+        rsa.update(msg);
+
+        Assert.assertTrue(rsa.verify(sig));
+    }
+
+    @Test
+    public void testLeadingZeroes_JCE() throws Throwable {
+        byte[] msg = Base64.decodeBase64("AAAAFPHgK1MeV9zNnok3pwNJhCd8SONqMgAAAAlidWlsZHVzZXIAAAAOc3NoLWNvbm5lY3Rpb24AAAAJcHVibGlja2V5AQAAAAdzc2gtcnNhAAABFQAAAAdzc2gtcnNhAAAAASMAAAEBAMs9HO/NH/Now+6fSnESebaG4wzaYQWA1b/q1TGV1wHNtCg9fGFGVSKs0VxKF4cfVyrSLtgLjnlXQTn+Lm7xiYKGbBbsTQWOqEDaBVBsRbAkxIkpuvr6/EBxwrtDbKmSQYTJZVJSD2bZRYjGsR9gpZXPorOOKFd5EPCMHXsqnhp2hidTGH7cK6RuLk7MNnPISsY0Nbx8/ZvikiPROGcoTZ8bzUv4IaLr3veW6epSeQem8tJqhnrpTHhbLU99zf045M0Gsnk/azjjlBM+qrHZ5FNdC1kowJnLtf2Oy/rUQNpkGJtcBPT8xvreV0wLsn9t3hSxzsc0+VkDNTQRlfU+o3M=".getBytes("utf-8"));
+        byte[] sig = Base64.decodeBase64("AAAAB3NzaC1yc2EAAAD/+Ntnf4qfr2J1voDS6I+u3VRjtMn+LdWJsAZfkLDxRkK1rQxP7QAjLdNqpT4CkWHp8dtoTGFlBFt6NieNJCMTA2KSOxJMZKsX7e/lHkh7C+vhQvJ9eLTKWjCxSFUrcM0NvFhmwbRCffwXSHvAKak4wbmofxQMpd+G4jZkNMz5kGpmeICBcNjRLPb7oXzuGr/g4x/3ge5Qaawqrg/gcZr/sKN6SdE8SszgKYO0SB320N4gcUoShVdLYr9uwdJ+kJoobfkUK6Or171JCctP/cu2nM79lDqVnJw/2jOG8OnTc8zRDXAh0RKoR5rOU8cOHm0Ls2MATsFdnyRU5FGUxqZ+".getBytes("utf-8"));
+
+        byte[] exp = Base64.decodeBase64("Iw==".getBytes("utf-8"));
+        byte[] mod = Base64.decodeBase64("AMs9HO/NH/Now+6fSnESebaG4wzaYQWA1b/q1TGV1wHNtCg9fGFGVSKs0VxKF4cfVyrSLtgLjnlXQTn+Lm7xiYKGbBbsTQWOqEDaBVBsRbAkxIkpuvr6/EBxwrtDbKmSQYTJZVJSD2bZRYjGsR9gpZXPorOOKFd5EPCMHXsqnhp2hidTGH7cK6RuLk7MNnPISsY0Nbx8/ZvikiPROGcoTZ8bzUv4IaLr3veW6epSeQem8tJqhnrpTHhbLU99zf045M0Gsnk/azjjlBM+qrHZ5FNdC1kowJnLtf2Oy/rUQNpkGJtcBPT8xvreV0wLsn9t3hSxzsc0+VkDNTQRlfU+o3M=".getBytes("utf-8"));
+
+        final PublicKey publicKey = KeyFactory.getInstance("RSA").generatePublic(new RSAPublicKeySpec(new BigInteger(mod), new BigInteger(exp)));
+
+        final SignatureRSA rsa = new SignatureRSA() {
+            @Override
+            protected Signature doInitSignature() throws GeneralSecurityException {
+                return java.security.Signature.getInstance(getAlgorithm());
+            }
+        };
+        rsa.initVerifier(publicKey);
+        rsa.update(msg);
+
+        Assert.assertTrue(rsa.verify(sig));
+    }
+}


### PR DESCRIPTION
Check expected signature length and add missing zeroes if needed.
Tests is also added
It turned out Bouncy Castle does not fail if signature size is less than public key modulus size
