### PR TITLE
OpenSSH client creates hash with port, mina should be able to verify …

### DIFF
--- a/sshd-common/src/main/java/org/apache/sshd/client/config/hosts/KnownHostEntry.java
+++ b/sshd-common/src/main/java/org/apache/sshd/client/config/hosts/KnownHostEntry.java
@@ -43,6 +43,8 @@ import org.apache.sshd.common.util.ValidateUtils;
 import org.apache.sshd.common.util.io.NoCloseInputStream;
 import org.apache.sshd.common.util.io.NoCloseReader;
 
+import static org.apache.sshd.common.config.ConfigFileReaderSupport.DEFAULT_PORT;
+
 /**
  * Contains a representation of an entry in the <code>known_hosts</code> file
  *
@@ -127,7 +129,11 @@ public class KnownHostEntry extends HostPatternsHolder {
         }
 
         KnownHostHashValue hash = getHashedEntry();
-        return (hash != null) && hash.isHostMatch(host);
+        String address = host;
+        if (port > 0 && DEFAULT_PORT != port ) {
+            address = HostPatternsHolder.NON_STANDARD_PORT_PATTERN_ENCLOSURE_START_DELIM + host + HostPatternsHolder.NON_STANDARD_PORT_PATTERN_ENCLOSURE_END_DELIM + HostPatternsHolder.PORT_VALUE_DELIMITER + port;
+        }
+        return (hash != null) && hash.isHostMatch(address);
     }
 
     @Override

--- a/sshd-common/src/test/java/org/apache/sshd/client/config/hosts/KnownHostEntryTest.java
+++ b/sshd-common/src/test/java/org/apache/sshd/client/config/hosts/KnownHostEntryTest.java
@@ -1,0 +1,33 @@
+package org.apache.sshd.client.config.hosts;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class KnownHostEntryTest {
+    @Test
+    public void testIsHostMatch_hashWithPort() {
+        // line generated `ssh xenon@localhost -p 10022 hostname` (SSH-2.0-OpenSSH_7.5)
+        String line = "|1|qhjoqX12EcnwZO3KNbpoFbxrdYE=|J+voEFzRbRL49TiHV+jbUfaS+kg= ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBJTsDTYFSYyRMlOec6JBfC8dEFqHNNWu7n8N0niS1zmHpggX+L4cndxhJPE0ILi9otHO7h0mp0cmqqho2tsX8lc=";
+        KnownHostEntry known = KnownHostEntry.parseKnownHostEntry(line);
+
+        assertTrue(known.isHostMatch("localhost", 10022));
+        // other ports should not match
+        assertFalse(known.isHostMatch("localhost", 0));
+        assertFalse(known.isHostMatch("localhost", 2222));
+        assertFalse(known.isHostMatch("localhost", 22));
+    }
+
+    @Test
+    public void testIsHostMatch_hashWithoutPort() {
+        // line generated `ssh xenon@localhost hostname` (SSH-2.0-OpenSSH_7.5)
+        String line = "|1|vLQs+atPgodQmPes21ZaMSgLD0s=|A2K2Ym0ZPtQmD8kB3FVViQvQ7qQ= ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBJTsDTYFSYyRMlOec6JBfC8dEFqHNNWu7n8N0niS1zmHpggX+L4cndxhJPE0ILi9otHO7h0mp0cmqqho2tsX8lc=";
+        KnownHostEntry known = KnownHostEntry.parseKnownHostEntry(line);
+
+        assertTrue(known.isHostMatch("localhost", 0));
+        assertTrue(known.isHostMatch("localhost", 22));
+        // other ports should not match
+        assertFalse(known.isHostMatch("localhost", 2222));
+    }
+}


### PR DESCRIPTION
…that hash

Compare hash with `[host]:port` if port is non-standard