### PR TITLE
[SSHD-1182] skip() doesn't work properly in SftpInputStreamAsync

### DIFF
--- a/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/impl/SftpInputStreamAsync.java
+++ b/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/impl/SftpInputStreamAsync.java
@@ -207,7 +207,7 @@ public class SftpInputStreamAsync extends InputStreamWithChannel implements Sftp
             if (log.isDebugEnabled()) {
                 log.debug("skip({}) virtual skip of {} bytes", this, n);
             }
-            clientOffset = n;
+            requestOffset = clientOffset = n;
             return n;
         }
 

--- a/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/impl/SftpInputStreamAsync.java
+++ b/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/impl/SftpInputStreamAsync.java
@@ -79,6 +79,7 @@ public class SftpInputStreamAsync extends InputStreamWithChannel implements Sftp
         this.path = path;
         this.handle = handle;
         this.bufferSize = bufferSize;
+        this.requestOffset = clientOffset;
         this.clientOffset = clientOffset;
         this.fileSize = fileSize;
     }
@@ -207,7 +208,8 @@ public class SftpInputStreamAsync extends InputStreamWithChannel implements Sftp
             if (log.isDebugEnabled()) {
                 log.debug("skip({}) virtual skip of {} bytes", this, n);
             }
-            requestOffset = clientOffset = n;
+            requestOffset = n;
+            clientOffset = n;
             return n;
         }
 

--- a/sshd-sftp/src/test/java/org/apache/sshd/sftp/client/SftpTest.java
+++ b/sshd-sftp/src/test/java/org/apache/sshd/sftp/client/SftpTest.java
@@ -543,17 +543,29 @@ public class SftpTest extends AbstractSftpClientTestSupport {
                      CommonTestSupportUtils.resolveRelativeRemotePath(parentPath, localFile), OpenMode.Read)) {
             byte[] expected = new byte[data.length / 4];
             int readLen = expected.length;
-            System.arraycopy(data, 0, expected, 0, readLen);
-
             byte[] actual = new byte[readLen];
+
+            stream.mark(readLen * 2);
+            long skipped = stream.skip(readLen);
+            assertEquals("Mismatched skipped forward size", readLen, skipped);
+
+            readLen = stream.read(actual);
+            assertEquals("Failed to read fully skipped forward data", actual.length, readLen);
+
+            System.arraycopy(data, readLen, expected, 0, expected.length);
+            assertArrayEquals("Mismatched original data contents", expected, actual);
+
+            stream.reset();
             readLen = stream.read(actual);
             assertEquals("Failed to read fully reset data", actual.length, readLen);
+
+            System.arraycopy(data, 0, expected, 0, readLen);
             assertArrayEquals("Mismatched re-read data contents", expected, actual);
 
             System.arraycopy(data, 0, expected, 0, expected.length);
             assertArrayEquals("Mismatched original data contents", expected, actual);
 
-            long skipped = stream.skip(readLen);
+            skipped = stream.skip(readLen);
             assertEquals("Mismatched skipped forward size", readLen, skipped);
 
             readLen = stream.read(actual);

--- a/sshd-sftp/src/test/java/org/apache/sshd/sftp/client/SftpTest.java
+++ b/sshd-sftp/src/test/java/org/apache/sshd/sftp/client/SftpTest.java
@@ -564,7 +564,7 @@ public class SftpTest extends AbstractSftpClientTestSupport {
         }
     }
 
-    @Test
+    @Test // see SSHD-1182
     public void testInputStreamSkipBeforeRead() throws Exception {
         Path targetPath = detectTargetFolder();
         Path parentPath = targetPath.getParent();


### PR DESCRIPTION
need to modify `requestOffset` when `clientOffset` is changed from 0 to specified value