### PR TITLE
[SSHD-1158] Don't send channel EOF after having received channel CLOSE

### DIFF
--- a/sshd-core/src/main/java/org/apache/sshd/common/channel/AbstractChannel.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/channel/AbstractChannel.java
@@ -547,7 +547,7 @@ public abstract class AbstractChannel extends AbstractInnerCloseable implements 
         }
 
         try {
-            if (!isEofSent()) {
+            if (!eofSent.getAndSet(true)) {
                 if (debugEnabled) {
                     log.debug("handleClose({}) prevent sending EOF", this);
                 }
@@ -683,7 +683,7 @@ public abstract class AbstractChannel extends AbstractInnerCloseable implements 
     @Override
     protected void preClose() {
         if (!isEofSent()) {
-            log.debug("close({}) prevent sending EOF", this);
+            log.debug("close({}) no EOF sent", this);
         }
 
         try {


### PR DESCRIPTION
When the peer closes the channel, just reply with a CLOSE message.
Do not send an EOF before the CLOSE. See RFC 4254, section 5.3.[1]

[1] https://tools.ietf.org/html/rfc4254#section-5.3