### PR TITLE
[SSHD-1221] Support key constraints when adding a key to the SSH agent

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,7 +27,7 @@
 
 * [SSHD-1017](https://issues.apache.org/jira/browse/SSHD-1017) Add support for the chacha20-poly1305@openssh.com cipher
 * [SSHD-1161](https://issues.apache.org/jira/browse/SSHD-1161) Support OpenSSH client certificates for publickey authentication
-* [SSHD-1163](https://issues.apache.org/jira/browse/SSHD-1163) Wrong server key algorithm chosen in DH group key exchange
+* [SSHD-1163](https://issues.apache.org/jira/browse/SSHD-1163) Wrong server key signature algorithm chosen in DH group key exchange
 * [SSHD-1164](https://issues.apache.org/jira/browse/SSHD-1164) Parsing of ~/.ssh/config Host patterns fails with extra whitespace
 * [SSHD-1166](https://issues.apache.org/jira/browse/SSHD-1166) Support creating signed OpenSSH certificates
 * [SSHD-1168](https://issues.apache.org/jira/browse/SSHD-1168) OpenSSH certificates: check certificate type
@@ -39,3 +39,4 @@
 * [SSHD-1218](https://issues.apache.org/jira/browse/SSHD-1218) SshAgentFactory.createClient() gets passed the session
 * [SSHD-1219](https://issues.apache.org/jira/browse/SSHD-1219) Obtaining rsa-sha2-256 or rsa-sha2-512 signatures from an SSH agent
 * [SSHD-1220](https://issues.apache.org/jira/browse/SSHD-1220) Reduce number of L(STAT) calls made by the SftpFileSystem
+* [SSHD-1221](https://issues.apache.org/jira/browse/SSHD-1221) Support key constraints when adding a key to an SSH agent

--- a/sshd-core/src/main/java/org/apache/sshd/agent/SshAgent.java
+++ b/sshd-core/src/main/java/org/apache/sshd/agent/SshAgent.java
@@ -57,7 +57,16 @@ public interface SshAgent extends java.nio.channels.Channel {
         return null;
     }
 
-    void addIdentity(KeyPair key, String comment) throws IOException;
+    /**
+     * Adds a key to the agent.
+     *
+     * @param  key         {@link KeyPair} to add
+     * @param  comment     to associate with the key
+     * @param  constraints {@link SshAgentKeyConstraint}s for this key to pass on to the agent
+     * @throws IOException if an error in the communication with the agent occurred, or the agent did not return a reply
+     *                     indicating successful addition of the key
+     */
+    void addIdentity(KeyPair key, String comment, SshAgentKeyConstraint... constraints) throws IOException;
 
     void removeIdentity(PublicKey key) throws IOException;
 

--- a/sshd-core/src/main/java/org/apache/sshd/agent/SshAgentConstants.java
+++ b/sshd-core/src/main/java/org/apache/sshd/agent/SshAgentConstants.java
@@ -65,9 +65,10 @@ public final class SshAgentConstants {
     public static final byte SSH2_AGENT_IDENTITIES_ANSWER = 12;
     public static final byte SSH2_AGENT_SIGN_RESPONSE = 14;
 
-    // Key constraint identifiers
+    // OpenSSH key constraint identifiers
     public static final byte SSH_AGENT_CONSTRAIN_LIFETIME = 1;
     public static final byte SSH_AGENT_CONSTRAIN_CONFIRM = 2;
+    public static final byte SSH_AGENT_CONSTRAIN_EXTENSION = (byte) 0xFF;
 
     // Packet types defined by IETF (https://tools.ietf.org/html/draft-ietf-secsh-agent-02)
     // Messages sent by the client

--- a/sshd-core/src/main/java/org/apache/sshd/agent/SshAgentKeyConstraint.java
+++ b/sshd-core/src/main/java/org/apache/sshd/agent/SshAgentKeyConstraint.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sshd.agent;
+
+import org.apache.sshd.common.util.GenericUtils;
+import org.apache.sshd.common.util.buffer.Buffer;
+
+/**
+ * A {@link SshAgentKeyConstraint} describes usage constraints for keys when being added to an SSH2 agent.
+ */
+public abstract class SshAgentKeyConstraint {
+
+    /**
+     * The singleton OpenSSH confirmation {@link SshAgentKeyConstraint}. If set, the SSH agent is supposed to prompt the
+     * user before each use of a key in a signing operation.
+     * <p>
+     * Users who have this option set via ssh config {@code AddKeysToAgent confirm} are responsible themselves for
+     * having configured their agent correctly so that it prompts in whatever way is appropriate.
+     * </p>
+     * <p>
+     * The OpenSSH agent prompts via via {@code ssh-askpass} or whatever program the environment variable SSH_ASKPASS
+     * defines. These prompts don't go through the prompting callback mechanisms of Apache MINA sshd.
+     * </p>
+     */
+    public static final SshAgentKeyConstraint CONFIRM = new SshAgentKeyConstraint(
+            SshAgentConstants.SSH_AGENT_CONSTRAIN_CONFIRM) {
+        // Nothing
+    };
+
+    private final byte id;
+
+    /**
+     * Constructor setting the agent protocol ID of the constraint.
+     *
+     * @param id for the key constraint
+     */
+    protected SshAgentKeyConstraint(byte id) {
+        this.id = id;
+    }
+
+    /**
+     * Retrieves the protocol ID of this constraint.
+     *
+     * @return the protocol id of this constraint
+     */
+    public byte getId() {
+        return id;
+    }
+
+    /**
+     * Writes this constraint into the given {@link Buffer}.
+     *
+     * @param buffer {@link Buffer} to write into at the current buffer write position
+     */
+    public void put(Buffer buffer) {
+        buffer.putByte(id);
+    }
+
+    /**
+     * An OpenSSH lifetime constraint expires a key added to an SSH agent after the given number of seconds.
+     */
+    public static class LifeTime extends SshAgentKeyConstraint {
+
+        private final int secondsToLive;
+
+        /**
+         * Creates a new {@link LifeTime} constraint.
+         *
+         * @param secondsToLive number of seconds after which the agent shall automatically remove the key again; must
+         *                      be strictly positive
+         */
+        public LifeTime(int secondsToLive) {
+            super(SshAgentConstants.SSH_AGENT_CONSTRAIN_LIFETIME);
+            if (secondsToLive <= 0) {
+                throw new IllegalArgumentException("Key lifetime must be > 0, was " + secondsToLive);
+            }
+            this.secondsToLive = secondsToLive;
+        }
+
+        @Override
+        public void put(Buffer buffer) {
+            super.put(buffer);
+            buffer.putInt(secondsToLive);
+        }
+    }
+
+    /**
+     * An OpenSSH {@link SshAgentKeyConstraint} extension. Extensions are identified by name.
+     */
+    public abstract static class Extension extends SshAgentKeyConstraint {
+
+        private final String name;
+
+        /**
+         * Creates a new {@link Extension}.
+         *
+         * @param name of the extension, must not be {@code null} or empty
+         */
+        protected Extension(String name) {
+            super(SshAgentConstants.SSH_AGENT_CONSTRAIN_EXTENSION);
+            if (GenericUtils.isEmpty(name)) {
+                throw new IllegalArgumentException("Key constraint extension name must be non-empty");
+            }
+            this.name = name;
+        }
+
+        @Override
+        public void put(Buffer buffer) {
+            super.put(buffer);
+            buffer.putString(name);
+        }
+    }
+
+    /**
+     * The OpenSSH "sk-provider@openssh.com" key constraint extension used for FIDO keys. Could be set via ssh config
+     * {@code SecurityKeyProvider}.
+     */
+    public static class FidoProviderExtension extends Extension {
+
+        private final String provider;
+
+        /**
+         * Creates a new {@link FidoProviderExtension}.
+         *
+         * @param provider path to a middleware library; must not be {@code null} or empty
+         */
+        public FidoProviderExtension(String provider) {
+            super("sk-provider@openssh.com");
+            if (GenericUtils.isEmpty(provider)) {
+                throw new IllegalArgumentException("FIDO provider library path must be non-empty");
+            }
+            this.provider = provider;
+        }
+
+        @Override
+        public void put(Buffer buffer) {
+            super.put(buffer);
+            buffer.putString(provider);
+        }
+    }
+}

--- a/sshd-core/src/main/java/org/apache/sshd/agent/common/AgentDelegate.java
+++ b/sshd-core/src/main/java/org/apache/sshd/agent/common/AgentDelegate.java
@@ -24,6 +24,7 @@ import java.security.PublicKey;
 import java.util.Map;
 
 import org.apache.sshd.agent.SshAgent;
+import org.apache.sshd.agent.SshAgentKeyConstraint;
 import org.apache.sshd.common.session.SessionContext;
 
 public class AgentDelegate implements SshAgent {
@@ -55,8 +56,8 @@ public class AgentDelegate implements SshAgent {
     }
 
     @Override
-    public void addIdentity(KeyPair key, String comment) throws IOException {
-        agent.addIdentity(key, comment);
+    public void addIdentity(KeyPair key, String comment, SshAgentKeyConstraint... constraints) throws IOException {
+        agent.addIdentity(key, comment, constraints);
     }
 
     @Override


### PR DESCRIPTION
Change the API of SshAgent.addKeyToAgent() to be able to pass key
constraints. Provide default implementations for the documented
OpenSSH constraints: confirm, lifetime, and the sk-provider extension.

Handle them in the AbstractAgentProxy implementation. Note that
AbstractAgentProxy currently implements addKeyToAgent() only for
OpenSSH. Users wanting to support a different agent may have to
implement different constraints by extending the provided base classes,
and may have to provide their own SshAgent (and a factory for it)
implementing a different protocol for addKeyToAgent().