### PR TITLE
[SSHD-827] Close immediately channels that were not opened due to exception

### DIFF
--- a/sshd-core/src/main/java/org/apache/sshd/common/forward/SocksProxy.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/forward/SocksProxy.java
@@ -166,7 +166,7 @@ public class SocksProxy extends AbstractCloseable implements IoHandler {
             Throwable t = future.getException();
             if (t != null) {
                 service.unregisterChannel(channel);
-                channel.close(false);
+                channel.close(true);
                 buffer.putByte((byte) 0x5b);
             } else {
                 buffer.putByte((byte) 0x5a);
@@ -284,7 +284,7 @@ public class SocksProxy extends AbstractCloseable implements IoHandler {
             Throwable t = future.getException();
             if (t != null) {
                 service.unregisterChannel(channel);
-                channel.close(false);
+                channel.close(true);
                 response.putByte((byte) 0x01);
             } else {
                 response.putByte((byte) 0x00);


### PR DESCRIPTION
Fix for SSHD-827