### PR TITLE
[SSHD-1281] Close Nio2Session properly on failure after connecting

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,3 +17,8 @@
 # [Version 2.8.0 to 2.9.0](./docs/changes/2.9.0.md)
 
 # Planned for next version
+
+## Bug fixes
+
+* [SSHD-1281](https://issues.apache.org/jira/browse/SSHD-1281) ClientSession.auth().verify() is terminated with timeout
+* [SSHD-1285](https://issues.apache.org/jira/browse/SSHD-1285) 2.9.0 release broken on Java 8

--- a/sshd-core/src/main/java/org/apache/sshd/common/io/nio2/Nio2Connector.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/io/nio2/Nio2Connector.java
@@ -179,20 +179,24 @@ public class Nio2Connector extends Nio2Service implements IoConnector {
                     }
                 }
 
-                debug("onCompleted - failed {} to start session: {}",
-                        t.getClass().getSimpleName(), t.getMessage(), t);
+                log.debug("onCompleted - failed to start session: {} {}", t.getClass().getSimpleName(), t.getMessage(), t);
 
-                try {
-                    socket.close();
-                } catch (IOException err) {
-                    if (debugEnabled) {
-                        log.debug("onCompleted - failed {} to close socket: {}",
-                                err.getClass().getSimpleName(), err.getMessage());
+                IoSession session = future.getSession();
+                if (session != null) {
+                    session.close(true);
+                } else {
+                    try {
+                        socket.close();
+                    } catch (IOException err) {
+                        if (debugEnabled) {
+                            log.debug("onCompleted - failed to close socket: {} {}", err.getClass().getSimpleName(),
+                                    err.getMessage());
+                        }
                     }
-                }
 
-                future.setException(t);
-                unmapSession(sessionId);
+                    future.setException(t);
+                    unmapSession(sessionId);
+                }
             }
         }
 


### PR DESCRIPTION
If there's an exception in Nio2Connector after the session was set on
the DefaultIoConnectFuture, a program might just hang on that session
until the next read or write attempt, or until a timeout expired.

This was caused by closing the underlying connection, but not properly
closing the already existing session, and because the session was
already set on the future, setting the exception had no effect anymore.

Fix this by immediately closing the Nio2Session properly in that case.