### PR TITLE
[SSHD-929] Create separate listener for remove directory.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -49,6 +49,8 @@ may be available in the relevant data file.
 * `org.apache.sshd.agent.unix.AgentClient` constructor expects a non-*null* `FactoryManager` instance which
 it then exposes via its `getFactoryManager`.
 
+* `SftpEventListener` has separate callbacks for informing about removal of files vs. directories
+
 ## Minor code helpers
 
 * The `Session` object provides a `isServerSession` method that can be used to distinguish between
@@ -145,3 +147,5 @@ and therefore closing all currently tracked file/directory handles.
 * [SSHD-921](https://issues.apache.org/jira/browse/SSHD-921) - Do not send session disconnect message due to timeout expiration if already done so.
 
 * [SSHD-923](https://issues.apache.org/jira/browse/SSHD-923) - Added agent close detection mechanisms to avoid infinite waits on incoming messages.
+
+* [SSHD-929](https://issues.apache.org/jira/browse/SSHD-929) - Provide separate SFTP event listener callbacks for removal of files vs. directories.

--- a/sshd-cli/src/main/java/org/apache/sshd/cli/server/helper/SftpServerSubSystemEventListener.java
+++ b/sshd-cli/src/main/java/org/apache/sshd/cli/server/helper/SftpServerSubSystemEventListener.java
@@ -73,7 +73,7 @@ public class SftpServerSubSystemEventListener extends ServerEventListenerHelper 
     }
 
     @Override
-    public void removed(ServerSession session, Path path, Throwable thrown) throws IOException {
+    public void removedFile(ServerSession session, Path path, Throwable thrown) throws IOException {
         if (thrown == null) {
             outputDebugMessage("Session %s removed %s", session, path);
         } else {

--- a/sshd-contrib/src/main/java/org/apache/sshd/server/subsystem/sftp/SimpleAccessControlSftpEventListener.java
+++ b/sshd-contrib/src/main/java/org/apache/sshd/server/subsystem/sftp/SimpleAccessControlSftpEventListener.java
@@ -161,8 +161,16 @@ public abstract class SimpleAccessControlSftpEventListener extends AbstractSftpE
     }
 
     @Override
-    public void removing(ServerSession session, Path path) throws IOException {
-        super.removing(session, path);
+    public void removingFile(ServerSession session, Path path) throws IOException {
+        super.removingFile(session, path);
+        if (!isModificationAllowed(session, path.toString(), path)) {
+            throw new AccessDeniedException(path.toString());
+        }
+    }
+
+    @Override
+    public void removingDirectory(ServerSession session, Path path) throws IOException {
+        super.removingDirectory(session, path);
         if (!isModificationAllowed(session, path.toString(), path)) {
             throw new AccessDeniedException(path.toString());
         }

--- a/sshd-contrib/src/test/java/org/apache/sshd/server/subsystem/sftp/SimpleAccessControlSftpEventListenerTest.java
+++ b/sshd-contrib/src/test/java/org/apache/sshd/server/subsystem/sftp/SimpleAccessControlSftpEventListenerTest.java
@@ -139,7 +139,8 @@ public class SimpleAccessControlSftpEventListenerTest extends BaseTestSupport {
     public void testReadOnlyDirectoryAccess() throws Exception {
         Path targetPath = detectTargetFolder();
         Path parentPath = targetPath.getParent();
-        Path lclSftp = CommonTestSupportUtils.resolve(targetPath, SftpConstants.SFTP_SUBSYSTEM_NAME, getClass().getSimpleName(), getCurrentTestName());
+        Path lclSftp = CommonTestSupportUtils.resolve(
+                targetPath, SftpConstants.SFTP_SUBSYSTEM_NAME, getClass().getSimpleName(), getCurrentTestName());
         Path testFile = assertHierarchyTargetFolderExists(lclSftp).resolve("file.txt");
         byte[] data = (getClass().getName() + "#" + getCurrentTestName()).getBytes(StandardCharsets.UTF_8);
         Files.deleteIfExists(testFile);
@@ -148,7 +149,9 @@ public class SimpleAccessControlSftpEventListenerTest extends BaseTestSupport {
         try (SshClient client = setupTestClient()) {
             client.start();
 
-            try (ClientSession session = client.connect(getCurrentTestName(), TEST_LOCALHOST, port).verify(7L, TimeUnit.SECONDS).getSession()) {
+            try (ClientSession session = client.connect(getCurrentTestName(), TEST_LOCALHOST, port)
+                    .verify(7L, TimeUnit.SECONDS)
+                    .getSession()) {
                 session.addPasswordIdentity(getCurrentTestName());
                 session.auth().verify(5L, TimeUnit.SECONDS);
 
@@ -161,7 +164,7 @@ public class SimpleAccessControlSftpEventListenerTest extends BaseTestSupport {
                     String file = CommonTestSupportUtils.resolveRelativeRemotePath(parentPath, testFile);
                     try {
                         sftp.remove(file);
-                        fail("Unexpected file remove success");
+                        fail("Unexpected file removal success");
                     } catch (SftpException e) {
                         int status = e.getStatus();
                         assertEquals("Unexpected remove SFTP status code", SftpConstants.SSH_FX_PERMISSION_DENIED, status);
@@ -177,7 +180,7 @@ public class SimpleAccessControlSftpEventListenerTest extends BaseTestSupport {
 
                     try {
                         sftp.rmdir(folder);
-                        fail("Unexpected folder creation success");
+                        fail("Unexpected folder removal success");
                     } catch (SftpException e) {
                         int status = e.getStatus();
                         assertEquals("Unexpected rmdir SFTP status code", SftpConstants.SSH_FX_PERMISSION_DENIED, status);

--- a/sshd-sftp/src/main/java/org/apache/sshd/server/subsystem/sftp/AbstractSftpEventListenerAdapter.java
+++ b/sshd-sftp/src/main/java/org/apache/sshd/server/subsystem/sftp/AbstractSftpEventListenerAdapter.java
@@ -207,18 +207,18 @@ public abstract class AbstractSftpEventListenerAdapter extends AbstractLoggingBe
     }
 
     @Override
-    public void removing(ServerSession session, Path path)
+    public void removingFile(ServerSession session, Path path)
             throws IOException {
         if (log.isTraceEnabled()) {
-            log.trace("removing(" + session + ") " + path);
+            log.trace("removingFile(" + session + ") " + path);
         }
     }
 
     @Override
-    public void removed(ServerSession session, Path path, Throwable thrown)
+    public void removedFile(ServerSession session, Path path, Throwable thrown)
             throws IOException {
         if (log.isTraceEnabled()) {
-            log.trace("removed(" + session + ") " + path
+            log.trace("removedFile(" + session + ") " + path
                   + ((thrown == null) ? "" : (": " + thrown.getClass().getSimpleName() + ": " + thrown.getMessage())));
         }
     }

--- a/sshd-sftp/src/main/java/org/apache/sshd/server/subsystem/sftp/SftpEventListener.java
+++ b/sshd-sftp/src/main/java/org/apache/sshd/server/subsystem/sftp/SftpEventListener.java
@@ -370,26 +370,50 @@ public interface SftpEventListener extends SshdEventListener {
     }
 
     /**
-     * Called <U>prior</U> to removing a file / directory
+     * Called <U>prior</U> to removing a file
      *
      * @param session The {@link ServerSession} through which the request was handled
      * @param path    The {@link Path} about to be removed
      * @throws IOException If failed to handle the call
-     * @see #removed(ServerSession, Path, Throwable)
+     * @see #removedFile(ServerSession, Path, Throwable)
      */
-    default void removing(ServerSession session, Path path) throws IOException {
+    default void removingFile(ServerSession session, Path path) throws IOException {
         // ignored
     }
 
     /**
-     * Called <U>after</U> a file / directory has been removed
+     * Called <U>after</U> a file has been removed
      *
      * @param session The {@link ServerSession} through which the request was handled
      * @param path    The {@link Path} to be removed
      * @param thrown  If not-{@code null} then the reason for the failure to execute
      * @throws IOException If failed to handle the call
      */
-    default void removed(ServerSession session, Path path, Throwable thrown) throws IOException {
+    default void removedFile(ServerSession session, Path path, Throwable thrown) throws IOException {
+        // ignored
+    }
+
+    /**
+     * Called <U>prior</U> to removing a directory
+     *
+     * @param session The {@link ServerSession} through which the request was handled
+     * @param path    The {@link Path} about to be removed
+     * @throws IOException If failed to handle the call
+     * @see #removedDirectory(ServerSession, Path, Throwable)
+     */
+    default void removingDirectory(ServerSession session, Path path) throws IOException {
+        // ignored
+    }
+
+    /**
+     * Called <U>after</U> a directory has been removed
+     *
+     * @param session The {@link ServerSession} through which the request was handled
+     * @param path    The {@link Path} to be removed
+     * @param thrown  If not-{@code null} then the reason for the failure to execute
+     * @throws IOException If failed to handle the call
+     */
+    default void removedDirectory(ServerSession session, Path path, Throwable thrown) throws IOException {
         // ignored
     }
 

--- a/sshd-sftp/src/test/java/org/apache/sshd/client/subsystem/sftp/SftpTest.java
+++ b/sshd-sftp/src/test/java/org/apache/sshd/client/subsystem/sftp/SftpTest.java
@@ -738,6 +738,8 @@ public class SftpTest extends AbstractSftpClientTestSupport {
         AtomicInteger createdCount = new AtomicInteger(0);
         AtomicInteger removingCount = new AtomicInteger(0);
         AtomicInteger removedCount = new AtomicInteger(0);
+        AtomicInteger removingDirectoryCount = new AtomicInteger(0);
+        AtomicInteger removedDirectoryCount = new AtomicInteger(0);
         AtomicInteger modifyingCount = new AtomicInteger(0);
         AtomicInteger modifiedCount = new AtomicInteger(0);
         SftpEventListener listener = new AbstractSftpEventListenerAdapter() {
@@ -765,16 +767,29 @@ public class SftpTest extends AbstractSftpClientTestSupport {
             }
 
             @Override
-            public void removing(ServerSession session, Path path) {
+            public void removingFile(ServerSession session, Path path) {
                 removingCount.incrementAndGet();
-                log.info("removing(" + session + ") " + path);
+                log.info("removingFile(" + session + ") " + path);
             }
 
             @Override
-            public void removed(ServerSession session, Path path, Throwable thrown) {
+            public void removedFile(ServerSession session, Path path, Throwable thrown) {
                 removedCount.incrementAndGet();
-                log.info("removed(" + session + ") " + path
+                log.info("removedFile(" + session + ") " + path
                        + ((thrown == null) ? "" : (": " + thrown.getClass().getSimpleName() + ": " + thrown.getMessage())));
+            }
+
+            @Override
+            public void removingDirectory(ServerSession session, Path path) {
+                removingDirectoryCount.incrementAndGet();
+                log.info("removingDirectory(" + session + ") " + path);
+            }
+
+            @Override
+            public void removedDirectory(ServerSession session, Path path, Throwable thrown) {
+                removedDirectoryCount.incrementAndGet();
+                log.info("removedDirectory(" + session + ") " + path
+                        + ((thrown == null) ? "" : (": " + thrown.getClass().getSimpleName() + ": " + thrown.getMessage())));
             }
 
             @Override
@@ -909,6 +924,7 @@ public class SftpTest extends AbstractSftpClientTestSupport {
             assertTrue("No data read", readSize.get() > 0L);
             assertTrue("No data written", writeSize.get() > 0L);
             assertEquals("Mismatched removal counts", removingCount.get(), removedCount.get());
+            assertEquals("Mismatched directory removal counts", removingDirectoryCount.get(), removedDirectoryCount.get());
             assertTrue("No removals signalled", removedCount.get() > 0);
             assertEquals("Mismatched creation counts", creatingCount.get(), createdCount.get());
             assertTrue("No creations signalled", creatingCount.get() > 0);


### PR DESCRIPTION
Right now listener for deletion of file and directory is common. This makes it difficult to find whether directory / file has been removed.

The path passed to `removed` function in SftpEventListener will not tell if the deleted path was a directory or file. `Files.isDirectory(path)` will return false, as the directory doesn't exist.

This patch will have a fix to create one more listener entry for directory removal.