### PR TITLE
Fix hang in PortForwardingTest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1499,7 +1499,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <redirectTestOutputToFile>true</redirectTestOutputToFile>
                     <includes>
                         <include>**/*Test.java</include>
                     </includes>

--- a/sshd-core/src/main/java/org/apache/sshd/common/forward/DefaultForwarder.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/forward/DefaultForwarder.java
@@ -1090,14 +1090,13 @@ public class DefaultForwarder
 
             service.registerChannel(channel);
             channel.open().addListener(future -> {
+                session.resumeRead();
                 Throwable t = future.getException();
                 if (t != null) {
                     warn("Failed ({}) to open channel for session={}: {}",
                             t.getClass().getSimpleName(), session, t.getMessage(), t);
                     DefaultForwarder.this.service.unregisterChannel(channel);
                     channel.close(false);
-                } else {
-                    session.resumeRead();
                 }
             });
         }

--- a/sshd-core/src/main/java/org/apache/sshd/server/forward/TcpipServerChannel.java
+++ b/sshd-core/src/main/java/org/apache/sshd/server/forward/TcpipServerChannel.java
@@ -387,16 +387,14 @@ public class TcpipServerChannel extends AbstractServerChannel implements Forward
                 buffer.putBuffer(message);
                 session.suspendRead();
                 ThreadUtils.runAsInternal(() -> out.writeBuffer(buffer).addListener(f -> {
+                    session.resumeRead();
                     Throwable e = f.getException();
                     if (e != null) {
                         log.warn("messageReceived({}) channel={} signal close immediately=true due to {}[{}]", session,
                                 TcpipServerChannel.this, e.getClass().getSimpleName(), e.getMessage());
                         close(true);
-                    } else {
-                        if (log.isTraceEnabled()) {
-                            log.trace("messageReceived({}) channel={} message forwarded", session, TcpipServerChannel.this);
-                        }
-                        session.resumeRead();
+                    } else if (log.isTraceEnabled()) {
+                        log.trace("messageReceived({}) channel={} message forwarded", session, TcpipServerChannel.this);
                     }
                 }));
             }


### PR DESCRIPTION
TCP/IP forwarding: always resume reading, even in error cases

PortForwardingTest did hang sometimes in GitHub CI (Windows/Java 1.8).

Also: don't redirect test output to a file; these files are not
accessible once a GitHUb CI pod has terminated. By not redirecting,
the GitHUb CI build log has much more information useful to analyze
potential problems.