### PR TITLE
[SSHD-1254] Client side implementation of host bound pubkey auth

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -72,6 +72,7 @@ Was originally in *HostConfigEntry*.
 * [SSHD-1244](https://issues.apache.org/jira/browse/SSHD-1244) Re-defined channel identifiers as `long` rather than `int` to align with protocol UINT32 definition
 * [SSHD-1246](https://issues.apache.org/jira/browse/SSHD-1246) Added SshKeyDumpMain utility
 * [SSHD-1247](https://issues.apache.org/jira/browse/SSHD-1247) Added support for Argon2id encrypted PUTTY keys
+* [SSHD-1254](https://issues.apache.org/jira/browse/SSHD-1254) Support host-based pubkey authentication in the client ("publickey-hostbound@openssh.com" KEX extension)
 * [SSHD-1257](https://issues.apache.org/jira/browse/SSHD-1257) ChannelSession: don't flush out stream if already closed
 * [SSHD-1262](https://issues.apache.org/jira/browse/SSHD-1262) TCP/IP port forwarding: don't buffer, and don't read from port before channel is open
 * [SSHD-1264](https://issues.apache.org/jira/browse/SSHD-1264) Create KEX negotiation proposal only once per session, not on every re-KEX

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ based applications requiring SSH support.
 
 ## Implemented/available support
 
+* **Authentication methods**: hostbased, publickey, [OpenSSH host-based public-key](https://github.com/openssh/openssh-portable/blob/1781f507c11/PROTOCOL#L349), keyboard-interactive, password
 * **Ciphers**: aes128cbc, aes128ctr, aes192cbc, aes192ctr, aes256cbc, aes256ctr, arcfour128, arcfour256, blowfishcbc, tripledescbc,
 aes128-gcm@openssh.com, aes256-gcm@openssh.com, chacha20-poly1305@openssh.com
 * **Digests**: md5, sha1, sha224, sha256, sha384, sha512

--- a/sshd-common/src/main/java/org/apache/sshd/common/kex/extension/parser/HostBoundPubkeyAuthentication.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/kex/extension/parser/HostBoundPubkeyAuthentication.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sshd.common.kex.extension.parser;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.sshd.common.util.buffer.Buffer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class HostBoundPubkeyAuthentication extends AbstractKexExtensionParser<Integer> {
+
+    public static final String NAME = "publickey-hostbound@openssh.com";
+
+    public static final String AUTH_NAME = "publickey-hostbound-v00@openssh.com";
+
+    public static final HostBoundPubkeyAuthentication INSTANCE = new HostBoundPubkeyAuthentication();
+
+    private static final Logger LOG = LoggerFactory.getLogger(HostBoundPubkeyAuthentication.class);
+
+    public HostBoundPubkeyAuthentication() {
+        super(NAME);
+    }
+
+    @Override
+    public Integer parseExtension(Buffer buffer) throws IOException {
+        return parseExtension(buffer.array(), buffer.rpos(), buffer.available());
+    }
+
+    @Override
+    public Integer parseExtension(byte[] data, int off, int len) throws IOException {
+        if (len <= 0) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Inconsistent KEX extension {} received; no data (len={})", NAME, len);
+            }
+            return null;
+        }
+        String value = new String(data, off, len, StandardCharsets.UTF_8);
+        try {
+            Integer result = Integer.valueOf(Integer.parseUnsignedInt(value));
+            LOG.info("Server announced support for {} version {}", NAME, result);
+            return result;
+        } catch (NumberFormatException e) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Cannot parse KEX extension {} version {}", NAME, value);
+            }
+        }
+        return null;
+    }
+
+    @Override
+    protected void encode(Integer version, Buffer buffer) throws IOException {
+        buffer.putString(version.toString());
+    }
+}

--- a/sshd-core/src/test/java/org/apache/sshd/client/auth/pubkey/HostBoundPubKeyAuthTest.java
+++ b/sshd-core/src/test/java/org/apache/sshd/client/auth/pubkey/HostBoundPubKeyAuthTest.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sshd.client.auth.pubkey;
+
+import java.util.Arrays;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.sshd.client.SshClient;
+import org.apache.sshd.client.session.ClientSession;
+import org.apache.sshd.common.kex.extension.DefaultClientKexExtensionHandler;
+import org.apache.sshd.common.keyprovider.FileKeyPairProvider;
+import org.apache.sshd.util.test.BaseTestSupport;
+import org.apache.sshd.util.test.CommonTestSupportUtils;
+import org.apache.sshd.util.test.ContainerTestCase;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.images.builder.ImageFromDockerfile;
+import org.testcontainers.utility.MountableFile;
+
+@RunWith(Parameterized.class) // see https://github.com/junit-team/junit/wiki/Parameterized-tests
+@Category(ContainerTestCase.class)
+public class HostBoundPubKeyAuthTest extends BaseTestSupport {
+
+    private static final Logger LOG = LoggerFactory.getLogger(HostBoundPubKeyAuthTest.class);
+
+    // We re-use the keys (not the certificates) from the ClientOpenSSHCertificatesTest.
+    private static final String TEST_KEYS = "org/apache/sshd/client/opensshcerts/user";
+
+    private static final String TEST_RESOURCES = "org/apache/sshd/client/auth/pubkey";
+
+    private static final Pattern EXPECTED_LOG_ENTRY = //
+            Pattern.compile("\n.*debug2: userauth_pubkey: valid user bob attempting public key.*"
+                            + "\r?\n.*debug3: userauth_pubkey: publickey-hostbound-v00@openssh.com have");
+
+    @Rule
+    public GenericContainer<?> sshdContainer = new GenericContainer<>(
+            new ImageFromDockerfile().withDockerfileFromBuilder(builder -> builder.from("alpine:3.16")
+                    .run("apk --update add openssh-server") // Installs OpenSSH 9.0
+                    .run("ssh-keygen -A") // Generate multiple host keys
+                    .run("adduser -D bob") // Add a user
+                    .run("echo 'bob:passwordBob' | chpasswd") // Give it a password to unlock the user
+                    .run("mkdir -p /home/bob/.ssh") // Create the SSH config directory
+                    .entryPoint("/entrypoint.sh") // Sets bob as owner of anything under /home/bob and launches sshd
+                    .build())) //
+                            .withCopyFileToContainer(
+                                    MountableFile.forClasspathResource(TEST_KEYS + "/user01_authorized_keys"),
+                                    "/home/bob/.ssh/authorized_keys")
+                            .withCopyFileToContainer(MountableFile.forClasspathResource(TEST_RESOURCES + "/entrypoint.sh"),
+                                    "/entrypoint.sh")
+                            .waitingFor(Wait.forLogMessage(".*Server listening on :: port 22.*\\n", 1))
+                            .withExposedPorts(22) //
+                            .withLogConsumer(new Slf4jLogConsumer(LOG));
+
+    private final String privateKeyName;
+
+    public HostBoundPubKeyAuthTest(String privateKeyName) {
+        this.privateKeyName = privateKeyName;
+    }
+
+    @Parameterized.Parameters(name = "{0}")
+    public static Iterable<? extends String> privateKeyParams() {
+        return Arrays.asList( //
+                "user01_rsa_sha2_512_2048", //
+                "user01_rsa_sha2_512_4096", //
+                "user01_ed25519", //
+                "user01_ecdsa_256", //
+                "user01_ecdsa_384", //
+                "user01_ecdsa_521");
+    }
+
+    private String getPrivateKeyResource() {
+        return TEST_KEYS + '/' + privateKeyName;
+    }
+
+    private void checkLog(String logs) {
+        Matcher m = EXPECTED_LOG_ENTRY.matcher(logs);
+        assertTrue("Expected server log message not found", m.find());
+    }
+
+    @Test
+    public void testPubkeyAuth() throws Exception {
+        FileKeyPairProvider keyPairProvider = CommonTestSupportUtils.createTestKeyPairProvider(getPrivateKeyResource());
+        SshClient client = setupTestClient();
+        client.setKeyIdentityProvider(keyPairProvider);
+        client.start();
+
+        Integer actualPort = sshdContainer.getMappedPort(22);
+        String actualHost = sshdContainer.getHost();
+        try (ClientSession session = client.connect("bob", actualHost, actualPort).verify(CONNECT_TIMEOUT).getSession()) {
+            session.auth().verify(AUTH_TIMEOUT);
+            assertEquals(Integer.valueOf(0), session.getAttribute(DefaultClientKexExtensionHandler.HOSTBOUND_AUTHENTICATION));
+            checkLog(sshdContainer.getLogs());
+        } finally {
+            client.stop();
+        }
+    }
+}

--- a/sshd-core/src/test/resources/org/apache/sshd/client/auth/pubkey/entrypoint.sh
+++ b/sshd-core/src/test/resources/org/apache/sshd/client/auth/pubkey/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+chown -R bob /home/bob
+chmod 0600 /home/bob/.ssh/*
+/usr/sbin/sshd -D -ddd

--- a/sshd-mina/pom.xml
+++ b/sshd-mina/pom.xml
@@ -134,6 +134,7 @@
                         <!-- testcontainers filesystem building from classpath doesn't work from reusable test jar classpath -->
                         <exclude>**/ClientOpenSSHCertificatesTest.java</exclude>
                         <exclude>**/SessionReKeyHostKeyExchangeTest.java</exclude>
+                        <exclude>**/HostBoundPubKeyAuthTest.java</exclude>
                         <!-- reading files from classpath doesn't work correctly w/ reusable test jar -->
                         <exclude>**/OpenSSHCertificateTest.java</exclude>
                     </excludes>

--- a/sshd-netty/pom.xml
+++ b/sshd-netty/pom.xml
@@ -160,6 +160,7 @@
                         <!-- testcontainers filesystem building from classpath doesn't work from reusable test jar classpath -->
                         <exclude>**/ClientOpenSSHCertificatesTest.java</exclude>
                         <exclude>**/SessionReKeyHostKeyExchangeTest.java</exclude>
+                        <exclude>**/HostBoundPubKeyAuthTest.java</exclude>
                         <!-- reading files from classpath doesn't work correctly w/ reusable test jar -->
                         <exclude>**/OpenSSHCertificateTest.java</exclude>
                     </excludes>


### PR DESCRIPTION
Provide a KexExtensionParser for it; make the default client KEX
extension handler understand the "publickey-hostbound@openssh.com"
extension, and use it in UserAuthPublicKey.

The extension changes the auth name in the SSH_MSG_USERAUTH_REQUEST
from "pubkey" to "publickey-hostbound-v00@openssh.com" and includes
the server's public key in the message.

See https://github.com/openssh/openssh-portable/blob/807be686/PROTOCOL#L347