### PR TITLE
Core: Make checkConfig public

### DIFF
--- a/sshd-core/src/main/java/org/apache/sshd/client/SshClient.java
+++ b/sshd-core/src/main/java/org/apache/sshd/client/SshClient.java
@@ -321,7 +321,7 @@ public class SshClient extends AbstractFactoryManager implements ClientFactoryMa
     }
 
     @Override
-    protected void checkConfig() {
+    public void checkConfig() {
         super.checkConfig();
 
         Objects.requireNonNull(getForwarderFactory(), "ForwarderFactory not set");

--- a/sshd-core/src/main/java/org/apache/sshd/common/helpers/AbstractFactoryManager.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/helpers/AbstractFactoryManager.java
@@ -477,7 +477,7 @@ public abstract class AbstractFactoryManager extends AbstractKexFactoryManager i
         }
     }
 
-    protected void checkConfig() {
+    public void checkConfig() {
         ValidateUtils.checkNotNullAndNotEmpty(getKeyExchangeFactories(), "KeyExchangeFactories not set");
 
         if (getScheduledExecutorService() == null) {

--- a/sshd-core/src/main/java/org/apache/sshd/server/SshServer.java
+++ b/sshd-core/src/main/java/org/apache/sshd/server/SshServer.java
@@ -249,7 +249,7 @@ public class SshServer extends AbstractFactoryManager implements ServerFactoryMa
     }
 
     @Override
-    protected void checkConfig() {
+    public void checkConfig() {
         super.checkConfig();
 
         ValidateUtils.checkTrue(getPort() >= 0 /* zero means not set yet */, "Bad port number: %d", Integer.valueOf(getPort()));


### PR DESCRIPTION
`checkConfig` is documented in the README as a reference for how to configure an SshClient or SshServer, but we can't call it because it's protected.

This method would be helpful to have for setting up some sensible defaults when you want to use this library for its protocol handling combined with custom connection management. You would be able to call `checkConfig` without, for example, the entire `start` method in SshServer.