### PR TITLE
[SSHD-1163] Identify server key type by negotiation kex result parameters

### DIFF
--- a/sshd-core/src/main/java/org/apache/sshd/client/kex/DHGEXClient.java
+++ b/sshd-core/src/main/java/org/apache/sshd/client/kex/DHGEXClient.java
@@ -27,9 +27,9 @@ import org.apache.sshd.client.session.AbstractClientSession;
 import org.apache.sshd.common.NamedFactory;
 import org.apache.sshd.common.SshConstants;
 import org.apache.sshd.common.SshException;
-import org.apache.sshd.common.config.keys.KeyUtils;
 import org.apache.sshd.common.kex.AbstractDH;
 import org.apache.sshd.common.kex.DHFactory;
+import org.apache.sshd.common.kex.KexProposalOption;
 import org.apache.sshd.common.kex.KeyExchange;
 import org.apache.sshd.common.kex.KeyExchangeFactory;
 import org.apache.sshd.common.session.Session;
@@ -208,7 +208,7 @@ public class DHGEXClient extends AbstractDHClientKeyExchange {
             buffer = new ByteArrayBuffer(k_s);
             PublicKey serverKey = buffer.getRawPublicKey();
 
-            String keyAlg = KeyUtils.getKeyType(serverKey);
+            String keyAlg = session.getNegotiatedKexParameter(KexProposalOption.SERVERKEYS);
             if (GenericUtils.isEmpty(keyAlg)) {
                 throw new SshException(
                         "Unsupported server key type: " + serverKey.getAlgorithm()


### PR DESCRIPTION
Wrong server key type algorithm choose (in case of use rsa-sha2-256 and rsa-sha2-512 always identify like ssh-rsa) in case of usage DHFactories with group exchange.