### PR TITLE
[SSHD-786] Clients can't authenticate after unexpected exception in Nio2Acceptor

### DIFF
--- a/sshd-core/src/main/java/org/apache/sshd/common/io/nio2/Nio2Acceptor.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/io/nio2/Nio2Acceptor.java
@@ -245,8 +245,17 @@ public class Nio2Acceptor extends Nio2Service implements IoAcceptor {
 
             log.warn("Caught " + exc.getClass().getSimpleName()
                    + " while accepting incoming connection from " + address
-                   + ": " + exc.getMessage(),
-                    exc);
+                   + ": " + exc.getMessage(), exc);
+
+            try {
+                // Accept new connections
+                socket.accept(address, this);
+            } catch (Throwable t) {
+                // Do not call failed(t, address) to avoid infinite recursion
+                log.error("Failed (" + t.getClass().getSimpleName()
+                    + " to re-accept new connections on " + address
+                    + ": " + t.getMessage(), t);
+            }
         }
     }
 }

--- a/sshd-core/src/main/java/org/apache/sshd/common/io/nio2/Nio2Service.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/io/nio2/Nio2Service.java
@@ -93,6 +93,10 @@ public abstract class Nio2Service extends AbstractInnerCloseable implements IoSe
 
     public void dispose() {
         try {
+            if (disposing.getAndSet(true)) {
+                log.warn("dispose({}) already disposing", this);
+            }
+
             long maxWait = Closeable.getMaxCloseWaitTime(getFactoryManager());
             boolean successful = close(true).await(maxWait);
             if (!successful) {
@@ -100,11 +104,11 @@ public abstract class Nio2Service extends AbstractInnerCloseable implements IoSe
             }
         } catch (IOException e) {
             if (log.isDebugEnabled()) {
-                log.debug(e.getClass().getSimpleName() + " while stopping service: " + e.getMessage());
+                log.debug("dispose({}) {} while stopping service: {}", this, e.getClass().getSimpleName(), e.getMessage());
             }
 
             if (log.isTraceEnabled()) {
-                log.trace("Stop exception details", e);
+                log.trace("dispose(" + this + ") Stop exception details", e);
             }
         }
     }

--- a/sshd-core/src/test/java/org/apache/sshd/common/auth/AuthenticationTest.java
+++ b/sshd-core/src/test/java/org/apache/sshd/common/auth/AuthenticationTest.java
@@ -515,8 +515,8 @@ public class AuthenticationTest extends BaseTestSupport {
     @Test   // see SSHD-600
     public void testAuthExceptionPropagation() throws Exception {
         try (SshClient client = setupTestClient()) {
-            final RuntimeException expected = new RuntimeException("Synthetic exception");
-            final AtomicInteger invocations = new AtomicInteger(0);
+            RuntimeException expected = new RuntimeException("Synthetic exception");
+            AtomicInteger invocations = new AtomicInteger(0);
             client.addSessionListener(new SessionListener() {
                 @Override
                 public void sessionEvent(Session session, Event event) {
@@ -533,11 +533,15 @@ public class AuthenticationTest extends BaseTestSupport {
                 assertTrue("Failed to complete auth in allocated time", future.await(11L, TimeUnit.SECONDS));
                 assertFalse("Unexpected authentication success", future.isSuccess());
 
-                Throwable actual = future.getException();
+                Throwable signalled = future.getException();
+                Throwable actual = signalled;
                 if (actual instanceof IOException) {
                     actual = actual.getCause();
                 }
-                assertSame("Mismatched authentication failure reason", expected, actual);
+
+                if (expected != actual) {
+                    fail("Mismatched authentication failure reason: signalled=" + signalled + ", actual=" + actual);
+                }
             } finally {
                 client.stop();
             }


### PR DESCRIPTION
I have decide to along with _Guillaume_'s suggestion but with a minor twist - if the attempt to re-accept fails we do not call _fail_ in order to avoid infinite recursion.