### PR TITLE
[SSHD-975] Use AbstractFactoryManager's classloader for proxies

### DIFF
--- a/sshd-core/src/main/java/org/apache/sshd/common/channel/AbstractChannel.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/channel/AbstractChannel.java
@@ -130,8 +130,7 @@ public abstract class AbstractChannel
         gracefulFuture = new DefaultCloseFuture(discriminator, futureLock);
         localWindow = new Window(this, null, client, true);
         remoteWindow = new Window(this, null, client, false);
-        channelListenerProxy = EventListenerUtils.proxyWrapper(
-            ChannelListener.class, getClass().getClassLoader(), channelListeners);
+        channelListenerProxy = EventListenerUtils.proxyWrapper(ChannelListener.class, channelListeners);
         executor = executorService;
         addRequestHandlers(handlers);
     }

--- a/sshd-core/src/main/java/org/apache/sshd/common/forward/DefaultForwarderFactory.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/forward/DefaultForwarderFactory.java
@@ -51,7 +51,7 @@ public class DefaultForwarderFactory implements ForwardingFilterFactory, PortFor
     private final PortForwardingEventListener listenerProxy;
 
     public DefaultForwarderFactory() {
-        listenerProxy = EventListenerUtils.proxyWrapper(PortForwardingEventListener.class, getClass().getClassLoader(), listeners);
+        listenerProxy = EventListenerUtils.proxyWrapper(PortForwardingEventListener.class, listeners);
     }
 
     @Override

--- a/sshd-core/src/main/java/org/apache/sshd/common/forward/DefaultForwardingFilter.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/forward/DefaultForwardingFilter.java
@@ -117,7 +117,7 @@ public class DefaultForwardingFilter
     public DefaultForwardingFilter(ConnectionService service) {
         this.service = Objects.requireNonNull(service, "No connection service");
         this.sessionInstance = Objects.requireNonNull(service.getSession(), "No session");
-        this.listenerProxy = EventListenerUtils.proxyWrapper(PortForwardingEventListener.class, getClass().getClassLoader(), listeners);
+        this.listenerProxy = EventListenerUtils.proxyWrapper(PortForwardingEventListener.class, listeners);
     }
 
     @Override

--- a/sshd-core/src/main/java/org/apache/sshd/common/helpers/AbstractFactoryManager.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/helpers/AbstractFactoryManager.java
@@ -100,13 +100,12 @@ public abstract class AbstractFactoryManager extends AbstractKexFactoryManager i
     private IoServiceEventListener eventListener;
 
     protected AbstractFactoryManager() {
-        ClassLoader loader = getClass().getClassLoader();
         sessionListenerProxy =
-            EventListenerUtils.proxyWrapper(SessionListener.class, loader, sessionListeners);
+            EventListenerUtils.proxyWrapper(SessionListener.class, sessionListeners);
         channelListenerProxy =
-            EventListenerUtils.proxyWrapper(ChannelListener.class, loader, channelListeners);
+            EventListenerUtils.proxyWrapper(ChannelListener.class, channelListeners);
         tunnelListenerProxy =
-            EventListenerUtils.proxyWrapper(PortForwardingEventListener.class, loader, tunnelListeners);
+            EventListenerUtils.proxyWrapper(PortForwardingEventListener.class, tunnelListeners);
     }
 
     @Override

--- a/sshd-core/src/main/java/org/apache/sshd/common/session/AbstractConnectionServiceFactory.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/session/AbstractConnectionServiceFactory.java
@@ -36,7 +36,7 @@ public abstract class AbstractConnectionServiceFactory extends AbstractLoggingBe
     private final PortForwardingEventListener listenerProxy;
 
     protected AbstractConnectionServiceFactory() {
-        listenerProxy = EventListenerUtils.proxyWrapper(PortForwardingEventListener.class, getClass().getClassLoader(), listeners);
+        listenerProxy = EventListenerUtils.proxyWrapper(PortForwardingEventListener.class, listeners);
     }
 
     @Override

--- a/sshd-core/src/main/java/org/apache/sshd/common/session/helpers/AbstractConnectionService.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/session/helpers/AbstractConnectionService.java
@@ -120,8 +120,7 @@ public abstract class AbstractConnectionService
 
     protected AbstractConnectionService(AbstractSession session) {
         sessionInstance = Objects.requireNonNull(session, "No session");
-        listenerProxy = EventListenerUtils.proxyWrapper(
-            PortForwardingEventListener.class, getClass().getClassLoader(), listeners);
+        listenerProxy = EventListenerUtils.proxyWrapper(PortForwardingEventListener.class, listeners);
     }
 
     @Override

--- a/sshd-core/src/main/java/org/apache/sshd/common/session/helpers/AbstractSession.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/session/helpers/AbstractSession.java
@@ -238,13 +238,12 @@ public abstract class AbstractSession extends SessionHelper {
 
         refreshConfiguration();
 
-        ClassLoader loader = getClass().getClassLoader();
         sessionListenerProxy = EventListenerUtils.proxyWrapper(
-            SessionListener.class, loader, sessionListeners);
+            SessionListener.class, sessionListeners);
         channelListenerProxy = EventListenerUtils.proxyWrapper(
-            ChannelListener.class, loader, channelListeners);
+            ChannelListener.class, channelListeners);
         tunnelListenerProxy = EventListenerUtils.proxyWrapper(
-            PortForwardingEventListener.class, loader, tunnelListeners);
+            PortForwardingEventListener.class, tunnelListeners);
 
         try {
             signalSessionEstablished(ioSession);

--- a/sshd-scp/src/main/java/org/apache/sshd/client/scp/SimpleScpClientImpl.java
+++ b/sshd-scp/src/main/java/org/apache/sshd/client/scp/SimpleScpClientImpl.java
@@ -120,7 +120,7 @@ public class SimpleScpClientImpl extends AbstractLoggingBean implements SimpleSc
     }
 
     protected CloseableScpClient createScpClient(ClientSession session, ScpClient client) throws IOException {
-        ClassLoader loader = getClass().getClassLoader();
+        ClassLoader loader = CloseableScpClient.class.getClassLoader();
         Class<?>[] interfaces = {CloseableScpClient.class};
         return (CloseableScpClient) Proxy.newProxyInstance(loader, interfaces, (proxy, method, args) -> {
             String name = method.getName();

--- a/sshd-scp/src/main/java/org/apache/sshd/server/scp/ScpCommandFactory.java
+++ b/sshd-scp/src/main/java/org/apache/sshd/server/scp/ScpCommandFactory.java
@@ -110,8 +110,7 @@ public class ScpCommandFactory
 
     public ScpCommandFactory() {
         super(SCP_FACTORY_NAME);
-        listenerProxy = EventListenerUtils.proxyWrapper(
-            ScpTransferEventListener.class, getClass().getClassLoader(), listeners);
+        listenerProxy = EventListenerUtils.proxyWrapper(ScpTransferEventListener.class, listeners);
     }
 
     @Override
@@ -222,8 +221,7 @@ public class ScpCommandFactory
             ScpCommandFactory other = getClass().cast(super.clone());
             // clone the listeners set as well
             other.listeners = new CopyOnWriteArraySet<>(this.listeners);
-            other.listenerProxy = EventListenerUtils.proxyWrapper(
-                ScpTransferEventListener.class, getClass().getClassLoader(), other.listeners);
+            other.listenerProxy = EventListenerUtils.proxyWrapper(ScpTransferEventListener.class, other.listeners);
             return other;
         } catch (CloneNotSupportedException e) {
             throw new RuntimeException(e);    // un-expected...

--- a/sshd-sftp/src/main/java/org/apache/sshd/client/subsystem/sftp/impl/SimpleSftpClientImpl.java
+++ b/sshd-sftp/src/main/java/org/apache/sshd/client/subsystem/sftp/impl/SimpleSftpClientImpl.java
@@ -143,7 +143,7 @@ public class SimpleSftpClientImpl extends AbstractLoggingBean implements SimpleS
     }
 
     protected SftpClient createSftpClient(ClientSession session, SftpClient client) throws IOException {
-        ClassLoader loader = getClass().getClassLoader();
+        ClassLoader loader = SftpClient.class.getClassLoader();
         Class<?>[] interfaces = {SftpClient.class};
         return (SftpClient) Proxy.newProxyInstance(loader, interfaces, (proxy, method, args) -> {
             Throwable err = null;

--- a/sshd-sftp/src/main/java/org/apache/sshd/server/subsystem/sftp/AbstractSftpEventListenerManager.java
+++ b/sshd-sftp/src/main/java/org/apache/sshd/server/subsystem/sftp/AbstractSftpEventListenerManager.java
@@ -32,7 +32,7 @@ public abstract class AbstractSftpEventListenerManager implements SftpEventListe
     private final SftpEventListener sftpEventListenerProxy;
 
     protected AbstractSftpEventListenerManager() {
-        sftpEventListenerProxy = EventListenerUtils.proxyWrapper(SftpEventListener.class, getClass().getClassLoader(), sftpEventListeners);
+        sftpEventListenerProxy = EventListenerUtils.proxyWrapper(SftpEventListener.class, sftpEventListeners);
     }
 
     public Collection<SftpEventListener> getRegisteredListeners() {

--- a/sshd-sftp/src/main/java/org/apache/sshd/server/subsystem/sftp/AbstractSftpSubsystemHelper.java
+++ b/sshd-sftp/src/main/java/org/apache/sshd/server/subsystem/sftp/AbstractSftpSubsystemHelper.java
@@ -211,7 +211,7 @@ public abstract class AbstractSftpSubsystemHelper
         fileSystemAccessor =
             Objects.requireNonNull(accessor, "No file system accessor");
         sftpEventListenerProxy =
-            EventListenerUtils.proxyWrapper(SftpEventListener.class, getClass().getClassLoader(), sftpEventListeners);
+            EventListenerUtils.proxyWrapper(SftpEventListener.class, sftpEventListeners);
         errorStatusDataHandler =
             Objects.requireNonNull(handler, "No error status data handler");
     }


### PR DESCRIPTION
AbstractFactoryManager cannot make assumptions about the nature of the classloader returned by getClass().getClassLoader(). Use AbstractFactoryManager.class.getClassLoader() for loading proxies.