### PR TITLE
[SSHD-705] fix GSSAPI Auth breaken

### DIFF
--- a/sshd-core/src/main/java/org/apache/sshd/server/auth/gss/UserAuthGSS.java
+++ b/sshd-core/src/main/java/org/apache/sshd/server/auth/gss/UserAuthGSS.java
@@ -131,7 +131,7 @@ public class UserAuthGSS extends AbstractUserAuth {
 
                 msgbuf.putBytes(ValidateUtils.checkNotNullAndNotEmpty(session.getSessionId(), "No current session ID"));
                 msgbuf.putByte(SshConstants.SSH_MSG_USERAUTH_REQUEST);
-                msgbuf.putString(getUsername());
+                msgbuf.putString(super.getUsername());
                 msgbuf.putString(getService());
                 msgbuf.putString(getName());
 


### PR DESCRIPTION
GSSAPI auth is breaken after changing username with getUserName().

https://github.com/apache/mina-sshd/commit/d19f5eca5714b7055b8655a46aeba0629c9dc05a#diff-6632304d23a69cec2f1da01ee1b4eb8fL127

```
- msgbuf.putString(username);
+ msgbuf.putString(getUserName());
```

https://github.com/apache/mina-sshd/commit/d19f5eca5714b7055b8655a46aeba0629c9dc05a#diff-6632304d23a69cec2f1da01ee1b4eb8fL185

```
- return identity != null ? identity : username;
+ return identity != null ? identity : super.getUserName();
```

getUserName() is not equals with username when identity is not null.