### PR TITLE
[SSHD-1147] SftpInputStreamAsync: get file size before SSH_FXP_OPEN

### DIFF
--- a/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/impl/SftpInputStreamAsync.java
+++ b/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/impl/SftpInputStreamAsync.java
@@ -63,9 +63,9 @@ public class SftpInputStreamAsync extends InputStreamWithChannel {
         this.log = LoggerFactory.getLogger(getClass());
         this.clientInstance = Objects.requireNonNull(client, "No SFTP client instance");
         this.path = path;
+        this.fileSize = client.stat(path).getSize();
         this.handle = client.open(path, mode);
         this.bufferSize = bufferSize;
-        this.fileSize = client.stat(handle).getSize();
     }
 
     public SftpInputStreamAsync(AbstractSftpClient client, int bufferSize, long clientOffset, long fileSize,


### PR DESCRIPTION
IBM's Sterling B2B SFTP connector may limit some files to be downloaded
only once. The mechanism they use assumes that once a file has been
opened, it'll be read and closed without any other SFTP requests being
made on the same handle in between.

Get the file size via SSH_FXP_STAT before opening the file instead of
using SSH_FXP_FSTAT on the handle obtained from opening the file. That
way it should be possible to download such files from such an off-spec
SFTP server.