### PR TITLE
[SSHD-1257] Make ChannelOutputStream#flush no-op if the stream is already closed

### DIFF
--- a/sshd-core/src/main/java/org/apache/sshd/common/channel/ChannelOutputStream.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/channel/ChannelOutputStream.java
@@ -195,9 +195,7 @@ public class ChannelOutputStream extends OutputStream implements java.nio.channe
     public synchronized void flush() throws IOException {
         Channel channel = getChannel();
         if (!isOpen()) {
-            throw new SshChannelClosedException(
-                    channel.getChannelId(),
-                    "flush(" + this + ") length=" + bufferLength + " - stream is already closed");
+            return;
         }
 
         try {

--- a/sshd-core/src/main/java/org/apache/sshd/common/channel/ChannelOutputStream.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/channel/ChannelOutputStream.java
@@ -195,7 +195,9 @@ public class ChannelOutputStream extends OutputStream implements java.nio.channe
     public synchronized void flush() throws IOException {
         Channel channel = getChannel();
         if (!isOpen()) {
-            return;
+            throw new SshChannelClosedException(
+                    channel.getChannelId(),
+                    "flush(" + this + ") length=" + bufferLength + " - stream is already closed");
         }
 
         try {

--- a/sshd-core/src/main/java/org/apache/sshd/server/channel/ChannelSession.java
+++ b/sshd-core/src/main/java/org/apache/sshd/server/channel/ChannelSession.java
@@ -908,7 +908,7 @@ public class ChannelSession extends AbstractServerChannel {
 
         if (!isClosing()) {
             if (out != null) {
-                out.flush();
+                out.close();
             }
             sendEof();
             sendExitStatus(exitValue);


### PR DESCRIPTION
[SSHD-1257](https://issues.apache.org/jira/browse/SSHD-1257)

If the command implementation closes the output stream at the end of its execution, the ssh server hangs.
This changes the `ChannelOutputStream#flush` to become a no-op if it has been closed already.

Without change in `src/main` this fails with

```
java.lang.AssertionError: Wrong channel state after 11004 ms.: [TIMEOUT, OPENED]
        at org.junit.Assert.fail(Assert.java:89)
        at org.junit.Assert.assertTrue(Assert.java:42)
        at org.apache.sshd.server.channel.ChannelSessionTest.closeOutputStream(ChannelSessionTest.java:101)
```
indicating that the session doesn't get closed.