### PR TITLE
Added support for sftp client posix rename

### DIFF
--- a/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/extensions/BuiltinSftpClientExtensions.java
+++ b/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/extensions/BuiltinSftpClientExtensions.java
@@ -35,15 +35,18 @@ import org.apache.sshd.sftp.client.extensions.helpers.MD5FileExtensionImpl;
 import org.apache.sshd.sftp.client.extensions.helpers.MD5HandleExtensionImpl;
 import org.apache.sshd.sftp.client.extensions.helpers.SpaceAvailableExtensionImpl;
 import org.apache.sshd.sftp.client.extensions.openssh.OpenSSHFsyncExtension;
+import org.apache.sshd.sftp.client.extensions.openssh.OpenSSHPosixRenameExtension;
 import org.apache.sshd.sftp.client.extensions.openssh.OpenSSHStatHandleExtension;
 import org.apache.sshd.sftp.client.extensions.openssh.OpenSSHStatPathExtension;
 import org.apache.sshd.sftp.client.extensions.openssh.helpers.OpenSSHFsyncExtensionImpl;
+import org.apache.sshd.sftp.client.extensions.openssh.helpers.OpenSSHPosixRenameExtensionImpl;
 import org.apache.sshd.sftp.client.extensions.openssh.helpers.OpenSSHStatHandleExtensionImpl;
 import org.apache.sshd.sftp.client.extensions.openssh.helpers.OpenSSHStatPathExtensionImpl;
 import org.apache.sshd.sftp.common.SftpConstants;
 import org.apache.sshd.sftp.common.extensions.ParserUtils;
 import org.apache.sshd.sftp.common.extensions.openssh.FstatVfsExtensionParser;
 import org.apache.sshd.sftp.common.extensions.openssh.FsyncExtensionParser;
+import org.apache.sshd.sftp.common.extensions.openssh.PosixRenameExtensionParser;
 import org.apache.sshd.sftp.common.extensions.openssh.StatVfsExtensionParser;
 
 /**
@@ -118,6 +121,13 @@ public enum BuiltinSftpClientExtensions implements SftpClientExtensionFactory {
         public OpenSSHStatPathExtension create(
                 SftpClient client, RawSftpClient raw, Map<String, byte[]> extensions, Map<String, ?> parsed) {
             return new OpenSSHStatPathExtensionImpl(client, raw, extensions);
+        }
+    },
+    OPENSSH_POSIX_RENAME(PosixRenameExtensionParser.NAME, OpenSSHPosixRenameExtension.class) {
+        @Override // co-variant return
+        public OpenSSHPosixRenameExtension create(
+                SftpClient client, RawSftpClient raw, Map<String, byte[]> extensions, Map<String, ?> parsed) {
+            return new OpenSSHPosixRenameExtensionImpl(client, raw, extensions);
         }
     };
 

--- a/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/extensions/openssh/OpenSSHPosixRenameExtension.java
+++ b/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/extensions/openssh/OpenSSHPosixRenameExtension.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sshd.sftp.client.extensions.openssh;
+
+import java.io.IOException;
+
+import org.apache.sshd.sftp.client.extensions.SftpClientExtension;
+
+/**
+ * Implements the &quot;posix-rename@openssh.com&quot; extension
+ */
+public interface OpenSSHPosixRenameExtension extends SftpClientExtension {
+    void posixRename(String oldPath, String newPath) throws IOException;
+}

--- a/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/extensions/openssh/helpers/OpenSSHPosixRenameExtensionImpl.java
+++ b/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/extensions/openssh/helpers/OpenSSHPosixRenameExtensionImpl.java
@@ -39,7 +39,7 @@ public class OpenSSHPosixRenameExtensionImpl extends AbstractSftpClientExtension
 
     @Override
     public void posixRename(String oldPath, String newPath) throws IOException {
-        Buffer buffer = getCommandBuffer(Integer.BYTES + ((CharSequence) oldPath).length() + ((CharSequence) newPath).length());
+        Buffer buffer = getCommandBuffer(Integer.BYTES + oldPath.length() + newPath.length());
         putTarget(buffer, oldPath);
         putTarget(buffer, newPath);
 

--- a/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/extensions/openssh/helpers/OpenSSHPosixRenameExtensionImpl.java
+++ b/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/extensions/openssh/helpers/OpenSSHPosixRenameExtensionImpl.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sshd.sftp.client.extensions.openssh.helpers;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.apache.sshd.common.util.buffer.Buffer;
+import org.apache.sshd.sftp.client.RawSftpClient;
+import org.apache.sshd.sftp.client.SftpClient;
+import org.apache.sshd.sftp.client.extensions.helpers.AbstractSftpClientExtension;
+import org.apache.sshd.sftp.client.extensions.openssh.OpenSSHPosixRenameExtension;
+import org.apache.sshd.sftp.common.extensions.openssh.PosixRenameExtensionParser;
+
+/**
+ * @author <a href="mailto:chr.joedal@gmail.com">Christian Schou Jødal</a>
+ */
+public class OpenSSHPosixRenameExtensionImpl extends AbstractSftpClientExtension implements OpenSSHPosixRenameExtension {
+    public OpenSSHPosixRenameExtensionImpl(SftpClient client, RawSftpClient raw, Map<String, byte[]> extensions) {
+        super(PosixRenameExtensionParser.NAME, client, raw, extensions);
+    }
+
+    @Override
+    public void posixRename(String oldPath, String newPath) throws IOException {
+        Buffer buffer = getCommandBuffer(Integer.BYTES + ((CharSequence) oldPath).length() + ((CharSequence) newPath).length());
+        putTarget(buffer, oldPath);
+        putTarget(buffer, newPath);
+
+        checkExtendedReplyBuffer(receive(sendExtendedCommand(buffer)));
+    }
+}


### PR DESCRIPTION
The read-me file for SFTP states, that posix-rename is supported, but the posix rename extension for the sftp client was newer made.
I have made the small implementation, supporting the posix-rename command for the sftp client.