### PR TITLE
[SSHD-704] Add support for RFC 8731

### DIFF
--- a/sshd-common/src/main/java/org/apache/sshd/common/util/buffer/BufferUtils.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/util/buffer/BufferUtils.java
@@ -444,7 +444,7 @@ public final class BufferUtils {
         }
 
         if ((mpInt[0] & 0x80) != 0) {
-            return new BigInteger(0, mpInt);
+            return new BigInteger(1, mpInt);
         } else {
             return new BigInteger(mpInt);
         }

--- a/sshd-core/src/main/java/org/apache/sshd/client/kex/DHGClient.java
+++ b/sshd-core/src/main/java/org/apache/sshd/client/kex/DHGClient.java
@@ -102,7 +102,7 @@ public class DHGClient extends AbstractDHClientKeyExchange {
             log.debug("init({})[{}] Send SSH_MSG_KEXDH_INIT", this, s);
         }
         Buffer buffer = s.createBuffer(SshConstants.SSH_MSG_KEXDH_INIT, e.length + Integer.SIZE);
-        buffer.putMPInt(e);
+        dh.putE(buffer, e);
 
         s.writePacket(buffer);
     }
@@ -167,8 +167,8 @@ public class DHGClient extends AbstractDHClientKeyExchange {
         buffer.putBytes(i_c);
         buffer.putBytes(i_s);
         buffer.putBytes(k_s);
-        buffer.putMPInt(getE());
-        buffer.putMPInt(f);
+        dh.putE(buffer, getE());
+        dh.putF(buffer, f);
         buffer.putMPInt(k);
         hash.update(buffer.array(), 0, buffer.available());
         h = hash.digest();

--- a/sshd-core/src/main/java/org/apache/sshd/common/BaseBuilder.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/BaseBuilder.java
@@ -87,6 +87,9 @@ public class BaseBuilder<T extends AbstractFactoryManager, S extends BaseBuilder
      */
     public static final List<BuiltinDHFactories> DEFAULT_KEX_PREFERENCE = Collections.unmodifiableList(
             Arrays.asList(
+                    BuiltinDHFactories.curve25519,
+                    BuiltinDHFactories.curve25519_libssh,
+                    BuiltinDHFactories.curve448,
                     BuiltinDHFactories.ecdhp521,
                     BuiltinDHFactories.ecdhp384,
                     BuiltinDHFactories.ecdhp256,

--- a/sshd-core/src/main/java/org/apache/sshd/common/kex/AbstractDH.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/kex/AbstractDH.java
@@ -22,6 +22,7 @@ import javax.crypto.KeyAgreement;
 
 import org.apache.sshd.common.digest.Digest;
 import org.apache.sshd.common.util.NumberUtils;
+import org.apache.sshd.common.util.buffer.Buffer;
 
 /**
  * Base class for the Diffie-Hellman key agreement.
@@ -61,6 +62,16 @@ public abstract class AbstractDH {
         }
 
         return e_array;
+    }
+
+    public void putE(Buffer buffer, byte[] e) {
+        // RFC 4253, section 8: e and f are encoded as mpints.
+        buffer.putMPInt(e);
+    }
+
+    public void putF(Buffer buffer, byte[] f) {
+        // RFC 4253, section 8: e and f are encoded as mpints.
+        buffer.putMPInt(f);
     }
 
     public boolean isSharedSecretAvailable() {

--- a/sshd-core/src/main/java/org/apache/sshd/common/kex/BuiltinDHFactories.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/kex/BuiltinDHFactories.java
@@ -242,6 +242,54 @@ public enum BuiltinDHFactories implements DHFactory {
         public boolean isSupported() {
             return ECCurves.nistp521.isSupported();
         }
+    },
+    /**
+     * @see <a href="https://www.rfc-editor.org/info/rfc8731">RFC 8731</a>
+     */
+    curve25519(Constants.CURVE25519_SHA256) {
+        @Override
+        public XDH create(Object... params) throws Exception {
+            if (!GenericUtils.isEmpty(params)) {
+                throw new IllegalArgumentException("No accepted parameters for " + getName());
+            }
+            return new XDH(MontgomeryCurve.x25519);
+        }
+
+        @Override
+        public boolean isSupported() {
+            return MontgomeryCurve.x25519.isSupported();
+        }
+    },
+    curve25519_libssh(Constants.CURVE25519_SHA256_LIBSSH) {
+        @Override
+        public XDH create(Object... params) throws Exception {
+            if (!GenericUtils.isEmpty(params)) {
+                throw new IllegalArgumentException("No accepted parameters for " + getName());
+            }
+            return new XDH(MontgomeryCurve.x25519);
+        }
+
+        @Override
+        public boolean isSupported() {
+            return MontgomeryCurve.x25519.isSupported();
+        }
+    },
+    /**
+     * @see <a href="https://www.rfc-editor.org/info/rfc8731">RFC 8731</a>
+     */
+    curve448(Constants.CURVE448_SHA512) {
+        @Override
+        public XDH create(Object... params) throws Exception {
+            if (!GenericUtils.isEmpty(params)) {
+                throw new IllegalArgumentException("No accepted parameters for " + getName());
+            }
+            return new XDH(MontgomeryCurve.x448);
+        }
+
+        @Override
+        public boolean isSupported() {
+            return MontgomeryCurve.x448.isSupported();
+        }
     };
 
     public static final Set<BuiltinDHFactories> VALUES = Collections.unmodifiableSet(EnumSet.allOf(BuiltinDHFactories.class));
@@ -417,6 +465,9 @@ public enum BuiltinDHFactories implements DHFactory {
         public static final String ECDH_SHA2_NISTP256 = "ecdh-sha2-nistp256";
         public static final String ECDH_SHA2_NISTP384 = "ecdh-sha2-nistp384";
         public static final String ECDH_SHA2_NISTP521 = "ecdh-sha2-nistp521";
+        public static final String CURVE25519_SHA256 = "curve25519-sha256";
+        public static final String CURVE25519_SHA256_LIBSSH = "curve25519-sha256@libssh.org";
+        public static final String CURVE448_SHA512 = "curve448-sha512";
 
         private Constants() {
             throw new UnsupportedOperationException("No instance allowed");

--- a/sshd-core/src/main/java/org/apache/sshd/common/kex/ECDH.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/kex/ECDH.java
@@ -32,6 +32,7 @@ import org.apache.sshd.common.cipher.ECCurves;
 import org.apache.sshd.common.config.keys.KeyUtils;
 import org.apache.sshd.common.digest.Digest;
 import org.apache.sshd.common.util.ValidateUtils;
+import org.apache.sshd.common.util.buffer.Buffer;
 import org.apache.sshd.common.util.security.SecurityUtils;
 
 /**
@@ -98,6 +99,20 @@ public class ECDH extends AbstractDH {
         Objects.requireNonNull(params, "No ECParameterSpec(s)");
         Objects.requireNonNull(f, "No 'f' value specified");
         this.f = ECCurves.octetStringToEcPoint(f);
+    }
+
+    @Override
+    public void putE(Buffer buffer, byte[] e) {
+        // RFC 5656, section 4: Q_C and Q_S, which take the place of e and f, are written as "strings", i.e., byte
+        // arrays.
+        buffer.putBytes(e);
+    }
+
+    @Override
+    public void putF(Buffer buffer, byte[] f) {
+        // RFC 5656, section 4: Q_C and Q_S, which take the place of e and f, are written as "strings", i.e., byte
+        // arrays.
+        buffer.putBytes(f);
     }
 
     @Override

--- a/sshd-core/src/main/java/org/apache/sshd/common/kex/MontgomeryCurve.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/kex/MontgomeryCurve.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sshd.common.kex;
+
+import java.io.IOException;
+import java.io.StreamCorruptedException;
+import java.io.UncheckedIOException;
+import java.security.GeneralSecurityException;
+import java.security.InvalidKeyException;
+import java.security.KeyFactory;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.PublicKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.X509EncodedKeySpec;
+
+import javax.crypto.KeyAgreement;
+
+import org.apache.sshd.common.OptionalFeature;
+import org.apache.sshd.common.digest.BuiltinDigests;
+import org.apache.sshd.common.digest.Digest;
+import org.apache.sshd.common.digest.DigestFactory;
+import org.apache.sshd.common.keyprovider.KeySizeIndicator;
+import org.apache.sshd.common.util.io.der.ASN1Object;
+import org.apache.sshd.common.util.io.der.DERParser;
+import org.apache.sshd.common.util.security.SecurityUtils;
+
+/**
+ * Provides implementation details for Montgomery curves and their key exchange algorithms Curve25519/X25519 and
+ * Curve448/X448 specified in RFC 7748 and RFC 8731. Montgomery curves provide improved security and flexibility over
+ * Weierstrass curves used in ECDH.
+ *
+ * @see <a href="https://www.rfc-editor.org/info/rfc7748">RFC 7748</a>
+ * @see <a href="https://www.rfc-editor.org/info/rfc8731">RFC 8731</a>
+ */
+public enum MontgomeryCurve implements KeySizeIndicator, OptionalFeature {
+
+    /**
+     * X25519 uses Curve25519 and SHA-256 with a 32-byte key size.
+     */
+    x25519("X25519", 32, BuiltinDigests.sha256,
+           new byte[] { 0x30, 0x2a, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x6e, 0x03, 0x21, 0x00 }),
+    /**
+     * X448 uses Curve448 and SHA-512 with a 56-byte key size.
+     */
+    x448("X448", 56, BuiltinDigests.sha512,
+         new byte[] { 0x30, 0x42, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x6f, 0x03, 0x39, 0x00 });
+
+    private final String algorithm;
+    private final int keySize;
+    private final boolean supported;
+    private final DigestFactory digestFactory;
+    private final KeyPairGenerator keyPairGenerator;
+    private final KeyFactory keyFactory;
+    private final byte[] encodedPublicKeyPrefix;
+    private final int encodedKeySize;
+
+    MontgomeryCurve(String algorithm, int keySize, DigestFactory digestFactory, byte[] encodedPublicKeyPrefix) {
+        this.algorithm = algorithm;
+        this.keySize = keySize;
+        this.digestFactory = digestFactory;
+        this.encodedPublicKeyPrefix = encodedPublicKeyPrefix;
+        encodedKeySize = keySize + encodedPublicKeyPrefix.length;
+        boolean supported;
+        KeyPairGenerator generator = null;
+        KeyFactory factory = null;
+        try {
+            SecurityUtils.getKeyAgreement(algorithm);
+            generator = SecurityUtils.getKeyPairGenerator(algorithm);
+            factory = SecurityUtils.getKeyFactory(algorithm);
+            supported = true;
+        } catch (GeneralSecurityException ignored) {
+            supported = false;
+        }
+        this.supported = supported && digestFactory.isSupported();
+        keyPairGenerator = generator;
+        keyFactory = factory;
+    }
+
+    public String getAlgorithm() {
+        return algorithm;
+    }
+
+    @Override
+    public int getKeySize() {
+        return keySize;
+    }
+
+    @Override
+    public boolean isSupported() {
+        return supported;
+    }
+
+    public KeyAgreement createKeyAgreement() throws GeneralSecurityException {
+        return SecurityUtils.getKeyAgreement(algorithm);
+    }
+
+    public Digest createDigest() {
+        return digestFactory.create();
+    }
+
+    public KeyPair generateKeyPair() {
+        return keyPairGenerator.generateKeyPair();
+    }
+
+    public byte[] encode(PublicKey key) throws InvalidKeyException {
+        return extractSubjectPublicKey(key.getEncoded());
+    }
+
+    public PublicKey decode(byte[] key) throws InvalidKeySpecException {
+        if (key.length < getKeySize()) {
+            throw new InvalidKeySpecException("Provided key is too small for " + getAlgorithm());
+        }
+        // ideally, we'd just parse the key as a BigInteger and then create a XECPublicKeySpec in Java 11
+        // BouncyCastle supports a separate API, so we can use the generic X.509 encoding scheme supported by both
+        byte[] encoded = new byte[encodedKeySize];
+        System.arraycopy(encodedPublicKeyPrefix, 0, encoded, 0, encodedPublicKeyPrefix.length);
+        // note that key can be either the raw key data or it may be prefixed by a padding byte and the key length.
+        // these two bytes are already present as the last two bytes in encodedPublicKeyPrefix, thus there is no harm
+        // in potentially overwriting it
+        System.arraycopy(key, 0, encoded, encodedKeySize - key.length, key.length);
+        return keyFactory.generatePublic(new X509EncodedKeySpec(encoded));
+    }
+
+    private static byte[] extractSubjectPublicKey(byte[] subjectPublicKeyInfo) throws InvalidKeyException {
+        try {
+            //  SubjectPublicKeyInfo ::= SEQUENCE {
+            //   algorithm AlgorithmIdentifier,
+            //   subjectPublicKey BIT STRING }
+            ASN1Object spki = new DERParser(subjectPublicKeyInfo).readObject();
+            DERParser parser = spki.createParser();
+            parser.readObject();
+            return parser.readObject().getValue();
+        } catch (StreamCorruptedException e) {
+            throw new InvalidKeyException(e);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+}

--- a/sshd-core/src/main/java/org/apache/sshd/common/kex/XDH.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/kex/XDH.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sshd.common.kex;
+
+import java.security.KeyPair;
+import java.util.Objects;
+
+import org.apache.sshd.common.digest.Digest;
+
+/**
+ * Provides Diffie-Hellman SSH key exchange algorithms for the Montgomery curves specified in RFC 8731.
+ *
+ * @see <a href="https://www.rfc-editor.org/info/rfc8731">RFC 8731</a>
+ */
+public class XDH extends AbstractDH {
+
+    protected MontgomeryCurve curve;
+    protected byte[] f;
+
+    public XDH(MontgomeryCurve curve) throws Exception {
+        this.curve = Objects.requireNonNull(curve, "No MontgomeryCurve provided");
+        myKeyAgree = curve.createKeyAgreement();
+    }
+
+    @Override
+    protected byte[] calculateE() throws Exception {
+        KeyPair keyPair = curve.generateKeyPair();
+        myKeyAgree.init(keyPair.getPrivate());
+        return curve.encode(keyPair.getPublic());
+    }
+
+    @Override
+    public void setF(byte[] f) {
+        this.f = Objects.requireNonNull(f, "No 'f' value provided");
+    }
+
+    @Override
+    protected byte[] calculateK() throws Exception {
+        Objects.requireNonNull(f, "Missing 'f' value");
+        myKeyAgree.doPhase(curve.decode(f), true);
+        return stripLeadingZeroes(myKeyAgree.generateSecret());
+    }
+
+    @Override
+    public Digest getHash() throws Exception {
+        return curve.createDigest();
+    }
+}

--- a/sshd-core/src/main/java/org/apache/sshd/common/kex/XDH.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/kex/XDH.java
@@ -23,6 +23,7 @@ import java.security.KeyPair;
 import java.util.Objects;
 
 import org.apache.sshd.common.digest.Digest;
+import org.apache.sshd.common.util.buffer.Buffer;
 
 /**
  * Provides Diffie-Hellman SSH key exchange algorithms for the Montgomery curves specified in RFC 8731.
@@ -49,6 +50,24 @@ public class XDH extends AbstractDH {
     @Override
     public void setF(byte[] f) {
         this.f = Objects.requireNonNull(f, "No 'f' value provided");
+    }
+
+    @Override
+    public void putE(Buffer buffer, byte[] e) {
+        // RFC 5656, section 4: Q_C and Q_S, which take the place of e and f, are written as "strings", i.e., byte
+        // arrays.
+        // RFC 8731, section 3: Public ephemeral keys are encoded for transmission as standard SSH strings. (Q_C and Q_S
+        // are the client's and server's ephemeral public keys.)
+        buffer.putBytes(e);
+    }
+
+    @Override
+    public void putF(Buffer buffer, byte[] f) {
+        // RFC 5656, section 4: Q_C and Q_S, which take the place of e and f, are written as "strings", i.e., byte
+        // arrays.
+        // RFC 8731, section 3: Public ephemeral keys are encoded for transmission as standard SSH strings. (Q_C and Q_S
+        // are the client's and server's ephemeral public keys.)
+        buffer.putBytes(f);
     }
 
     @Override

--- a/sshd-core/src/main/java/org/apache/sshd/server/kex/DHGServer.java
+++ b/sshd-core/src/main/java/org/apache/sshd/server/kex/DHGServer.java
@@ -121,9 +121,9 @@ public class DHGServer extends AbstractDHServerKeyExchange {
         buffer.putBytes(i_c);
         buffer.putBytes(i_s);
         buffer.putBytes(k_s);
-        buffer.putMPInt(e);
+        dh.putE(buffer, e);
         byte[] f = getF();
-        buffer.putMPInt(f);
+        dh.putF(buffer, f);
         buffer.putMPInt(k);
 
         hash.update(buffer.array(), 0, buffer.available());
@@ -149,7 +149,7 @@ public class DHGServer extends AbstractDHServerKeyExchange {
 
         buffer = session.prepareBuffer(SshConstants.SSH_MSG_KEXDH_REPLY, BufferUtils.clear(buffer));
         buffer.putBytes(k_s);
-        buffer.putBytes(f);
+        dh.putF(buffer, f);
         buffer.putBytes(sigH);
         session.writePacket(buffer);
         return true;

--- a/sshd-core/src/test/java/org/apache/sshd/DefaultSetupTestSupport.java
+++ b/sshd-core/src/test/java/org/apache/sshd/DefaultSetupTestSupport.java
@@ -75,7 +75,8 @@ public abstract class DefaultSetupTestSupport<M extends AbstractFactoryManager> 
     @Test
     public void testDefaultKeyExchangeList() {
         assertSameNamedResourceListNames(KeyExchange.class.getSimpleName(),
-                BaseBuilder.DEFAULT_KEX_PREFERENCE, factory.getKeyExchangeFactories());
+                BaseBuilder.DEFAULT_KEX_PREFERENCE.stream().filter(dh -> dh.isSupported()).collect(Collectors.toList()),
+                factory.getKeyExchangeFactories());
     }
 
     @Test   // SSHD-1004


### PR DESCRIPTION
This adds support for curve25519-sha256 (and its libssh version) along with curve448-sha512. These key exchange methods are supported for both Java 11 and Bouncy Castle.

https://issues.apache.org/jira/browse/SSHD-704
https://tools.ietf.org/html/rfc8731
https://tools.ietf.org/html/rfc7748 (for the X25519/X448 algorithms)