### PR TITLE
SSHD-746 add minimal support so IPv6 addresses do not throw exceptions.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -327,6 +327,11 @@
                 </exclusions>
             </dependency>
             <dependency>
+                <groupId>commons-validator</groupId>
+                <artifactId>commons-validator</artifactId>
+                <version>1.6</version>
+            </dependency>
+            <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpclient</artifactId>
                 <version>${httpcomps.version}</version>

--- a/sshd-core/pom.xml
+++ b/sshd-core/pom.xml
@@ -63,8 +63,13 @@
             <artifactId>bcpkix-jdk15on</artifactId>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>commons-validator</groupId>
+            <artifactId>commons-validator</artifactId>
+        </dependency>
 
-            <!-- For ed25519 support -->
+
+        <!-- For ed25519 support -->
         <dependency>
             <groupId>net.i2p.crypto</groupId>
             <artifactId>eddsa</artifactId>

--- a/sshd-core/src/main/java/org/apache/sshd/client/SshClient.java
+++ b/sshd-core/src/main/java/org/apache/sshd/client/SshClient.java
@@ -56,6 +56,7 @@ import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
 
+import org.apache.commons.validator.routines.InetAddressValidator;
 import org.apache.sshd.agent.SshAgentFactory;
 import org.apache.sshd.client.auth.AuthenticationIdentitiesProvider;
 import org.apache.sshd.client.auth.UserAuth;
@@ -495,9 +496,14 @@ public class SshClient extends AbstractFactoryManager implements ClientFactoryMa
             if (log.isDebugEnabled()) {
                 log.debug("connect({}@{}:{}) no overrides", username, host, port);
             }
-
-            // generate a synthetic entry
-            entry = new HostConfigEntry(host, host, port, username);
+            //IPv6 addresses have a format which means they need special treatment, separate from pattern validation
+            if (InetAddressValidator.getInstance().isValidInet6Address(host)) {
+                // generate a synthetic entry, not using a pattern as the hostname passed in was a valid IPv6 address
+                entry = new HostConfigEntry("", host, port, username);
+            } else {
+                // generate a synthetic entry
+                entry = new HostConfigEntry(host, host, port, username);
+            }
         } else {
             if (log.isDebugEnabled()) {
                 log.debug("connect({}@{}:{}) effective: {}", username, host, port, entry);


### PR DESCRIPTION
This is the bare minimum required to make it possible to connect to hosts identified by an IPv6 address. I have tested this to confirm it works. The aim here is to make it possible (i.e no exceptions thrown) to connect to hosts defined by only an IPv6 address.