### PR TITLE
[SSHD-750] Allow SSH 1.99 in addition to 2.0 for SSHD

### DIFF
--- a/sshd-core/src/main/java/org/apache/sshd/server/session/AbstractServerSession.java
+++ b/sshd-core/src/main/java/org/apache/sshd/server/session/AbstractServerSession.java
@@ -347,7 +347,7 @@ public abstract class AbstractServerSession extends AbstractSession implements S
         }
 
         String errorMessage = null;
-        if ((errorMessage == null) && (!clientVersion.startsWith(DEFAULT_SSH_VERSION_PREFIX))) {
+        if (!(clientVersion.startsWith(DEFAULT_SSH_VERSION_PREFIX) || clientVersion.startsWith("SSH-1.99-"))) {
             errorMessage = "Unsupported protocol version: " + clientVersion;
         }
 


### PR DESCRIPTION
Several versions ago, SSH 1.99 support was added to the client to allow it to connect to Cisco devices. I'm now proposing the same be done to allow Cisco devices still using 1.99 to connect to SSHD.