### PR TITLE
SSHD-838 Remove LoggingUtils.logExceptionStackTrace.

### DIFF
--- a/sshd-core/src/main/java/org/apache/sshd/common/io/nio2/Nio2Acceptor.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/io/nio2/Nio2Acceptor.java
@@ -31,14 +31,12 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.logging.Level;
 
 import org.apache.sshd.common.Closeable;
 import org.apache.sshd.common.FactoryManager;
 import org.apache.sshd.common.io.IoAcceptor;
 import org.apache.sshd.common.io.IoHandler;
 import org.apache.sshd.common.util.ValidateUtils;
-import org.apache.sshd.common.util.logging.LoggingUtils;
 
 /**
  * @author <a href="mailto:dev@mina.apache.org">Apache MINA SSHD Project</a>
@@ -288,8 +286,7 @@ public class Nio2Acceptor extends Nio2Service implements IoAcceptor {
             }
 
             log.warn("Caught {} while accepting incoming connection from {}: {}",
-                exc.getClass().getSimpleName(), address, exc.getMessage());
-            LoggingUtils.logExceptionStackTrace(log, Level.WARNING, exc);
+                exc.getClass().getSimpleName(), address, exc.getMessage(), exc);
             return true;
         }
     }

--- a/sshd-core/src/main/java/org/apache/sshd/common/io/nio2/Nio2Session.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/io/nio2/Nio2Session.java
@@ -32,7 +32,6 @@ import java.util.concurrent.LinkedTransferQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.logging.Level;
 
 import org.apache.sshd.common.FactoryManager;
 import org.apache.sshd.common.RuntimeSshException;
@@ -44,7 +43,6 @@ import org.apache.sshd.common.util.GenericUtils;
 import org.apache.sshd.common.util.Readable;
 import org.apache.sshd.common.util.buffer.Buffer;
 import org.apache.sshd.common.util.closeable.AbstractCloseable;
-import org.apache.sshd.common.util.logging.LoggingUtils;
 
 /**
  * @author <a href="mailto:dev@mina.apache.org">Apache MINA SSHD Project</a>
@@ -254,8 +252,7 @@ public class Nio2Session extends AbstractCloseable implements IoSession {
 
         } catch (IOException e) {
             log.info("doCloseImmediately({}) {} caught while closing socket={}: {}",
-                    this, e.getClass().getSimpleName(), socket, e.getMessage());
-            LoggingUtils.logExceptionStackTrace(log, Level.INFO, e);
+                    this, e.getClass().getSimpleName(), socket, e.getMessage(), e);
         }
 
         service.sessionClosed(this);


### PR DESCRIPTION
- Removed LoggingUtils.logExceptionStackTrace and its related helpers
- Updated call sites in Nio2Acceptor and Nio2Session to log exceptions by passing them directly to SLF4J