### PR TITLE
[SSHD-894] Fix Race condition when doing async auth.

### DIFF
--- a/sshd-core/src/main/java/org/apache/sshd/server/session/ServerUserAuthService.java
+++ b/sshd-core/src/main/java/org/apache/sshd/server/session/ServerUserAuthService.java
@@ -339,11 +339,13 @@ public class ServerUserAuthService extends AbstractCloseable implements Service,
                 sendWelcomeBanner(session);
             }
 
-            Buffer response = session.createBuffer(SshConstants.SSH_MSG_USERAUTH_SUCCESS, Byte.SIZE);
-            session.writePacket(response);
             session.setUsername(username);
             session.setAuthenticated();
             session.startService(authService, buffer);
+
+            buffer = session.createBuffer(SshConstants.SSH_MSG_USERAUTH_SUCCESS, Byte.SIZE);
+            session.writePacket(buffer);
+
             session.resetIdleTimeout();
             log.info("Session {}@{} authenticated", username, session.getIoSession().getRemoteAddress());
         } else {


### PR DESCRIPTION
Currently, when doing async auth, the response is being sent to client
before starting the service with auth status set. When the client
responds back with next request, the request will reach auth service and
fail with `No current authentication mechanism for cmd=SSH_MSG_CHANNEL_OPEN`.
This happens mostly when the system starts (as, service initialization
might take time)

This patch fixes the issue by changing the order and send the packet
after the service starts.

cc @lgoldstein @thefourtheye @sramki