### PR TITLE
[SSHD-1164] - fixed parsing of sshd_config "Host" lines to collapse spaces

### DIFF
--- a/sshd-common/src/main/java/org/apache/sshd/client/config/hosts/HostConfigEntry.java
+++ b/sshd-common/src/main/java/org/apache/sshd/client/config/hosts/HostConfigEntry.java
@@ -898,6 +898,8 @@ public class HostConfigEntry extends HostPatternsHolder implements MutableUserHo
             List<String> valsList = parseConfigValue(value);
 
             if (HOST_CONFIG_PROP.equalsIgnoreCase(key)) {
+                // parseConfigValue may result in entries that are empty strings if > 1 space is used between values
+                valsList = GenericUtils.filterToNotBlank(valsList);
                 if (GenericUtils.isEmpty(valsList)) {
                     throw new StreamCorruptedException("Missing host pattern(s) at line " + lineNumber + ": " + line);
                 }

--- a/sshd-common/src/main/java/org/apache/sshd/common/util/GenericUtils.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/util/GenericUtils.java
@@ -196,6 +196,49 @@ public final class GenericUtils {
         return !isEmpty(cs);
     }
 
+    /**
+     * <p>
+     * Checks if a CharSequence is empty (""), null or whitespace only.
+     * </p>
+     *
+     * <p>
+     * Whitespace is defined by {@link Character#isWhitespace(char)}.
+     * </p>
+     *
+     * <pre>
+     * StringUtils.isBlank(null)      = true
+     * StringUtils.isBlank("")        = true
+     * StringUtils.isBlank(" ")       = true
+     * StringUtils.isBlank("bob")     = false
+     * StringUtils.isBlank("  bob  ") = false
+     * </pre>
+     *
+     * @param  cs the CharSequence to check, may be null
+     * @return    {@code true} if the CharSequence is null, empty or whitespace only
+     * @since     2.0
+     * @since     3.0 Changed signature from isBlank(String) to isBlank(CharSequence)
+     */
+    public static boolean isBlank(final CharSequence cs) {
+        int strLen = cs != null ? cs.length() : 0;
+        if (cs == null || strLen == 0) {
+            return true;
+        }
+        for (int i = 0; i < strLen; i++) {
+            if (!Character.isWhitespace(cs.charAt(i))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public static boolean isNotBlank(final CharSequence cs) {
+        return !isBlank(cs);
+    }
+
+    public static List<String> filterToNotBlank(final List<String> values) {
+        return values.stream().filter(GenericUtils::isNotBlank).collect(Collectors.toList());
+    }
+
     public static int indexOf(CharSequence cs, char c) {
         int len = length(cs);
         for (int pos = 0; pos < len; pos++) {

--- a/sshd-common/src/test/java/org/apache/sshd/common/util/GenericUtilsTest.java
+++ b/sshd-common/src/test/java/org/apache/sshd/common/util/GenericUtilsTest.java
@@ -42,6 +42,32 @@ public class GenericUtilsTest extends JUnitTestSupport {
     }
 
     @Test
+    public void testIsBlank() {
+        assertTrue(GenericUtils.isBlank(null));
+        assertTrue(GenericUtils.isBlank(""));
+        assertTrue(GenericUtils.isBlank(" "));
+        assertFalse(GenericUtils.isBlank("a"));
+        assertFalse(GenericUtils.isBlank(" a "));
+    }
+
+    @Test
+    public void testFilterToNotBlank() {
+        assertEquals(Collections.emptyList(), GenericUtils.filterToNotBlank(Arrays.asList((String) null)));
+        assertEquals(Collections.emptyList(), GenericUtils.filterToNotBlank(Arrays.asList("")));
+        assertEquals(Collections.emptyList(), GenericUtils.filterToNotBlank(Arrays.asList(" ")));
+        assertEquals(Arrays.asList("a"), GenericUtils.filterToNotBlank(Arrays.asList("a")));
+        assertEquals(Arrays.asList("a", "b"), GenericUtils.filterToNotBlank(Arrays.asList("a", "b")));
+        assertEquals(Arrays.asList("a"), GenericUtils.filterToNotBlank(Arrays.asList("a", "")));
+        assertEquals(Arrays.asList("a"), GenericUtils.filterToNotBlank(Arrays.asList("a", " ")));
+        assertEquals(Arrays.asList("a"), GenericUtils.filterToNotBlank(Arrays.asList("a", "  ")));
+        assertEquals(Arrays.asList("a"), GenericUtils.filterToNotBlank(Arrays.asList("a", null)));
+        assertEquals(Arrays.asList("a", "b"), GenericUtils.filterToNotBlank(Arrays.asList("a", null, "b")));
+        assertEquals(Arrays.asList("a", "b"), GenericUtils.filterToNotBlank(Arrays.asList("a", "", "b")));
+        assertEquals(Arrays.asList("a", "b"), GenericUtils.filterToNotBlank(Arrays.asList("a", " ", "b")));
+        assertEquals(Arrays.asList("a", "b"), GenericUtils.filterToNotBlank(Arrays.asList("a", "  ", "b")));
+    }
+
+    @Test
     public void testSplitAndJoin() {
         List<String> expected = Collections.unmodifiableList(
                 Arrays.asList(

--- a/sshd-common/src/test/resources/org/apache/sshd/client/config/hosts/testReadMultipleHostPatterns.config.txt
+++ b/sshd-common/src/test/resources/org/apache/sshd/client/config/hosts/testReadMultipleHostPatterns.config.txt
@@ -1,5 +1,5 @@
 # Same configuration duplicated in multiple configuration entries
-Host *.github.com *.apache.org 10.*.*.*
+Host *.github.com *.apache.org  10.*.*.*
     User mina-sshd
     Port 443
     HostName 7.3.6.5


### PR DESCRIPTION
The `ssh_config` man page defines the format for `Host` a bit vaguely as:

```
If more than one pattern is provided, they should be separated by whitespace.
```

When running the unit test suite that read my `~/.ssh/config` file, there was a `Host` line which had two spaces between some values which failed parsing in MINA, but doesn't cause any problem for OpenSSH.

This PR simply makes the parsing of `Host` directive values more lenient by removing blank strings from the split values