### PR TITLE
[SSHD-706] AbstractSession#checkForTimeouts: Avoid eager log4j invoca…

### DIFF
--- a/sshd-core/src/main/java/org/apache/sshd/common/session/helpers/AbstractSession.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/session/helpers/AbstractSession.java
@@ -2365,8 +2365,10 @@ public abstract class AbstractSession extends AbstractKexFactoryManager implemen
      */
     protected void checkForTimeouts() throws IOException {
         if (isClosing()) {
-            log.debug("checkForTimeouts({}) session closing", this);
-            return;
+            if (log.isDebugEnabled()) {
+                log.debug("checkForTimeouts({}) session closing", this);
+                return;
+            }
         }
 
         long now = System.currentTimeMillis();


### PR DESCRIPTION
…tions

Without Logger.isDebugEnabled() guard, the log message was always
constructed even though the log level was less than debug.