### PR TITLE
[SSHD-967] fixed byte buffer issue

### DIFF
--- a/sshd-sftp/src/main/java/org/apache/sshd/client/subsystem/sftp/SftpRemotePathChannel.java
+++ b/sshd-sftp/src/main/java/org/apache/sshd/client/subsystem/sftp/SftpRemotePathChannel.java
@@ -262,7 +262,7 @@ public class SftpRemotePathChannel extends FileChannel {
                 while (totalRead < count) {
                     int read = sftp.read(handle, curPos, buffer, 0, buffer.length);
                     if (read > 0) {
-                        ByteBuffer wrap = ByteBuffer.wrap(buffer);
+                        ByteBuffer wrap = ByteBuffer.wrap(buffer, 0,  (int) Math.min(count - totalRead, buffer.length));
                         while (wrap.remaining() > 0) {
                             target.write(wrap);
                         }

--- a/sshd-sftp/src/main/java/org/apache/sshd/client/subsystem/sftp/SftpRemotePathChannel.java
+++ b/sshd-sftp/src/main/java/org/apache/sshd/client/subsystem/sftp/SftpRemotePathChannel.java
@@ -262,7 +262,7 @@ public class SftpRemotePathChannel extends FileChannel {
                 while (totalRead < count) {
                     int read = sftp.read(handle, curPos, buffer, 0, buffer.length);
                     if (read > 0) {
-                        ByteBuffer wrap = ByteBuffer.wrap(buffer, 0,  (int) Math.min(count - totalRead, buffer.length));
+                        ByteBuffer wrap = ByteBuffer.wrap(buffer, 0,  read);
                         while (wrap.remaining() > 0) {
                             target.write(wrap);
                         }


### PR DESCRIPTION
In the last cycle of write if read size was less than buffer size remaining buffer indexes was still containing old value and was flushed in the file.
Fix this by giving the amount of byte to be wrapped to  flushed to file