### PR TITLE
Clean up service support

### DIFF
--- a/sshd-core/src/main/java/org/apache/sshd/client/session/AbstractClientSession.java
+++ b/sshd-core/src/main/java/org/apache/sshd/client/session/AbstractClientSession.java
@@ -48,6 +48,7 @@ import org.apache.sshd.common.AttributeRepository;
 import org.apache.sshd.common.FactoryManager;
 import org.apache.sshd.common.NamedResource;
 import org.apache.sshd.common.RuntimeSshException;
+import org.apache.sshd.common.Service;
 import org.apache.sshd.common.SshConstants;
 import org.apache.sshd.common.SshException;
 import org.apache.sshd.common.channel.Channel;
@@ -632,8 +633,9 @@ public abstract class AbstractClientSession extends AbstractSession implements C
 
     @Override
     public KeyExchangeFuture switchToNoneCipher() throws IOException {
-        if (!(currentService instanceof AbstractConnectionService)
-                || !GenericUtils.isEmpty(((AbstractConnectionService) currentService).getChannels())) {
+        Service service = currentService.getService();
+        if (!(service instanceof AbstractConnectionService)
+                || !GenericUtils.isEmpty(((AbstractConnectionService) service).getChannels())) {
             throw new IllegalStateException(
                     "The switch to the none cipher must be done immediately after authentication");
         }

--- a/sshd-core/src/main/java/org/apache/sshd/common/session/helpers/CurrentService.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/session/helpers/CurrentService.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sshd.common.session.helpers;
+
+import java.util.Objects;
+
+import org.apache.sshd.common.Service;
+import org.apache.sshd.common.ServiceFactory;
+import org.apache.sshd.common.session.Session;
+import org.apache.sshd.common.util.ValidateUtils;
+import org.apache.sshd.common.util.buffer.Buffer;
+
+/**
+ * Holds the current SSH service for a {@link Session}.
+ *
+ * @author <a href="mailto:dev@mina.apache.org">Apache MINA SSHD Project</a>
+ */
+public class CurrentService {
+
+    /** The session this {@link CurrentService} belongs to. */
+    protected final Session session;
+
+    private String currentName;
+
+    private Service currentService;
+
+    /**
+     * Creates a new {@link CurrentService} instance belonging to the given {@link Session}.
+     *
+     * @param session {@link Session} the instance belongs to
+     */
+    protected CurrentService(Session session) {
+        this.session = Objects.requireNonNull(session, "No session given");
+    }
+
+    /**
+     * Retrieves the name of the current service.
+     *
+     * @return the name, or {@code null} if none is set
+     */
+    public synchronized String getName() {
+        return currentName;
+    }
+
+    /**
+     * Retrieves the current service.
+     *
+     * @return the current service, or {@code null} if none is set
+     */
+    public synchronized Service getService() {
+        return currentService;
+    }
+
+    /**
+     * Sets the current service and its name, and optionally starts the service.
+     *
+     * @param service {@link Service} to set
+     * @param name    Name of the service (the name of the {@link ServiceFactory} that created it)
+     * @param start   whether to start the service
+     */
+    public synchronized void set(Service service, String name, boolean start) {
+        ValidateUtils.checkNotNullAndNotEmpty(name, "No service name specified");
+        Objects.requireNonNull(service, "No service specified");
+        currentName = name;
+        currentService = service;
+        if (start) {
+            service.start();
+        }
+    }
+
+    /**
+     * Starts the current service.
+     */
+    public synchronized void start() {
+        ValidateUtils.checkState(currentService != null, "No current SSH service; cannot start");
+        currentService.start();
+    }
+
+    /**
+     * Processes a service request.
+     *
+     * @param  cmd       the command
+     * @param  buffer    the data received with the command
+     * @return           {@code true} if a current service is set, {@code false} if no current service exists
+     * @throws Exception when the current service fails
+     */
+    public synchronized boolean process(int cmd, Buffer buffer) throws Exception {
+        if (currentService != null) {
+            currentService.process(cmd, buffer);
+            return true;
+        }
+        return false;
+    }
+}

--- a/sshd-core/src/main/java/org/apache/sshd/common/session/helpers/SessionHelper.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/session/helpers/SessionHelper.java
@@ -81,8 +81,6 @@ import org.apache.sshd.core.CoreModuleProperties;
  * Contains split code in order to make {@link AbstractSession} class smaller
  */
 public abstract class SessionHelper extends AbstractKexFactoryManager implements Session {
-    /** Session level lock for regulating access to sensitive data */
-    protected final Object sessionLock = new Object();
 
     // Session timeout measurements
     protected Instant authStart = Instant.now();


### PR DESCRIPTION
Previous code declared a `SessionHelper.sessionLock` and used it in
`AbstractSession` around `doHandleMessage()` and in `ClientSessionImpl`
to partially guard service-related info (the service names and the next
service) against concurrent accesses.

The use of this `sessionLock` around handling messages was a way to
synchronize access to the `currentService` field.

Encapsulate the current service in a synchronized per-session
`CurrentService` object. In `ClientSessionImpl`, install a customized
object that also can handle switching the service (from authentication
to connections), and set the `initialRequestSent` flag atomically.

Message handling is serialized per session already via the `decodeLock`.
Remove the locking in `AbstractSession.handleMessage()`.

Note that like previous code `AbstractServerSession.startService()`
actually does _not_ call `start()` on the service. This looks like an
oversight, but doing so leads to flaky tests in my test runs.