### PR TITLE
[SSHD-1215] Treat ACE4_APPEND_DATA as a hint only

### DIFF
--- a/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/impl/AbstractSftpClient.java
+++ b/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/impl/AbstractSftpClient.java
@@ -679,6 +679,7 @@ public abstract class AbstractSftpClient
             }
             if (options.contains(OpenMode.Append)) {
                 access |= SftpConstants.ACE4_APPEND_DATA;
+                mode |= SftpConstants.SSH_FXF_APPEND_DATA;
             }
             buffer.putInt(access);
 


### PR DESCRIPTION
Some SFTP clients in SFTP version >= V5 set the NFS desired-access flag
ACE4_APPEND_DATA even when they only open the file for normal write
access. SFTP append mode should be active only if the file is indeed
opened with one of the "append" options SSH_FXF_APPEND or
SSH_FXF_APPEND_DATA or SSH_FXF_APPEND_DATA_ATOMIC.

The SFTP draft RFCs appear to allow the combination of SSH_FXF_READ,
SSH_FXF_WRITE, and SSH_FXF_APPEND, which would open the file for reading
and writing, all writes going to the current end of the file. POSIX
also allows the combination O_RDWR | O_APPEND. But Java complains about
using both StandardOpenOption.READ and StandardOpenOption.APPEND.
Therefore never open files in Java with StandardOpenOption.APPEND but
always manage the "append" logic explicitly. Internally, make sure that
ACE4_APPEND_DATA is set only if the user/client had indeed requested
"append" mode.