### PR TITLE
Asynchronous handling of global requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,3 +198,5 @@ mvn -Pquick clean install
 ## [SSH Key Exchange](./docs/technical/kex.md)
 
 ## [TCP/IP Port Forwarding](./docs/technical/tcpip-forwarding.md)
+
+## [Global Requests](./docs/technical/global_requests.md)

--- a/docs/technical/global_requests.md
+++ b/docs/technical/global_requests.md
@@ -1,0 +1,153 @@
+## Global Requests
+
+**Global requests** are messages sent between an SSH client and an SSH server
+that are independent of any SSH channel. Such messages may just provide information
+to the peer, or they may instruct it to initiate certain actions. For example,
+starting or cancelling a [TCP/IP remote port forwarding](./tcpip-forwarding.md) is
+done with global requests. The OpenSSH host key update and rotation extension to
+the SSH protocol also uses global requests.
+
+Global requests are specified in [RFC 4254](https://tools.ietf.org/html/rfc4254#section-4).
+
+### Request kinds
+
+Global requests are identified by a request name, and the sender may indicate whether
+it wants a reply from the recipient. So there are two different kinds of global requests:
+
+* `want-reply=false`: asynchronous, "fire-and-forget" one-way messages.
+* `want-reply=true`: messages to which there is a reply, similar to a remote procedure call (RPC)
+
+Other than the request name, a global request does not carry any request identifier. So
+a crucial piece of a normal RPC protocol is missing in the SSH protocol. In RPC, a request
+normally carries a unique identifier (some sequence number), which is repeated in the reply,
+so that the sender can know which request the reply belongs to. In the SSH protocol, this
+request identifier is missing in the reply.
+
+All SSH packets are globally numbered in a session; so each message *does* have a unique
+identifier. If that sequence number were included in the reply to a global request, the
+sender could know easily which request a certain reply belonged to.
+
+RFC 4254 specifies instead that *"it is REQUIRED that replies to SSH_MSG_GLOBAL_REQUESTS
+MUST be sent in the same order as the corresponding request messages"*.
+
+In other words, if one party sends two global requests
+
+```
+  SSH_MSG_GLOBAL_REQUEST "a" want-reply=true ...
+  SSH_MSG_GLOBAL_REQUEST "b" want-reply=true ...
+```
+
+the other party must reply first to "a" and then to "b". (Note that in the two requests
+the request-name might also be the same, for instance two "tcpip-forward" requests.)
+
+The reply can be either a `SSH_MSG_REQUEST_SUCCESS` message, possibly with additional data,
+or a `SSH_MSG_REQUEST_FAILURE` message, which carries no additional data.
+
+To implement such RPC-style requests without request identifiers in the reply, the sender
+must keep a list of requests it made (per session), and when it receives a reply associate
+it with the frontmost request made.
+
+### Unknown requests
+
+If a recipient receives a global request with a request name it doesn't recognize, it
+is supposed to reply with a `SSH_MSG_REQUEST_FAILURE` message *if it was an RPC request*
+(`want-reply=true`). However, some SSH implementations respond with an `SSH_MSG_UNIMPLEMENTED`
+message instead. This may indicate that the recipient doesn't implement global requests
+at all. Replying on a global request with an unknown *request name* with an "unimplemented"
+message is not covered by the SSH RFCs.
+
+These "unimplemented" messages include the packet sequence number of the original
+message they refer to. [RFC 4253](https://tools.ietf.org/html/rfc4253#section-11.4)
+specifies that *"An implementation MUST respond to all unrecognized messages with an
+SSH_MSG_UNIMPLEMENTED message in the order in which the messages were received."*
+It is unspecified, though, whether this order and the order of global request replies
+from RFC 4254 are independent, or whether there must one single global order.
+
+To handle this, a sender must remember for each RPC-style request it makes also the
+packet sequence number so that it can remove the correct request from its list of
+global requests.
+
+### API
+
+Prior to version 2.9.0, `Session.request()` was the only way to make an RPC-style global
+request (`want-reply=true`). There was no support for making "fire-and-forget" global
+requests (`want-reply=false`), such requests had to be sent directly via `Session.writePacket()`.
+
+Also, the implementation of `Session.request()` was *synchronous*: it sent the request
+and then waited until the reply was received, blocking the thread executing the call.
+There could be only one pending RPC-style request. (Some other SSH libraries also use
+such a simplistic implementation, for instance JSch 0.1.55.)
+
+Synchronous requests, however, are not a good idea with the asynchronous I/O frameworks
+(NIO2, Mina, Netty) that Apache MINA sshd uses. If the request was executed on an I/O
+thread, that thread would be blocked and couldn't handle any other message. Moreover,
+if the request was made on an I/O thread, this means it runs as part of handling some
+message in an SSH session, and Apache MINA sshd handles all messages in an SSH session
+sequentially and holds a session-global lock: any other thread that might receive the
+reply would not be able to deliver it because that lock would still be held by the
+blocked thread waiting for the reply.
+
+The blocking `Session.request()` implementation still exists in Apache MINA sshd 2.9.0. It
+provides a simple interface and may be useful in cases where one knows that the invocation
+happens in an application thread, not in an I/O thread handling some other incoming message.
+
+But Apache MINA 2.9.0 adds another variant that associates a callback to handle the reply
+with the request. That version of `Session.request()` does *not* block waiting for the reply.
+It just sends the request and records the request together with the callback handler in
+its list of global requests, and when the reply arrives invokes that handler on whatever
+I/O thread received the reply.
+
+Both versions of `Session.request()` in Apache MINA 2.9.0 can also be used to send
+"fire-and-forget" global requests.
+
+The asynchronous version of `Session.request()` has the interface
+
+```java
+public GlobalRequestFuture request(Buffer buffer, String request, ReplyHandler replyHandler) throws IOException;
+```
+
+The `Buffer` is supposed to contain the full request, including the `request` name (for
+instance, "tcpip-forward"), the `want-reply` flag, and any additional data needed. This
+can be used to make RPC-style or "fire-and-forget" requests, and there are several possible
+ways to use it.
+
+* `want-reply=true` and `replyHandler != null`: the methods sends the request and returns a
+  future that is fulfilled when the request was actually sent. The future is fulfilled with
+  an exception if sending the request failed, or with `null` if it was sent successfully.
+  Once the reply is received, the handler is invoked with the SSH command (`SSH_MSG_REQUEST_SUCCESS`,
+  `SSH_MSG_REQUEST_FAILURE`, or `SSH_MSG_UNIMPLEMENTED`) and the buffer received.
+* `want-reply=true` and `replyHandler == null`: the method sends the request and returns a
+  future that is fulfilled with an exception if sending it failed, or if a `SSH_MSG_REQUEST_FAILURE`
+  or `SSH_MSG_UNIMPLEMENTED` reply was received. Otherwise the future is fulfilled with the received
+  Buffer once the reply has been received.
+* `want-reply=false`: the method sends the request and returns a future that is fulfilled when
+  the request was actually sent. The future is fulfilled with an exception if sending the request
+  failed, or with an empty buffer if it was sent successfully. If `replyHandler != null`, it is
+  invoked with an empty buffer once the request was sent.
+  
+If the method throws an `IOException`, the request was not sent, and the handler will not be
+invoked.
+
+### Implementation
+
+Global requests are implemented in Apache MINA sshd in [`AbstractSession`](../../sshd-core/src/main/java/org/apache/sshd/common/session/helpers/AbstractSession.java).
+
+The asynchronous `Session.request()` implementation uses a FIFO queue of requests sent, and in
+`AbstractSession.requestSuccess()` and `AbstractSession.requestFailure` associates a reply with the
+front-most request in that FIFO list. Only RPC-style requests with `want-reply=true` go onto this
+list. The FIFO list stores the [`GlobalRequestFuture`](../../sshd-core/src/main/java/org/apache/sshd/common/future/GlobalRequestFuture.java))
+of the requests made.
+
+Futures are put onto the tail of the FIFO list before actually sending the request to avoid
+a possible race condition between registering the future and a reply coming in very quickly.
+If the request cannot be sent, such a future for a request that never went out is removed
+again from the tail of the FIFO queue.
+
+The implementation also keeps track of the SSH packet sequence number of each request made
+so that it can remove the correct request from the FIFO list when a `SSH_MSG_UNIMPLEMENTED` is
+received. This sequence number is determined when the request message packet is encrypted,
+and is set on the `GlobalRequestFuture` of the global request via a callback. When an
+"unimplemented" message is received and the FIFO list contains a request future with a
+matching sequence number, that request is removed from the list irrespective of its
+position in the list, and the request is failed as if a `SSH_MSG_REQUEST_FAILURE` message
+had been received.

--- a/sshd-core/src/main/java/org/apache/sshd/client/session/ClientConnectionService.java
+++ b/sshd-core/src/main/java/org/apache/sshd/client/session/ClientConnectionService.java
@@ -20,6 +20,8 @@ package org.apache.sshd.client.session;
 
 import java.io.IOException;
 import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -28,6 +30,7 @@ import org.apache.sshd.agent.common.AgentForwardSupport;
 import org.apache.sshd.common.FactoryManager;
 import org.apache.sshd.common.SshConstants;
 import org.apache.sshd.common.SshException;
+import org.apache.sshd.common.future.GlobalRequestFuture;
 import org.apache.sshd.common.io.IoWriteFuture;
 import org.apache.sshd.common.session.Session;
 import org.apache.sshd.common.session.helpers.AbstractConnectionService;
@@ -125,11 +128,33 @@ public class ClientConnectionService
             buf.putBoolean(withReply);
 
             if (withReply) {
-                Buffer reply = session.request(heartbeatRequest, buf, heartbeatReplyMaxWait);
-                if (reply != null) {
+                Instant start = Instant.now();
+                CountDownLatch replyReceived = new CountDownLatch(1);
+                GlobalRequestFuture writeFuture = session.request(buf, heartbeatRequest, (cmd, reply) -> {
+                    replyReceived.countDown();
                     if (log.isTraceEnabled()) {
-                        log.trace("sendHeartBeat({}) received reply size={} for request={}",
-                                session, reply.available(), heartbeatRequest);
+                        log.trace("sendHeartBeat({}) received reply={} size={} for request={}", session,
+                                SshConstants.getCommandMessageName(cmd), reply.available(), heartbeatRequest);
+                    }
+                });
+                writeFuture.await(heartbeatReplyMaxWait);
+                Throwable t = writeFuture.getException();
+                if (t != null) {
+                    // We couldn't even send the request.
+                    throw new IOException(t.getMessage(), t);
+                }
+                Duration elapsed = Duration.between(start, Instant.now());
+                if (elapsed.compareTo(heartbeatReplyMaxWait) < 0) {
+                    long toWait = heartbeatReplyMaxWait.minus(elapsed).toMillis();
+                    if (toWait > 0) {
+                        try {
+                            replyReceived.await(toWait, TimeUnit.MILLISECONDS);
+                        } catch (InterruptedException e) {
+                            if (log.isTraceEnabled()) {
+                                log.trace("sendHeartBeat({}) interrupted waiting for reply to request={}", session,
+                                        heartbeatRequest);
+                            }
+                        }
                     }
                 }
             } else {

--- a/sshd-core/src/main/java/org/apache/sshd/common/future/GlobalRequestFuture.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/future/GlobalRequestFuture.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sshd.common.future;
+
+import org.apache.sshd.common.SshConstants;
+import org.apache.sshd.common.SshException;
+import org.apache.sshd.common.io.IoWriteFuture;
+import org.apache.sshd.common.util.GenericUtils;
+import org.apache.sshd.common.util.buffer.Buffer;
+
+/**
+ * A {@link DefaultSshFuture} that can be used to wait for the reply of an SSH_MSG_GLOBAL_REQUEST sent with
+ * {@code want-reply = true}.
+ *
+ * @see {@link org.apache.sshd.common.session.Session#request(Buffer, String, ReplyHandler)}
+ */
+public class GlobalRequestFuture extends DefaultSshFuture<GlobalRequestFuture>
+        implements SshFutureListener<IoWriteFuture> {
+
+    /**
+     * A {@code ReplyHandler} is invoked asynchronously when the reply for a request with {@code want-reply = true} is
+     * received. It is <em>not</em> invoked if the request could not be sent; to catch such cases
+     * {@link DefaultSshFuture#await()} the {@link GlobalRequestFuture} and check
+     * {@link GlobalRequestFuture#getException()}.
+     */
+    @FunctionalInterface
+    public interface ReplyHandler {
+
+        /**
+         * Invoked by the framework upon reception of the reply. If the global request was sent with
+         * {@code want-reply = false}, it is invoked with {@link SshConstants#SSH_MSG_REQUEST_SUCCESS} and an empty
+         * buffer after the request was successfully sent.
+         *
+         * @param cmd    the command received, can be one of {@link SshConstants#SSH_MSG_REQUEST_SUCCESS},
+         *               {@link SshConstants#SSH_MSG_UNIMPLEMENTED}, or {@link SshConstants#SSH_MSG_REQUEST_FAILURE}
+         * @param buffer the {@link Buffer} received
+         */
+        void accept(int cmd, Buffer buffer);
+    }
+
+    private final ReplyHandler handler;
+
+    private long sequenceNumber;
+
+    /**
+     * Creates a new {@link GlobalRequestFuture} for a global request. Synchronization occurs on the future itself. The
+     * future will be fulfilled once the reply has been received or an error occurred.
+     *
+     * @param request the request identifier
+     */
+    public GlobalRequestFuture(String request) {
+        this(request, null);
+    }
+
+    /**
+     * Creates a new {@link GlobalRequestFuture} for a global request. Synchronization occurs on the future itself. The
+     * future will be fulfilled once the request has been sent, or an error occurred during sending. The framework will
+     * invoke the handler once the reply has been received. For global requests with {@code want-reply = false}, the
+     * handler will be invoked with an empty buffer if the request was successfully sent.
+     *
+     * @param request the request identifier
+     * @param handler the {@link ReplyHandler}, or {@code null}
+     */
+    public GlobalRequestFuture(String request, ReplyHandler handler) {
+        super(request, null);
+        this.handler = handler;
+    }
+
+    @Override
+    public String getId() {
+        return (String) super.getId();
+    }
+
+    /**
+     * Retrieves this future's packet sequence number.
+     *
+     * @return the sequence number
+     */
+    public long getSequenceNumber() {
+        return sequenceNumber;
+    }
+
+    /**
+     * Sets the packet sequence number of the global request represented by this future.
+     *
+     * @param  number                   the packet sequence number
+     * @throws IllegalArgumentException if the number given is not an unsigned 32bit value
+     */
+    public void setSequenceNumber(long number) {
+        if (number < 0 || ((number & 0xFFFF_FFFFL) != number)) {
+            throw new IllegalArgumentException("Invalid sequence number " + number);
+        }
+        sequenceNumber = number;
+    }
+
+    /**
+     * Fulfills this future, marking it as failed.
+     *
+     * @param message An explanation of the failure reason
+     */
+    public void fail(String message) {
+        setValue(new SshException(GenericUtils.isEmpty(message) ? "Global request failure; unknown reason" : message));
+    }
+
+    /**
+     * Retrieves the {@link ReplyHandler} of this future, if any.
+     *
+     * @return the handler, or {@code null} if none was set
+     */
+    public ReplyHandler getHandler() {
+        return handler;
+    }
+
+    /**
+     * Obtains the reply {@link Buffer} if the request was successful. If called after {@link #isDone()} is
+     * {@code true}, a non-{@code null} result means the request was successful.
+     *
+     * @return the {@link Buffer}, or {@code null} if the request was not successful or the reply was not received yet
+     */
+    public Buffer getBuffer() {
+        Object value = getValue();
+        if (value instanceof Buffer) {
+            return (Buffer) value;
+        }
+        return null;
+    }
+
+    /**
+     * Retrieves an exception if the request failed. If called after {@link #isDone()} is {@code true}, a
+     * {@code null} result means the request did not fail.
+     *
+     * @return a failure reason, or {@code null} if there isn't one or if the request did not fail
+     */
+    public Throwable getException() {
+        Object value = getValue();
+        if (value instanceof Throwable) {
+            return (Throwable) value;
+        }
+        return null;
+    }
+
+    @Override
+    public void operationComplete(IoWriteFuture future) {
+        if (!future.isWritten()) {
+            // Sending the request message failed
+            Throwable ioe = future.getException();
+            if (ioe != null) {
+                setValue(ioe);
+            } else {
+                fail("Could not write global request " + getId() + " seqNo=" + getSequenceNumber());
+            }
+        }
+    }
+
+    @Override
+    public String toString() {
+        return super.toString() + "[seqNo=" + sequenceNumber + ']';
+    }
+}

--- a/sshd-core/src/test/java/org/apache/sshd/common/session/GlobalRequestTest.java
+++ b/sshd-core/src/test/java/org/apache/sshd/common/session/GlobalRequestTest.java
@@ -1,0 +1,420 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sshd.common.session;
+
+import java.security.PublicKey;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.apache.sshd.client.SshClient;
+import org.apache.sshd.client.global.OpenSshHostKeysHandler;
+import org.apache.sshd.client.session.ClientSession;
+import org.apache.sshd.common.NamedFactory;
+import org.apache.sshd.common.SshConstants;
+import org.apache.sshd.common.channel.RequestHandler;
+import org.apache.sshd.common.config.keys.KeyUtils;
+import org.apache.sshd.common.future.GlobalRequestFuture;
+import org.apache.sshd.common.session.helpers.AbstractConnectionServiceRequestHandler;
+import org.apache.sshd.common.signature.Signature;
+import org.apache.sshd.common.util.GenericUtils;
+import org.apache.sshd.common.util.ValidateUtils;
+import org.apache.sshd.common.util.buffer.Buffer;
+import org.apache.sshd.common.util.buffer.ByteArrayBuffer;
+import org.apache.sshd.server.SshServer;
+import org.apache.sshd.util.test.BaseTestSupport;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests for sending global requests.
+ */
+public class GlobalRequestTest extends BaseTestSupport {
+    private SshServer sshd;
+    private SshClient client;
+    private int port;
+
+    public GlobalRequestTest() {
+        super();
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        sshd = setupTestServer();
+        sshd.start();
+        port = sshd.getPort();
+
+        client = setupTestClient();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (sshd != null) {
+            sshd.stop(true);
+        }
+        if (client != null) {
+            client.stop();
+        }
+    }
+
+    @Test
+    public void testSingleRequestNoReply() throws Exception {
+        AtomicBoolean wrongWantReply = new AtomicBoolean(false);
+        CountDownLatch latch = new CountDownLatch(1);
+        List<RequestHandler<ConnectionService>> globalHandlers = new ArrayList<>(sshd.getGlobalRequestHandlers());
+        final String testRequest = getCurrentTestName() + "@sshd.org";
+        globalHandlers.add(new AbstractConnectionServiceRequestHandler() {
+            @Override
+            public Result process(ConnectionService connectionService, String request, boolean wantReply, Buffer buffer)
+                    throws Exception {
+                if (testRequest.equals(request)) {
+                    latch.countDown();
+                    if (wantReply) {
+                        wrongWantReply.set(true);
+                        return Result.ReplyFailure;
+                    }
+                    return Result.Replied;
+                }
+                return Result.Unsupported;
+            }
+        });
+        sshd.setGlobalRequestHandlers(globalHandlers);
+        client.start();
+        try (ClientSession session
+                = client.connect(getCurrentTestName(), TEST_LOCALHOST, port).verify(CONNECT_TIMEOUT).getSession()) {
+            session.addPasswordIdentity(getCurrentTestName());
+            session.auth().verify(AUTH_TIMEOUT);
+
+            Buffer buffer = session.createBuffer(SshConstants.SSH_MSG_GLOBAL_REQUEST);
+            buffer.putString(testRequest);
+            buffer.putBoolean(false); // want-reply false
+            Buffer reply = session.request(testRequest, buffer, DEFAULT_TIMEOUT);
+            assertNotNull("Expected a (fake) reply", reply);
+            assertEquals("Expected a (fake) success", 0, reply.available());
+            // Check that the server got it. Should take much less than 5 seconds.
+            assertTrue("Server did not get request", latch.await(5, TimeUnit.SECONDS));
+        }
+        assertFalse("Had a wrong want-reply", wrongWantReply.get());
+    }
+
+    @Test
+    public void testOverlappedRequests() throws Exception {
+        final int numberOfRequests = 6;
+        CountDownLatch latch = new CountDownLatch(numberOfRequests);
+        List<RequestHandler<ConnectionService>> globalHandlers = new ArrayList<>(sshd.getGlobalRequestHandlers());
+        final String testRequest = getCurrentTestName() + "@sshd.org";
+        globalHandlers.add(new AbstractConnectionServiceRequestHandler() {
+
+            private int count;
+
+            private boolean extraRequests;
+
+            @Override
+            public Result process(ConnectionService connectionService, String request, boolean wantReply, Buffer buffer)
+                    throws Exception {
+                boolean sendReplies = false;
+                if (testRequest.equals(request)) {
+                    latch.countDown();
+                    count++;
+                    if (extraRequests) {
+                        return Result.ReplySuccess;
+                    }
+                    sendReplies = true;
+                } else if (request.endsWith("-unimplemented")) {
+                    latch.countDown();
+                    // Trigger unimplemented handler
+                    connectionService.process(255, buffer);
+                    sendReplies = true;
+                }
+                if (sendReplies) {
+                    if (latch.getCount() == 0) {
+                        extraRequests = true;
+                        // Send alternating success or failure messages.
+                        Session session = connectionService.getSession();
+                        byte[] cmds = { SshConstants.SSH_MSG_REQUEST_SUCCESS, SshConstants.SSH_MSG_REQUEST_FAILURE };
+                        for (int i = 0; i < count; i++) {
+                            Buffer reply = session.createBuffer(cmds[i % 2], 2);
+                            if (i % 2 == 0) {
+                                reply.putByte((byte) ('1' + i));
+                            }
+                            session.writePacket(reply);
+                        }
+                    }
+                    return Result.Replied;
+                }
+                return Result.Unsupported;
+            }
+        });
+        sshd.setGlobalRequestHandlers(globalHandlers);
+        client.start();
+        try (ClientSession session = client.connect(getCurrentTestName(), TEST_LOCALHOST, port).verify(CONNECT_TIMEOUT)
+                .getSession()) {
+            session.addPasswordIdentity(getCurrentTestName());
+            session.auth().verify(AUTH_TIMEOUT);
+
+            GlobalRequestFuture[] requests = new GlobalRequestFuture[numberOfRequests];
+            for (int i = 0; i < numberOfRequests; i++) {
+                Buffer buffer = session.createBuffer(SshConstants.SSH_MSG_GLOBAL_REQUEST);
+                String req = testRequest + (((i % 3) == 2) ? "-unimplemented" : "");
+                buffer.putString(req);
+                buffer.putBoolean(true); // want-reply true
+                requests[i] = session.request(buffer, req, null);
+            }
+            // Now wait for them one by one and check them
+            for (int i = 0; i < numberOfRequests; i++) {
+                GlobalRequestFuture request = requests[i];
+                request.await(DEFAULT_TIMEOUT);
+                assertTrue("Unexpected timeout after " + DEFAULT_TIMEOUT + "on request " + i, request.isDone());
+            }
+            // Check that the server got it. Should take much less than 5 seconds.
+            assertTrue("Server did not get all requests", latch.await(5, TimeUnit.SECONDS));
+            int j = 0;
+            for (int i = 0; i < numberOfRequests; i++) {
+                GlobalRequestFuture request = requests[i];
+                Throwable failure;
+                switch (i % 3) {
+                    case 0: {
+                        j++;
+                        Buffer reply = request.getBuffer();
+                        assertTrue("Expected success for request " + i, reply != null);
+                        assertEquals("Expected a success", (byte) ('1' + j - 1), reply.getByte());
+                        break;
+                    }
+                    case 1:
+                        j++;
+                        failure = request.getException();
+                        assertNotNull("Expected failure for request " + i, failure);
+                        assertEquals("Unexpected failure reason for request " + i, "SSH_MSG_REQUEST_FAILURE",
+                                failure.getMessage());
+                        break;
+                    default:
+                        failure = request.getException();
+                        assertNotNull("Expected failure for request " + i, failure);
+                        assertEquals("Unexpected failure reason for request " + i, "SSH_MSG_UNIMPLEMENTED",
+                                failure.getMessage());
+                        break;
+                }
+            }
+            // Make another normal request just to be sure.
+            Buffer buffer = session.createBuffer(SshConstants.SSH_MSG_GLOBAL_REQUEST);
+            buffer.putString(testRequest);
+            buffer.putBoolean(true); // want-reply true
+            Buffer reply = session.request(testRequest, buffer, DEFAULT_TIMEOUT);
+            assertNotNull("Expected a success", reply);
+        }
+    }
+
+    @Test
+    public void testGlobalRequestWithReplyInMessageHandling() throws Exception {
+        // Use a crude implementation of the hostkey rotation OpenSSH extension. Note that the implementation in
+        // Apache MINA sshd server is incomplete, and for RSA keys does not match the OpenSSH implementation.
+        List<RequestHandler<ConnectionService>> globalHandlers = new ArrayList<>(sshd.getGlobalRequestHandlers());
+        final String testRequest = getCurrentTestName() + "@sshd.org";
+        // Apache MINA sshd doesn't implement the server-side sending of hostkeys-00@openssh.com yet (should occur
+        // right after successful user authentication), and with only one host key, it shouldn't send that message
+        // anyway even if it was implemented. So we fake this by telling the server explicitly that it should
+        // send us such a message via an extra global request ('testRequest') from the client.
+        globalHandlers.add(new AbstractConnectionServiceRequestHandler() {
+
+            @Override
+            public Result process(ConnectionService connectionService, String request, boolean wantReply, Buffer buffer)
+                    throws Exception {
+                if (testRequest.equals(request)) {
+                    Session session = connectionService.getSession();
+                    Buffer hostKeysBuffer = session.createBuffer(SshConstants.SSH_MSG_GLOBAL_REQUEST);
+                    hostKeysBuffer.putString("hostkeys-00@openssh.com");
+                    hostKeysBuffer.putBoolean(false); // want-reply
+                    sshd.getKeyPairProvider().loadKeys(session).forEach(kp -> hostKeysBuffer.putPublicKey(kp.getPublic()));
+                    session.writePacket(hostKeysBuffer);
+                    return Result.Replied;
+                }
+                return Result.Unsupported;
+            }
+        });
+        sshd.setGlobalRequestHandlers(globalHandlers);
+        GlobalRequestFuture[] req = { null };
+        List<PublicKey> keysFromServer = new ArrayList<>();
+        CountDownLatch latch = new CountDownLatch(1);
+        client.setGlobalRequestHandlers(Collections.singletonList(new OpenSshHostKeysHandler() {
+
+            @Override
+            protected Result handleHostKeys(
+                    Session session, Collection<? extends PublicKey> keys, boolean wantReply,
+                    Buffer buffer)
+                    throws Exception {
+                ValidateUtils.checkTrue(!wantReply, "Unexpected reply required for the host keys of %s", session);
+                assertFalse(GenericUtils.isEmpty(keys));
+                // Let the server prove ownership of all these keys
+                Buffer requestBuffer = session.createBuffer(SshConstants.SSH_MSG_GLOBAL_REQUEST);
+                requestBuffer.putString("hostkeys-prove-00@openssh.com");
+                requestBuffer.putBoolean(true); // want-reply
+                keys.forEach(requestBuffer::putPublicKey);
+                keysFromServer.addAll(keys);
+                // Make the request here synchronously, handle the reply asynchronously later on. In a real client-side
+                // implementation, you'd have to use a Thread or an ExecutorService, but here in the test we can just
+                // handle it in the test thread below.
+                //
+                // The split between making the request here and handling the reply asynchronously is a bit artificial
+                // and serves only to illustrate that this is possible. However, one could also execute the whole
+                // request asynchronously in a thread, with the request itself being a normal synchronous
+                // session.request() invocation.
+                req[0] = session.request(requestBuffer, "hostkeys-prove-00@openssh.com", null);
+                latch.countDown();
+                return Result.Replied;
+            }
+        }));
+        client.start();
+        try (ClientSession session = client.connect(getCurrentTestName(), TEST_LOCALHOST, port).verify(CONNECT_TIMEOUT)
+                .getSession()) {
+            session.addPasswordIdentity(getCurrentTestName());
+            session.auth().verify(AUTH_TIMEOUT);
+            // Tell the server to send us the hostkeys-00 message
+            Buffer buffer = session.createBuffer(SshConstants.SSH_MSG_GLOBAL_REQUEST);
+            buffer.putString(testRequest);
+            buffer.putBoolean(false); // want-reply
+            // For once use session.request() instead of session.writePacket() to make the request.
+            session.request(testRequest, buffer, DEFAULT_TIMEOUT);
+            // Wait until we've received the hostkeys-00 message, and have made our hostkeys-prove-00 request.
+            assertTrue("Did not get hostkeys-00 message in time", latch.await(5, TimeUnit.SECONDS));
+            assertNotNull("Did not make hostkeys-prove-00 request", req[0]);
+            // Wait until we have the server's hostkeys-prove-00 reply.
+            assertTrue("Did not get hostkeys-prove-00 reply in time", req[0].await(DEFAULT_TIMEOUT));
+            Buffer reply = req[0].getBuffer();
+            assertNotNull("Got a null hostkeys-prove-00 reply", req[0]);
+            // We should have as many signatures as we had gotten keys.
+            Collection<NamedFactory<Signature>> factories = client.getSignatureFactories();
+            keysFromServer.forEach(k -> {
+                byte[] signature = reply.getBytes();
+                // An Apache MINA sshd server uses the key type always, even for RSA keys (i.e., the SHA1 ssh-rsa
+                // signature). An OpenSSH server uses the signature algorithm negotiated in KEX if that was an RSA key
+                // and signature. (This protocol doesn't seem to be well designed. Would be better if the reply
+                // contained the signature algorithm identifiers.)
+                String algo = KeyUtils.getKeyType(k);
+                // Verify the signature.
+                Signature verifier = NamedFactory.create(factories, algo);
+                Buffer expected = new ByteArrayBuffer();
+                expected.putString("hostkeys-prove-00@openssh.com");
+                expected.putBytes(session.getSessionId());
+                expected.putPublicKey(k);
+                try {
+                    verifier.initVerifier(session, k);
+                    verifier.update(session, expected.array(), expected.rpos(), expected.available());
+                    assertTrue("Signature does not match", verifier.verify(session, signature));
+                } catch (Exception e) {
+                    throw new RuntimeException("Signature verification failed", e);
+                }
+            });
+            assertEquals("Did not consume all bytes from the reply", 0, reply.available());
+        }
+    }
+
+    @Test
+    public void testGlobalRequestWithReplyHandler() throws Exception {
+        // This is the same as above, but using a ReplyHandler. The whole key rotation exchange can be done completely
+        // inside the OpenSshHostKeysHandler without any need for any extra threads. The framework's thread handling the
+        // reply message will invoke the handler.
+        List<RequestHandler<ConnectionService>> globalHandlers = new ArrayList<>(sshd.getGlobalRequestHandlers());
+        final String testRequest = getCurrentTestName() + "@sshd.org";
+        // Fake 'testRequest' handler.
+        globalHandlers.add(new AbstractConnectionServiceRequestHandler() {
+
+            @Override
+            public Result process(ConnectionService connectionService, String request, boolean wantReply, Buffer buffer)
+                    throws Exception {
+                if (testRequest.equals(request)) {
+                    Session session = connectionService.getSession();
+                    Buffer hostKeysBuffer = session.createBuffer(SshConstants.SSH_MSG_GLOBAL_REQUEST);
+                    hostKeysBuffer.putString("hostkeys-00@openssh.com");
+                    hostKeysBuffer.putBoolean(false); // want-reply
+                    sshd.getKeyPairProvider().loadKeys(session).forEach(kp -> hostKeysBuffer.putPublicKey(kp.getPublic()));
+                    session.writePacket(hostKeysBuffer);
+                    return Result.Replied;
+                }
+                return Result.Unsupported;
+            }
+        });
+        sshd.setGlobalRequestHandlers(globalHandlers);
+        CountDownLatch replyHandled = new CountDownLatch(1);
+        List<String> testFailures = new ArrayList<>();
+        client.setGlobalRequestHandlers(Collections.singletonList(new OpenSshHostKeysHandler() {
+
+            @Override
+            protected Result handleHostKeys(
+                    Session session, Collection<? extends PublicKey> keys, boolean wantReply,
+                    Buffer buffer)
+                    throws Exception {
+                ValidateUtils.checkTrue(!wantReply, "Unexpected reply required for the host keys of %s", session);
+                assertFalse(GenericUtils.isEmpty(keys));
+                // Let the server prove ownership of all these keys
+                Buffer requestBuffer = session.createBuffer(SshConstants.SSH_MSG_GLOBAL_REQUEST);
+                requestBuffer.putString("hostkeys-prove-00@openssh.com");
+                requestBuffer.putBoolean(true); // want-reply
+                keys.forEach(requestBuffer::putPublicKey);
+                session.request(requestBuffer, "hostkeys-prove-00@openssh.com", (cmd, reply) -> {
+                    keys.forEach(k -> {
+                        byte[] signature = reply.getBytes();
+                        String algo = KeyUtils.getKeyType(k);
+                        // Verify the signature.
+                        Signature verifier = NamedFactory.create(client.getSignatureFactories(), algo);
+                        Buffer expected = new ByteArrayBuffer();
+                        expected.putString("hostkeys-prove-00@openssh.com");
+                        expected.putBytes(session.getSessionId());
+                        expected.putPublicKey(k);
+                        try {
+                            verifier.initVerifier(session, k);
+                            verifier.update(session, expected.array(), expected.rpos(), expected.available());
+                            // Cannot assert here; it's in another thread
+                            if (!verifier.verify(session, signature)) {
+                                testFailures.add("Signature did not validate for " + KeyUtils.getKeyType(k) + " "
+                                                 + KeyUtils.getFingerPrint(k));
+                            }
+                        } catch (Exception e) {
+                            testFailures.add("Signature verification failed " + e);
+                            throw new RuntimeException("Signature verification failed", e);
+                        }
+                        if (reply.available() > 0) {
+                            testFailures.add("Did not consume all bytes from the reply");
+                        }
+                    });
+                    replyHandled.countDown();
+                });
+                return Result.Replied;
+            }
+        }));
+        client.start();
+        try (ClientSession session = client.connect(getCurrentTestName(), TEST_LOCALHOST, port).verify(CONNECT_TIMEOUT)
+                .getSession()) {
+            session.addPasswordIdentity(getCurrentTestName());
+            session.auth().verify(AUTH_TIMEOUT);
+            // Tell the server to send us the hostkeys-00 message
+            Buffer buffer = session.createBuffer(SshConstants.SSH_MSG_GLOBAL_REQUEST);
+            buffer.putString(testRequest);
+            buffer.putBoolean(false); // want-reply
+            session.request(testRequest, buffer, DEFAULT_TIMEOUT);
+            // Wait until all keys verified.
+            assertTrue("Did not handle hostkeys-prove-00 message in time", replyHandled.await(10, TimeUnit.SECONDS));
+            assertEquals("Test failures", "", String.join(System.lineSeparator(), testFailures));
+        }
+    }
+}


### PR DESCRIPTION
Handling of global requests with want-reply=true was synchronous. This
is fine if the call is made on a non-I/O thread, but to be able to use
global requests in I/O threads, an asynchronous handling is needed.

Provide an asynchronous variant of Session.request() that returns a
future and that takes an optional reply handler as argument. If a
handler is given, it will be invoked by the framework once the reply
is received, on the I/O thread that received the reply. The future can
in this case be used to wait until the request has indeed be sent.
Without handler, the future can be used to await the reply on some
other thread, or to handle it via a future listener.

This makes global request handling much more flexible, avoids that a
synchronous implementation blocks an I/O thread, and it avoids problems
with making global requests while a key exchange is ongoing.

It also removes the restriction that there must be only one pending
global request per SSH session. The implementation keeps a FIFO list
of requests sent, and associates a reply with the front-most request
in that list. Only requests with want-reply=true enter that list.

Because of SSHD-968 we must also know the SSH message sequence number
of each global request made with want-reply=true. The previous
implementation assumed that the when a request was made, the next
packet written would be that request. But that may not be true when a
KEX is ongoing. Improve that implementation to report the sequence
number via a callback when the request's packet is indeed sent.

In AbstractSession.preClose(), fail all pending global requests.

Additionally, make Session.request() also work for global requests with
want-reply=false. Such requests can also be written directly with
Session.writePacket(), but it seems natural and convenient for users
of the library to also be able to use Session.request() for this.

Add some fairly advanced unit tests to verify the implementation. The
new unit tests showcase different implementations, somewhat simplified,
of a client-side OpenSshHostKeysHandler.

Add some technical documentation on global requests.