### PR TITLE
[SSHD-1216] Server-side server-sig-algs KEX extension

### DIFF
--- a/sshd-core/src/main/java/org/apache/sshd/client/ClientBuilder.java
+++ b/sshd-core/src/main/java/org/apache/sshd/client/ClientBuilder.java
@@ -80,15 +80,9 @@ public class ClientBuilder extends BaseBuilder<SshClient, ClientBuilder> {
     protected HostConfigEntryResolver hostConfigEntryResolver;
     protected ClientIdentityLoader clientIdentityLoader;
     protected FilePasswordProvider filePasswordProvider;
-    protected KexExtensionHandler kexExtensionHandler;
 
     public ClientBuilder() {
         super();
-    }
-
-    public ClientBuilder kexExtensionHandler(KexExtensionHandler kexExtensionHandler) {
-        this.kexExtensionHandler = kexExtensionHandler;
-        return me();
     }
 
     public ClientBuilder serverKeyVerifier(ServerKeyVerifier serverKeyVerifier) {
@@ -127,6 +121,10 @@ public class ClientBuilder extends BaseBuilder<SshClient, ClientBuilder> {
             keyExchangeFactories = setUpDefaultKeyExchanges(false);
         }
 
+        if (kexExtensionHandler == null) {
+            kexExtensionHandler = DEFAULT_KEX_EXTENSION_HANDLER;
+        }
+
         if (channelFactories == null) {
             channelFactories = DEFAULT_CHANNEL_FACTORIES;
         }
@@ -151,10 +149,6 @@ public class ClientBuilder extends BaseBuilder<SshClient, ClientBuilder> {
             filePasswordProvider = DEFAULT_FILE_PASSWORD_PROVIDER;
         }
 
-        if (kexExtensionHandler == null) {
-            kexExtensionHandler = DEFAULT_KEX_EXTENSION_HANDLER;
-        }
-
         if (factory == null) {
             factory = SshClient.DEFAULT_SSH_CLIENT_FACTORY;
         }
@@ -169,7 +163,6 @@ public class ClientBuilder extends BaseBuilder<SshClient, ClientBuilder> {
         client.setHostConfigEntryResolver(hostConfigEntryResolver);
         client.setClientIdentityLoader(clientIdentityLoader);
         client.setFilePasswordProvider(filePasswordProvider);
-        client.setKexExtensionHandler(kexExtensionHandler);
         return client;
     }
 

--- a/sshd-core/src/main/java/org/apache/sshd/common/BaseBuilder.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/BaseBuilder.java
@@ -36,6 +36,7 @@ import org.apache.sshd.common.forward.ForwarderFactory;
 import org.apache.sshd.common.helpers.AbstractFactoryManager;
 import org.apache.sshd.common.kex.BuiltinDHFactories;
 import org.apache.sshd.common.kex.KeyExchangeFactory;
+import org.apache.sshd.common.kex.extension.KexExtensionHandler;
 import org.apache.sshd.common.mac.BuiltinMacs;
 import org.apache.sshd.common.mac.Mac;
 import org.apache.sshd.common.random.Random;
@@ -151,6 +152,7 @@ public class BaseBuilder<T extends AbstractFactoryManager, S extends BaseBuilder
     protected ForwardingFilter forwardingFilter;
     protected ChannelStreamWriterResolver channelStreamPacketWriterResolver;
     protected UnknownChannelReferenceHandler unknownChannelReferenceHandler;
+    protected KexExtensionHandler kexExtensionHandler;
 
     public BaseBuilder() {
         super();
@@ -190,6 +192,11 @@ public class BaseBuilder<T extends AbstractFactoryManager, S extends BaseBuilder
 
     public S keyExchangeFactories(List<KeyExchangeFactory> keyExchangeFactories) {
         this.keyExchangeFactories = keyExchangeFactories;
+        return me();
+    }
+
+    public S kexExtensionHandler(KexExtensionHandler kexExtensionHandler) {
+        this.kexExtensionHandler = kexExtensionHandler;
         return me();
     }
 
@@ -265,6 +272,7 @@ public class BaseBuilder<T extends AbstractFactoryManager, S extends BaseBuilder
 
         T ssh = factory.create();
 
+        ssh.setKexExtensionHandler(kexExtensionHandler);
         ssh.setKeyExchangeFactories(keyExchangeFactories);
         ssh.setSignatureFactories(signatureFactories);
         ssh.setRandomFactory(randomFactory);

--- a/sshd-core/src/main/java/org/apache/sshd/common/kex/extension/DefaultServerKexExtensionHandler.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/kex/extension/DefaultServerKexExtensionHandler.java
@@ -1,0 +1,186 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sshd.common.kex.extension;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiConsumer;
+
+import org.apache.sshd.common.AttributeRepository.AttributeKey;
+import org.apache.sshd.common.kex.KexProposalOption;
+import org.apache.sshd.common.kex.extension.parser.ServerSignatureAlgorithms;
+import org.apache.sshd.common.session.Session;
+import org.apache.sshd.common.session.SessionListener;
+import org.apache.sshd.common.util.GenericUtils;
+import org.apache.sshd.common.util.buffer.Buffer;
+import org.apache.sshd.common.util.logging.AbstractLoggingBean;
+
+/**
+ * A basic default implementation of a server-side {@link KexExtensionHandler} handling the
+ * {@link ServerSignatureAlgorithms} KEX extension.
+ *
+ * @see <a href="https://tools.ietf.org/html/rfc8308">RFC 8308</a>
+ */
+public class DefaultServerKexExtensionHandler extends AbstractLoggingBean implements KexExtensionHandler {
+
+    /** Default singleton instance. */
+    public static final DefaultServerKexExtensionHandler INSTANCE = new DefaultServerKexExtensionHandler();
+
+    /**
+     * Session {@link AttributeKey} storing whether the client requested to get the EXT_INFO message. Possible values
+     * are:
+     * <dl>
+     * <dt>{@code null}</dt>
+     * <dd>Unknown. We have not yet received the client's KEX proposal. Do not send the message.</dd>
+     * <dt>{@code Boolean.TRUE}</dt>
+     * <dd>We have received the client's KEX proposal, and the client has requested to get the EXT_INFO message.</dd>
+     * <dt>{@code Boolean.FALSE}</dt>
+     * <dd>We have received the client's KEX proposal, and the client did not request to get the EXT_INFO message. Do
+     * not send the message.</dd>
+     * </dl>
+     */
+    public static final AttributeKey<Boolean> CLIENT_REQUESTED_EXT_INFO = new AttributeKey<>();
+
+    /**
+     * Session {@link AttributeKey} storing whether the server sent an EXT_INFO message at {@link KexPhase#NEWKEYS}. A
+     * server is supposed to send the message at that point only on the very first NEWKEYS message. Possible values are:
+     * <dl>
+     * <dt>{@code null} or {@code Boolean.FALSE}</dt>
+     * <dd>The EXT_INFO message at {@link KexPhase#NEWKEYS} was not done yet.</dd>
+     * <dt>{@code Boolean.TRUE}</dt>
+     * <dd>The EXT_INFO message at {@link KexPhase#NEWKEYS} was done.</dd>
+     * </dl>
+     */
+    public static final AttributeKey<Boolean> EXT_INFO_SENT_AT_NEWKEYS = new AttributeKey<>();
+
+    public DefaultServerKexExtensionHandler() {
+        super();
+    }
+
+    @Override
+    public void handleKexInitProposal(Session session, boolean initiator, Map<KexProposalOption, String> proposal)
+            throws Exception {
+        if (!initiator) {
+            if (session.getAttribute(CLIENT_REQUESTED_EXT_INFO) == null) {
+                // Only the first time, not on re-KEX
+                String algorithms = proposal.get(KexProposalOption.ALGORITHMS);
+                boolean clientWantsExtInfo = Arrays.asList(GenericUtils.split(algorithms, ','))
+                        .contains(KexExtensions.CLIENT_KEX_EXTENSION);
+                session.setAttribute(CLIENT_REQUESTED_EXT_INFO, clientWantsExtInfo);
+                if (clientWantsExtInfo && log.isTraceEnabled()) {
+                    log.trace("handleKexInitProposal({}): got ext-info-c from client", session);
+                }
+            }
+        }
+    }
+
+    @Override
+    public void sendKexExtensions(Session session, KexPhase phase) throws Exception {
+        if (phase == KexPhase.NEWKEYS) {
+            Boolean alreadySent = session.getAttribute(EXT_INFO_SENT_AT_NEWKEYS);
+            if (alreadySent != null && alreadySent.booleanValue()) {
+                // It's not the first NEWKEYS.
+                return;
+            }
+            session.setAttribute(EXT_INFO_SENT_AT_NEWKEYS, Boolean.TRUE);
+        }
+        Boolean doExtInfo = session.getAttribute(CLIENT_REQUESTED_EXT_INFO);
+        if (doExtInfo == null || !doExtInfo.booleanValue()) {
+            if (log.isTraceEnabled()) {
+                log.trace("sendKexExtensions({})[{}]: client did not send ext-info-c; skipping sending SSH_MSG_EXT_INFO",
+                        session, phase);
+            }
+            return;
+        }
+        Map<String, Object> extensions = new LinkedHashMap<>();
+        collectExtensions(session, phase, extensions::put);
+        if (!extensions.isEmpty()) {
+            Buffer buffer = session.createBuffer(KexExtensions.SSH_MSG_EXT_INFO);
+            KexExtensions.putExtensions(extensions.entrySet(), buffer);
+            int numberOfExtensions = extensions.size();
+            if (log.isDebugEnabled()) {
+                log.debug("sendKexExtensions({})[{}]: prepared SSH_MSG_EXT_INFO with {} info records", session, phase,
+                        numberOfExtensions);
+            }
+            // We must send the SSH_MSG_EXT_INFO as the next packet following our SSH_MSG_NEWKEYS message. It must be
+            // encoded with the new keys, though, which we will install only once we get the peer's SSH_MG_NEWKEYS.
+            // Hence delay the sending until the KeyEstablished event is fired. That event is fired before any pending
+            // higher level messages are written, so this packet goes out first even if there are pending packets. Note
+            // that it will never be queued since it has low command ID; SSH_MSG_EXT_INFO is 7.
+            //
+            // RFC 8308 recommends that "the server sends its SSH_MSG_EXT_INFO not only as the next packet after
+            // SSH_MSG_NEWKEYS, but without delay". This cannot be implemented currently; it would require setting up
+            // the keys already when we send our SSH_MG_NEWKEYS so that they are already set correctly if we did a
+            // session.writePacket(buffer) here directly.
+            session.addSessionListener(new SessionListener() {
+
+                @Override
+                public void sessionEvent(Session session, Event event) {
+                    if (event == Event.KeyEstablished) {
+                        try {
+                            if (log.isDebugEnabled()) {
+                                log.debug("sendKexExtensions({})[{}]: sending SSH_MSG_EXT_INFO with {} info records", session,
+                                        phase, numberOfExtensions);
+                            }
+                            session.writePacket(buffer);
+                        } catch (IOException e) {
+                            log.error("sendKexExtensions({})[{}]: sending SSH_MSG_EXT_INFO failed", session, phase, e);
+                        } finally {
+                            session.removeSessionListener(this);
+                        }
+                    }
+                }
+            });
+        } else if (log.isDebugEnabled()) {
+            log.debug("sendKexExtensions({})[{}]: no extension info; skipping sending SSH_MSG_EXT_INFO", session, phase);
+        }
+    }
+
+    /**
+     * Collects extension info records, handing them off to the given {@code marshaller} for writing into an
+     * {@link KexExtensions#SSH_MSG_EXT_INFO} message.
+     * <p>
+     * This default implementation marshals a {@link ServerSignatureAlgorithms} extension if the {@code phase} is
+     * {@link KexPhase#NEWKEYS}.
+     * </p>
+     *
+     * @param session    {@link Session} to send the KEX extension information for
+     * @param phase      {@link KexPhase} of the SSH protocol
+     * @param marshaller {@link BiConsumer} writing the extensions into an SSH message
+     */
+    public void collectExtensions(Session session, KexPhase phase, BiConsumer<String, Object> marshaller) {
+        if (phase == KexPhase.NEWKEYS) {
+            List<String> algorithms = session.getSignatureFactoriesNames();
+            if (!GenericUtils.isEmpty(algorithms)) {
+                marshaller.accept(ServerSignatureAlgorithms.NAME, algorithms);
+                if (log.isDebugEnabled()) {
+                    log.debug("collectExtensions({})[{}]: extension info {}: {}", session, phase,
+                            ServerSignatureAlgorithms.NAME, String.join(",", algorithms));
+                }
+            } else if (log.isWarnEnabled()) {
+                log.warn("collectExtensions({})[{}]: extension info {} has no algorithms; skipping", session, phase,
+                        ServerSignatureAlgorithms.NAME);
+            }
+        }
+    }
+}

--- a/sshd-core/src/main/java/org/apache/sshd/server/ServerBuilder.java
+++ b/sshd-core/src/main/java/org/apache/sshd/server/ServerBuilder.java
@@ -34,6 +34,8 @@ import org.apache.sshd.common.compression.CompressionFactory;
 import org.apache.sshd.common.kex.DHFactory;
 import org.apache.sshd.common.kex.KeyExchange;
 import org.apache.sshd.common.kex.KeyExchangeFactory;
+import org.apache.sshd.common.kex.extension.DefaultServerKexExtensionHandler;
+import org.apache.sshd.common.kex.extension.KexExtensionHandler;
 import org.apache.sshd.common.session.ConnectionService;
 import org.apache.sshd.common.signature.Signature;
 import org.apache.sshd.server.auth.keyboard.DefaultKeyboardInteractiveAuthenticator;
@@ -82,6 +84,7 @@ public class ServerBuilder extends BaseBuilder<SshServer, ServerBuilder> {
                     BuiltinCompressions.none,
                     BuiltinCompressions.zlib,
                     BuiltinCompressions.delayedZlib));
+    public static final KexExtensionHandler DEFAULT_KEX_EXTENSION_HANDLER = DefaultServerKexExtensionHandler.INSTANCE;
 
     protected PublickeyAuthenticator pubkeyAuthenticator;
     protected KeyboardInteractiveAuthenticator interactiveAuthenticator;
@@ -114,6 +117,10 @@ public class ServerBuilder extends BaseBuilder<SshServer, ServerBuilder> {
 
         if (keyExchangeFactories == null) {
             keyExchangeFactories = setUpDefaultKeyExchanges(false);
+        }
+
+        if (kexExtensionHandler == null) {
+            kexExtensionHandler = DEFAULT_KEX_EXTENSION_HANDLER;
         }
 
         if (channelFactories == null) {


### PR DESCRIPTION
Provide a default implementation for the server-side SSH_MSG_EXT_INFO
message sending including the server-sig-algs KEX extension.[1]

A server that implements the rsa-sha2-512 or rsa-sha2-256 signature
algorithms should implement this extension, otherwise even clients that
also have these signature algorithms may fall back to ssh-rsa to avoid
authentication penalties.[2]

Apache MINA sshd servers by default do implement the SHA-2 RSA
signatures, and an Apache MINA sshd client by default does request KEX
extension information and does handle the server-sig-algs extension. So
an Apache MINA sshd server should by default implement this extension.

This implementation sends the server-sig-algs extension record once at
the end of the initial key exchange.

[1] https://tools.ietf.org/html/rfc8308
[2] https://tools.ietf.org/html/rfc8332#section-3.3