### PR TITLE
[SSHD-1230] Log netty channel traffic on TRACE level

### DIFF
--- a/sshd-netty/src/main/java/org/apache/sshd/netty/NettyIoAcceptor.java
+++ b/sshd-netty/src/main/java/org/apache/sshd/netty/NettyIoAcceptor.java
@@ -56,6 +56,9 @@ import org.apache.sshd.common.util.GenericUtils;
  * @author <a href="mailto:dev@mina.apache.org">Apache MINA SSHD Project</a>
  */
 public class NettyIoAcceptor extends NettyIoService implements IoAcceptor {
+    // Shared across all acceptors
+    private static final LoggingHandler LOGGING_TRACE = new LoggingHandler(NettyIoAcceptor.class, LogLevel.TRACE);
+
     protected final ServerBootstrap bootstrap = new ServerBootstrap();
     protected final Map<SocketAddress, Channel> boundAddresses = new ConcurrentHashMap<>();
 
@@ -66,7 +69,7 @@ public class NettyIoAcceptor extends NettyIoService implements IoAcceptor {
         bootstrap.group(factory.eventLoopGroup)
                 .channel(NioServerSocketChannel.class)
                 .option(ChannelOption.SO_BACKLOG, 100) // TODO make this configurable
-                .handler(new LoggingHandler(LogLevel.INFO)) // TODO make this configurable
+                .handler(LOGGING_TRACE) // TODO make this configurable
                 .childHandler(new ChannelInitializer<SocketChannel>() {
                     @Override
                     @SuppressWarnings("synthetic-access")

--- a/sshd-netty/src/main/java/org/apache/sshd/netty/NettyIoConnector.java
+++ b/sshd-netty/src/main/java/org/apache/sshd/netty/NettyIoConnector.java
@@ -47,6 +47,9 @@ import org.apache.sshd.common.io.IoSession;
  * @author <a href="mailto:dev@mina.apache.org">Apache MINA SSHD Project</a>
  */
 public class NettyIoConnector extends NettyIoService implements IoConnector {
+    // Shared across all connectors
+    private static final LoggingHandler LOGGING_TRACE = new LoggingHandler(NettyIoConnector.class, LogLevel.TRACE);
+
     protected final Bootstrap bootstrap = new Bootstrap();
 
     public NettyIoConnector(NettyIoServiceFactory factory, IoHandler handler) {
@@ -83,7 +86,7 @@ public class NettyIoConnector extends NettyIoService implements IoConnector {
                             }
 
                             ChannelPipeline p = ch.pipeline();
-                            p.addLast(new LoggingHandler(LogLevel.INFO)); // TODO make this configurable
+                            p.addLast(LOGGING_TRACE); // TODO make this configurable
                             p.addLast(session.adapter);
                         } catch (Exception e) {
                             if (listener != null) {


### PR DESCRIPTION
The hard-coded logger is overly verbose by default. Change the log level to TRACE and propagate class identity, so that Logger implementations can correctly enable/disable the messages. Also share a single LoggingHandler for all channels, reducing memory footprint. 