### PR TITLE
[SSHD-799] SSHD port forwarding. Missing SSH_MSG_CHANNEL_OPEN_FAILURE

### DIFF
--- a/sshd-core/src/main/java/org/apache/sshd/common/session/helpers/AbstractConnectionService.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/session/helpers/AbstractConnectionService.java
@@ -639,19 +639,21 @@ public abstract class AbstractConnectionService<S extends AbstractSession>
                     buf.putInt(window.getPacketSize());
                     session.writePacket(buf);
                 } else {
+                    int reasonCode = 0;
+                    String message =  "Error while opening channel: " + channelId;
+                    
                     Throwable exception = future.getException();
                     if (exception != null) {
-                        String message = exception.getMessage();
-                        int reasonCode = 0;
+                        message = exception.getMessage();
                         if (exception instanceof SshChannelOpenException) {
                             reasonCode = ((SshChannelOpenException) exception).getReasonCode();
                         } else {
-                            message = exception.getClass().getSimpleName() + " while opening channel: " + message;
-                        }
+                            message = exception.getClass().getSimpleName() + " while opening channel: " + message;                        }
 
-                        Buffer buf = session.createBuffer(SshConstants.SSH_MSG_CHANNEL_OPEN_FAILURE, message.length() + Long.SIZE);
-                        sendChannelOpenFailure(buf, sender, reasonCode, message, "");
-                    }
+                    } 
+                    
+                    Buffer buf = session.createBuffer(SshConstants.SSH_MSG_CHANNEL_OPEN_FAILURE, message.length() + Long.SIZE);
+                    sendChannelOpenFailure(buf, sender, reasonCode, message, "");
                 }
             } catch (IOException e) {
                 if (log.isDebugEnabled()) {


### PR DESCRIPTION
New PR containing only commit for the issue in subject