### PR TITLE
[SSHD-846] Allow KeyPairGenerators to be garbage-collected

### DIFF
--- a/sshd-core/src/main/java/org/apache/sshd/common/kex/DHG.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/kex/DHG.java
@@ -69,6 +69,9 @@ public class DHG extends AbstractDH {
             myKeyAgree.init(myKpair.getPrivate());
             e = ((javax.crypto.interfaces.DHPublicKey) (myKpair.getPublic())).getY();
             e_array = e.toByteArray();
+
+            // At this point we will not need the KeyPairGenerator, allow it to be garbage-collected
+            myKpairGen = null;
         }
         return e_array;
     }

--- a/sshd-core/src/main/java/org/apache/sshd/common/kex/ECDH.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/kex/ECDH.java
@@ -77,6 +77,9 @@ public class ECDH extends AbstractDH {
             myKeyAgree.init(myKpair.getPrivate());
             e = ((ECPublicKey) myKpair.getPublic()).getW();
             e_array = ECCurves.encodeECPoint(e, params);
+
+            // At this point we will not need the KeyPairGenerator, allow it to be garbage-collected
+            myKpairGen = null;
         }
         return e_array;
     }

--- a/sshd-core/src/main/java/org/apache/sshd/common/session/helpers/AbstractSession.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/session/helpers/AbstractSession.java
@@ -1967,6 +1967,7 @@ public abstract class AbstractSession extends AbstractKexFactoryManager implemen
         outBlocksCount.set(0L);
         lastKeyTimeValue.set(System.currentTimeMillis());
         firstKexPacketFollows = null;
+        kex = null;
     }
 
     /**


### PR DESCRIPTION
Since we do not use the KeyPairGenerator once we have generated the keypair, make sure we remove our reference so it can be garbage-collected. With Bouncy Castle that translates to around ~34KiB memory savings per session.