### PR TITLE
SSHD-968 interpret SSH_MSG_UNIMPLEMENTED response to a global request as its failure

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,3 +15,7 @@
 * [SSHD-964](https://issues.apache.org/jira/browse/SSHD-964) - Send SSH_MSG_CHANNEL_EOF when tunnel channel being closed.
 
 * [SSHD-967](https://issues.apache.org/jira/browse/SSHD-967) - Extra bytes written when `SftpRemotePathChannel#transferTo` is used.
+
+* [SSHD-968](https://issues.apache.org/jira/browse/SSHD-968) - Interpret SSH_MSG_UNIMPLEMENTED response to a heartbeat request as a liveness indicator
+
+* [SSHD-970](https://issues.apache.org/jira/browse/SSHD-970) - `transferTo` function of `SftpRemotePathChannel` will loop if count parameter is greater than file size

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,14 @@
 
 ## Major code re-factoring
 
+* Reception of an `SSH_MSG_UNIMPLEMENTED` response to a `SSH_MSG_GLOBAL_REQUEST` is
+translated internally into same code flow as if an `SSH_MSH_REQUEST_FAILURE` has
+been received - see [SSHD-968](https://issues.apache.org/jira/browse/SSHD-968).
+
 ## Minor code helpers
+
+* Handling of debug/ignore/unimplemented messages has been split into `handleXXX` and `doInvokeXXXMsgHandler` methods
+where the former validate the messages and deal with the idle timeout, and the latter execute the actual invcation.
 
 ## Behavioral changes and enhancements
 

--- a/docs/client-setup.md
+++ b/docs/client-setup.md
@@ -238,7 +238,10 @@ the `ClientSession` (for specific session configuration).
     * If specified timeout expires for the `wantReply` option then session will be **closed**.
 
     * *Any* response - including [`SSH_MSH_REQUEST_FAILURE`](https://tools.ietf.org/html/rfc4254#page-4)
-    is considered a "good" response for the heartbeat request.
+    is considered a "good" response for the heartbeat request. In this context, a special patch
+    has been introduced in [SSHD-968](https://issues.apache.org/jira/browse/SSHD-968) that converts
+    an `SSH_MSG_UNIMPLEMENTED` response to such a global request into a `SSH_MSH_REQUEST_FAILURE`
+    since some servers have been found that violate the standard and reply with it to the request.
 
 * When using the CLI, these options can be configured using the following `-o key=value` properties:
 

--- a/sshd-common/src/main/java/org/apache/sshd/common/util/buffer/Buffer.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/util/buffer/Buffer.java
@@ -115,11 +115,25 @@ public abstract class Buffer implements Readable {
 
     /**
      * @param pos A position in the <U>raw</U> underlying data bytes
-     * @return The byte at that position
+     * @return The byte at the specified position without changing the
+     * current {@link #rpos() read position}. <B>Note:</B> no validation
+     * is made whether the position lies within array boundaries
      */
     public byte rawByte(int pos) {
         byte[] data = array();
         return data[pos];
+    }
+
+    /**
+     * @param pos A position in the <U>raw</U> underlying data bytes
+     * @return The unsigned 32 bit integer at the specified position
+     * without changing the current {@link #rpos() read position}.
+     * <B>Note:</B> no validation is made whether the position and
+     * the required extra 4 bytes lie within array boundaries
+     */
+    public long rawUInt(int pos) {
+        byte[] data = array();
+        return BufferUtils.getUInt(data, pos, Integer.BYTES);
     }
 
     /**

--- a/sshd-common/src/main/java/org/apache/sshd/common/util/buffer/ByteArrayBuffer.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/util/buffer/ByteArrayBuffer.java
@@ -163,6 +163,11 @@ public class ByteArrayBuffer extends Buffer {
     }
 
     @Override
+    public long rawUInt(int pos) {
+        return BufferUtils.getUInt(data, pos, Integer.BYTES);
+    }
+
+    @Override
     public void compact() {
         int avail = available();
         if (avail > 0) {

--- a/sshd-core/src/main/java/org/apache/sshd/common/session/helpers/AbstractSession.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/session/helpers/AbstractSession.java
@@ -1624,8 +1624,7 @@ public abstract class AbstractSession extends SessionHelper {
      * @see #sendNotImplemented(long)
      */
     protected IoWriteFuture notImplemented(int cmd, Buffer buffer) throws Exception {
-        ReservedSessionMessagesHandler handler = resolveReservedSessionMessagesHandler();
-        if (handler.handleUnimplementedMessage(this, cmd, buffer)) {
+        if (doInvokeUnimplementedMessageHandler(cmd, buffer)) {
             return null;
         }
 

--- a/sshd-core/src/main/java/org/apache/sshd/common/session/helpers/SessionHelper.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/session/helpers/SessionHelper.java
@@ -404,8 +404,22 @@ public abstract class SessionHelper extends AbstractKexFactoryManager implements
             return;
         }
         resetIdleTimeout();
+        doInvokeIgnoreMessageHandler(buffer);
+    }
 
-        ReservedSessionMessagesHandler handler = resolveReservedSessionMessagesHandler();
+    /**
+     * Invoked by {@link #handleDebug(Buffer)} after validating that the buffer
+     * structure seems well-formed and also resetting the idle timeout. By default,
+     * retrieves the {@link #resolveReservedSessionMessagesHandler() ReservedSessionMessagesHandler}
+     * and invokes its {@link ReservedSessionMessagesHandler#handleIgnoreMessage(Session, Buffer) handleIgnoreMessage}
+     * method.
+     *
+     * @param buffer The input {@link Buffer}
+     * @throws Exception if failed to handle the message
+     */
+    protected void doInvokeIgnoreMessageHandler(Buffer buffer) throws Exception {
+        ReservedSessionMessagesHandler handler =
+            resolveReservedSessionMessagesHandler();
         handler.handleIgnoreMessage(this, buffer);
     }
 
@@ -430,9 +444,19 @@ public abstract class SessionHelper extends AbstractKexFactoryManager implements
             return;
         }
         resetIdleTimeout();
+        doInvokeUnimplementedMessageHandler(SshConstants.SSH_MSG_UNIMPLEMENTED, buffer);
+    }
 
-        ReservedSessionMessagesHandler handler = resolveReservedSessionMessagesHandler();
-        handler.handleUnimplementedMessage(this, SshConstants.SSH_MSG_UNIMPLEMENTED, buffer);
+    /**
+     * @param cmd The unimplemented command
+     * @param buffer The input {@link Buffer}
+     * @return Result of invoking {@link ReservedSessionMessagesHandler#handleUnimplementedMessage(Session, int, Buffer) handleUnimplementedMessage}
+     * @throws Exception if failed to handle the message
+     */
+    protected boolean doInvokeUnimplementedMessageHandler(int cmd, Buffer buffer) throws Exception {
+        ReservedSessionMessagesHandler handler =
+            resolveReservedSessionMessagesHandler();
+        return handler.handleUnimplementedMessage(this, cmd, buffer);
     }
 
     @Override
@@ -456,9 +480,24 @@ public abstract class SessionHelper extends AbstractKexFactoryManager implements
             }
             return;
         }
-        resetIdleTimeout();
 
-        ReservedSessionMessagesHandler handler = resolveReservedSessionMessagesHandler();
+        resetIdleTimeout();
+        doInvokeDebugMessageHandler(buffer);
+    }
+
+    /**
+     * Invoked by {@link #handleDebug(Buffer)} after validating that the buffer
+     * structure seems well-formed and also resetting the idle timeout. By default,
+     * retrieves the {@link #resolveReservedSessionMessagesHandler() ReservedSessionMessagesHandler}
+     * and invokes its {@link ReservedSessionMessagesHandler#handleDebugMessage(Session, Buffer) handleDebugMessage}
+     * method.
+     *
+     * @param buffer The input {@link Buffer}
+     * @throws Exception if failed to handle the message
+     */
+    protected void doInvokeDebugMessageHandler(Buffer buffer) throws Exception {
+        ReservedSessionMessagesHandler handler =
+            resolveReservedSessionMessagesHandler();
         handler.handleDebugMessage(this, buffer);
     }
 

--- a/sshd-core/src/main/java/org/apache/sshd/common/session/helpers/SessionHelper.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/session/helpers/SessionHelper.java
@@ -556,10 +556,10 @@ public abstract class SessionHelper extends AbstractKexFactoryManager implements
         return writePacket(buffer);
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public IoWriteFuture writePacket(Buffer buffer, long timeout, TimeUnit unit) throws IOException {
         IoWriteFuture writeFuture = writePacket(buffer);
+        @SuppressWarnings("unchecked")
         DefaultSshFuture<IoWriteFuture> future = (DefaultSshFuture<IoWriteFuture>) writeFuture;
         FactoryManager factoryManager = getFactoryManager();
         ScheduledExecutorService executor = factoryManager.getScheduledExecutorService();

--- a/sshd-core/src/test/java/org/apache/sshd/KeepAliveTest.java
+++ b/sshd-core/src/test/java/org/apache/sshd/KeepAliveTest.java
@@ -20,7 +20,9 @@ package org.apache.sshd;
 
 import java.io.ByteArrayOutputStream;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.EnumSet;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -32,6 +34,10 @@ import org.apache.sshd.client.session.ClientSession;
 import org.apache.sshd.common.FactoryManager;
 import org.apache.sshd.common.PropertyResolverUtils;
 import org.apache.sshd.common.channel.Channel;
+import org.apache.sshd.common.channel.RequestHandler;
+import org.apache.sshd.common.session.ConnectionService;
+import org.apache.sshd.common.session.helpers.AbstractConnectionServiceRequestHandler;
+import org.apache.sshd.common.util.buffer.Buffer;
 import org.apache.sshd.server.SshServer;
 import org.apache.sshd.server.channel.ChannelSession;
 import org.apache.sshd.server.command.Command;
@@ -101,17 +107,21 @@ public class KeepAliveTest extends BaseTestSupport {
 
     @After
     public void tearDown() {
+        // Restore default value
         PropertyResolverUtils.updateProperty(
             sshd, FactoryManager.IDLE_TIMEOUT, FactoryManager.DEFAULT_IDLE_TIMEOUT);
         PropertyResolverUtils.updateProperty(
             client, ClientFactoryManager.HEARTBEAT_INTERVAL, ClientFactoryManager.DEFAULT_HEARTBEAT_INTERVAL);
+        PropertyResolverUtils.updateProperty(
+            client, ClientFactoryManager.HEARTBEAT_REPLY_WAIT, ClientFactoryManager.DEFAULT_HEARTBEAT_REPLY_WAIT);
     }
 
     @Test
     public void testIdleClient() throws Exception {
-        try (ClientSession session = client.connect(getCurrentTestName(), TEST_LOCALHOST, port)
-                .verify(7L, TimeUnit.SECONDS)
-                .getSession()) {
+        try (ClientSession session =
+                client.connect(getCurrentTestName(), TEST_LOCALHOST, port)
+                    .verify(7L, TimeUnit.SECONDS)
+                    .getSession()) {
             session.addPasswordIdentity(getCurrentTestName());
             session.auth().verify(5L, TimeUnit.SECONDS);
 
@@ -128,10 +138,12 @@ public class KeepAliveTest extends BaseTestSupport {
 
     @Test
     public void testClientWithHeartBeat() throws Exception {
-        PropertyResolverUtils.updateProperty(client, ClientFactoryManager.HEARTBEAT_INTERVAL, HEARTBEAT);
-        try (ClientSession session = client.connect(getCurrentTestName(), TEST_LOCALHOST, port)
-                .verify(7L, TimeUnit.SECONDS)
-                .getSession()) {
+        PropertyResolverUtils.updateProperty(
+            client, ClientFactoryManager.HEARTBEAT_INTERVAL, HEARTBEAT);
+        try (ClientSession session =
+                client.connect(getCurrentTestName(), TEST_LOCALHOST, port)
+                    .verify(7L, TimeUnit.SECONDS)
+                    .getSession()) {
             session.addPasswordIdentity(getCurrentTestName());
             session.auth().verify(5L, TimeUnit.SECONDS);
 
@@ -150,7 +162,8 @@ public class KeepAliveTest extends BaseTestSupport {
     public void testShellClosedOnClientTimeout() throws Exception {
         TestEchoShell.latch = new CountDownLatch(1);
 
-        try (ClientSession session = client.connect(getCurrentTestName(), TEST_LOCALHOST, port)
+        try (ClientSession session =
+                client.connect(getCurrentTestName(), TEST_LOCALHOST, port)
                     .verify(7L, TimeUnit.SECONDS)
                     .getSession()) {
             session.addPasswordIdentity(getCurrentTestName());
@@ -175,6 +188,45 @@ public class KeepAliveTest extends BaseTestSupport {
             }
         } finally {
             TestEchoShell.latch = null;
+        }
+    }
+
+    @Test // see SSHD-968
+    public void testAllowUnimplementedMessageHeartbeatResponse() throws Exception {
+        List<RequestHandler<ConnectionService>> globalHandlers = sshd.getGlobalRequestHandlers();
+        sshd.setGlobalRequestHandlers(
+            Collections.singletonList(
+                new AbstractConnectionServiceRequestHandler() {
+                    @Override
+                    public Result process(
+                            ConnectionService connectionService, String request,
+                            boolean wantReply, Buffer buffer)
+                                throws Exception {
+                        connectionService.process(
+                            255 /* trigger unimplemented command handler */, buffer);
+                        return Result.Replied;
+                    }
+                }));
+        PropertyResolverUtils.updateProperty(
+            client, ClientFactoryManager.HEARTBEAT_INTERVAL, HEARTBEAT);
+        PropertyResolverUtils.updateProperty(
+            client, ClientFactoryManager.HEARTBEAT_REPLY_WAIT, TimeUnit.SECONDS.toMillis(5L));
+        try (ClientSession session = client.connect(getCurrentTestName(), TEST_LOCALHOST, port)
+                .verify(7L, TimeUnit.SECONDS)
+                .getSession()) {
+            session.addPasswordIdentity(getCurrentTestName());
+            session.auth().verify(5L, TimeUnit.SECONDS);
+
+            try (ClientChannel channel = session.createChannel(Channel.CHANNEL_SHELL)) {
+                long waitStart = System.currentTimeMillis();
+                Collection<ClientChannelEvent> result =
+                    channel.waitFor(EnumSet.of(ClientChannelEvent.CLOSED), WAIT);
+                long waitEnd = System.currentTimeMillis();
+                assertTrue("Wrong channel state after wait of " + (waitEnd - waitStart) + " ms: " + result,
+                    result.contains(ClientChannelEvent.TIMEOUT));
+            }
+        } finally {
+            sshd.setGlobalRequestHandlers(globalHandlers); // restore original
         }
     }
 


### PR DESCRIPTION
The main flow is as follows:

* when `AbstractSession#preProcessEncodeBuffer` override is called as part of sending the global request, it checks if the buffer about to be encoded and written is a `SSH_MSG_GLOBAL_REQUEST` command. If so, it stores the outgoing message sequence number in case `SSH_MSG_UNIMPLEMENTED` is reported for it.

* `AbstractSession#request` resets the tracked global request outgoing sequence number if either a response was received or timeout expired.

* `AbstractSession#doInvokeUnimplementedMessageHandler` override checks if the reported message number matches the currently tracked global request message and converts it to a message failure signal instead (thus releasing the `AbstractSession#request` loop waiting for it).