### PR TITLE
[SSHD-840] Respond to unknown messages with SSH_MSG_UNIMPLEMENTED

### DIFF
--- a/sshd-core/src/main/java/org/apache/sshd/common/session/helpers/AbstractConnectionService.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/session/helpers/AbstractConnectionService.java
@@ -369,7 +369,10 @@ public abstract class AbstractConnectionService
                 requestFailure(buffer);
                 break;
             default:
-                throw new IllegalStateException("Unsupported command: " + SshConstants.getCommandMessageName(cmd));
+                if (log.isDebugEnabled()) {
+                    log.debug("Unsupported command: {}", SshConstants.getCommandMessageName(cmd));
+                }
+                getSession().notImplemented();
         }
     }
 


### PR DESCRIPTION
Instead of throwing IllegalStateException, implement proper handling
as per https://tools.ietf.org/html/rfc4253#section-11.4.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>