### PR TITLE
fixbug "LEAK: netty"

### DIFF
--- a/sshd-netty/src/main/java/org/apache/sshd/netty/NettyIoSession.java
+++ b/sshd-netty/src/main/java/org/apache/sshd/netty/NettyIoSession.java
@@ -187,6 +187,7 @@ public class NettyIoSession extends AbstractCloseable implements IoSession {
     protected void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
         ByteBuf buf = (ByteBuf) msg;
         handler.messageReceived(NettyIoSession.this, NettySupport.asReadable(buf));
+        buf.release();
     }
 
     protected void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {


### PR DESCRIPTION
LEAK: ByteBuf.release() was not called before it's garbage-collected.