### PR TITLE
do not replace username with identity

### DIFF
--- a/sshd-core/src/main/java/org/apache/sshd/server/auth/gss/UserAuthGSS.java
+++ b/sshd-core/src/main/java/org/apache/sshd/server/auth/gss/UserAuthGSS.java
@@ -130,7 +130,7 @@ public class UserAuthGSS extends AbstractUserAuth {
                 Buffer msgbuf = new ByteArrayBuffer();
                 msgbuf.putBytes(ValidateUtils.checkNotNullAndNotEmpty(session.getSessionId(), "No current session ID"));
                 msgbuf.putByte(SshConstants.SSH_MSG_USERAUTH_REQUEST);
-                msgbuf.putString(super.getUsername());
+                msgbuf.putString(getUsername());
                 msgbuf.putString(getService());
                 msgbuf.putString(getName());
 
@@ -178,11 +178,6 @@ public class UserAuthGSS extends AbstractUserAuth {
                 }
             }
         }
-    }
-
-    @Override
-    public String getUsername() {
-        return identity != null ? identity : super.getUsername();
     }
 
     /**


### PR DESCRIPTION
This patch addresses the following problem:

In the existing code, once the identity is not null it replaces username. 
In case of GSS authentication the identity looks like 

   joe@EXAMPLE.ORG

It is separate and not equivalent to username. 

The issue came up while I was developing kerberized sshd that is used in admin shell interface in our 
project - dCache (dcache.org). We use apache MINA ssh server. Multiple users, each having their 
specific identities, need to login to account having one username. ACLs are defined for the username and multiple user identies map to this username (something similar to what is provided by .k5login file allowing multiple users login to the same account). The actual shell implementation picks username from Environment.ENV_USER and since exiting code replaces user w/ identity I am pretty much stuck.  

w/ this patch I am a happy customer :) 

Thank you, 
Dmitry 