### PR TITLE
Use RSA for generated host keys by default

### DIFF
--- a/sshd-core/src/main/java/org/apache/sshd/server/keyprovider/AbstractGeneratorHostKeyProvider.java
+++ b/sshd-core/src/main/java/org/apache/sshd/server/keyprovider/AbstractGeneratorHostKeyProvider.java
@@ -52,7 +52,7 @@ import org.apache.sshd.common.util.security.SecurityUtils;
  * @author <a href="mailto:dev@mina.apache.org">Apache MINA SSHD Project</a>
  */
 public abstract class AbstractGeneratorHostKeyProvider extends AbstractKeyPairProvider {
-    public static final String DEFAULT_ALGORITHM = KeyUtils.DSS_ALGORITHM;
+    public static final String DEFAULT_ALGORITHM = KeyUtils.RSA_ALGORITHM;
     public static final boolean DEFAULT_ALLOWED_TO_OVERWRITE = true;
 
     private final AtomicReference<KeyPair> keyPairHolder = new AtomicReference<>();


### PR DESCRIPTION
As described [here](http://stackoverflow.com/a/33692432/12916), the default DSS algorithm is rejected by modern OpenSSH clients for security reasons. To make the server work smoothly by default it is better to use the RSA algorithm.