### PR TITLE
[bugfix] fix transfer large file bug(more than1GB)

### DIFF
--- a/sshd-common/src/main/java/org/apache/sshd/common/util/buffer/ByteArrayBuffer.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/util/buffer/ByteArrayBuffer.java
@@ -206,14 +206,29 @@ public class ByteArrayBuffer extends Buffer {
         int curPos = wpos();
         int remaining = maxSize - curPos;
         if (remaining < capacity) {
-            int minimum = curPos + capacity;
-            int actual = growthFactor.applyAsInt(minimum);
-            if (actual < minimum) {
-                throw new IllegalStateException("ensureCapacity(" + capacity + ") actual (" + actual + ") below min. (" + minimum + ")");
+            if (maxSize < MAX_LEN) {
+                //increase data by growthFactor
+                int minimum = curPos + capacity;
+                int actual = growthFactor.applyAsInt(minimum);
+                if (actual < minimum) {
+                    throw new IllegalStateException("ensureCapacity(" + capacity + ") actual (" + actual + ") below min. (" + minimum + ")");
+                }
+                byte[] tmp = new byte[actual];
+                System.arraycopy(data, 0, tmp, 0, data.length);
+                data = tmp;
+            } else {
+                //if data increased to max size, compact
+                compact();
+                int maxSizeAfterCompact = size();   //shoul same as maxSize
+                int curPosAfterCompact = wpos();
+                int remainingAfterCompact = maxSizeAfterCompact - curPosAfterCompact;
+                if (remainingAfterCompact < capacity) {
+                    //after compact, if remaining still less than capacity, throws exception
+                    throw new IllegalStateException("remaining still less than capacity after compact, please decrease capacity, remainingAfterCompact(" + remainingAfterCompact
+                            + "), capacity(" + capacity + "), max buffer size(" + maxSizeAfterCompact + ")");
+                }
             }
-            byte[] tmp = new byte[actual];
-            System.arraycopy(data, 0, tmp, 0, data.length);
-            data = tmp;
+
         }
     }
 


### PR DESCRIPTION
fix a bug when using mina sshd to transfer a large source file(more than 1GB) by scp(scp username@remote:/largefile ./)
because if the source file is larger than 1GB, the function NumberUtils.getNextPowerOf2(int) can not compute a correct value for new cache and in endless loop (the value j will be negative and in next round, j will be 0, and the function comes to endless loop)