### PR TITLE
Add continuous integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+language: java
+install: mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V || cat target/rat.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,3 +18,6 @@
 language: java
 jdk: openjdk8
 script: mvn test -B -Dtest=!org.apache.sshd.client.ClientTest#testConnectUsingIPv6Address
+cache:
+  directories:
+    - $HOME/.m2

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,4 @@
 # under the License.
 
 language: java
-install: mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V || cat target/rat.txt
+script: mvn test -B -Dtest=!org.apache.sshd.client.ClientTest#testConnectUsingIPv6Address

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,5 @@
 # under the License.
 
 language: java
+jdk: openjdk8
 script: mvn test -B -Dtest=!org.apache.sshd.client.ClientTest#testConnectUsingIPv6Address


### PR DESCRIPTION
This PR adds a continuous integration configuration, which I think would make it easier for contributors to test their changes.

About this PR:
- would use Travis CI. See here https://travis-ci.org/wh0/mina-sshd for example build output on my fork.
- Travis CI doesn't have IPv6 set up on their runners, so I've made it skip the IPv6-related client tests.
- One test is failing: `testLocalForwardingPayload(org.apache.sshd.common.forward.PortForwardingLoadTest)`. Could someone confirm that this test passes for them?