### PR TITLE
Fix download with pattern issue in rooted filesystem

### DIFF
--- a/sshd-scp/src/main/java/org/apache/sshd/common/scp/ScpHelper.java
+++ b/sshd-scp/src/main/java/org/apache/sshd/common/scp/ScpHelper.java
@@ -401,9 +401,11 @@ public class ScpHelper extends AbstractLoggingBean implements SessionHolder<Sess
                 }
 
                 Session session = getSession();
-                Iterable<String> included = opener.getMatchingFilesToSend(session, basedir, pattern);
+                Path basePath = resolveLocalPath(basedir);
+                Iterable<String> included = opener.getMatchingFilesToSend(session, basePath.toFile().getAbsolutePath(), pattern);
+
                 for (String path : included) {
-                    Path file = resolveLocalPath(basedir, path);
+                    Path file = basePath.resolve(path);
                     if (opener.sendAsRegularFile(session, file, options)) {
                         sendFile(file, preserve, bufferSize);
                     } else if (opener.sendAsDirectory(session, file, options)) {


### PR DESCRIPTION
Right now, download with pattern doesn't work when the underlying
filesystem is virtual filesystem. Also, the tests were masking the
behaviour by providing working location as rooted filesystem path.

This patch fixes the issue, by providing absolute path to retrieve files
matching the pattern.

cc  @lgoldstein  @thefourtheye @sramki