### PR TITLE
Fix incrementing the invocation_counter part of the IV.

### DIFF
--- a/sshd-common/src/main/java/org/apache/sshd/common/cipher/BaseGCMCipher.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/cipher/BaseGCMCipher.java
@@ -90,7 +90,7 @@ public class BaseGCMCipher extends BaseCipher {
         protected void incrementCounter() {
             int off = iv.length - Long.BYTES;
             long counter = BufferUtils.getLong(iv, off, Long.BYTES);
-            BufferUtils.putLong(Math.addExact(counter, 1L), iv, off, Long.BYTES);
+            BufferUtils.putLong(counter + 1L, iv, off, Long.BYTES);
         }
 
         @Override


### PR DESCRIPTION
Since the invocation_counter part of the IV is treated as a uint64,
guarding against overflow by using Math.addExact() would incorrectly
throw an ArithmeticException when it hits Long.MAX_VALUE.