### PR TITLE
Set output and input encodings separately at end of KEX

### DIFF
--- a/sshd-core/src/main/java/org/apache/sshd/common/session/SessionListener.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/session/SessionListener.java
@@ -31,8 +31,22 @@ import org.apache.sshd.common.util.SshdEventListener;
  */
 public interface SessionListener extends SshdEventListener {
     enum Event {
+
+        /**
+         * Fired at the end of a key exchange once both parties have updated the message encoding/decoding; i.e., when
+         * both parties have handled the peer's SSH_MSG_NEWKEY message.
+         */
         KeyEstablished,
+
+        /**
+         * Fired when the session is fully authenticated.
+         */
         Authenticated,
+
+        /**
+         * Fired at the end of KEX negotiation, i.e., when both proposals have been handled and the
+         * {@link org.apache.sshd.common.kex.KeyExchange} is initialized.
+         */
         KexCompleted
     }
 


### PR DESCRIPTION
Once SSH_MSG_NEWKEYS is sent any subsequent packet sent must use the
new encoding settings. Once SSH_MSG_NEWKEYS is received, the new
encoding settings are to be used for any message received. So set the
cipher/mac/compression separately for outgoing and incoming messages
in sendNewKeys() and handleNewKeys().

Previously, we set both only in handleNewKeys(), i.e., when the peer's
SSH_MSG_NEWKEYS was received. This makes implementing a KEX extension
handler more complicated than necessary since it had to delay sending
the SSH_MSG_EXT_INFO packet until after the peer's SSH_MSG_NEW_KEYS was
received.

RFC 8308 recommends that "the server sends its SSH_MSG_EXT_INFO not
only as the next packet after SSH_MSG_NEWKEYS, but without delay". This
is now possible since the output settings are already set up correctly.

SSH_MSG_EXT_INFO is always sent and received after SSH_MSG_NEWKEY, and
the Apache MINA sshd implementation guarantees that either party handles
the peer's SSH_MSG_NEWKEY *after* having sent its own SSH_MSG_NEWKEY.