### PR TITLE
[SSHD-1288] SFTP: fix reading files that are being written

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,4 +22,5 @@
 
 * [SSHD-1281](https://issues.apache.org/jira/browse/SSHD-1281) ClientSession.auth().verify() is terminated with timeout
 * [SSHD-1285](https://issues.apache.org/jira/browse/SSHD-1285) 2.9.0 release broken on Java 8
+* [SSHD-1288](https://issues.apache.org/jira/browse/SSHD-1288) SFTP: fix reading files that are being written
 * [SSHD-1289](https://issues.apache.org/jira/browse/SSHD-1289) Deadlock during session exit


### PR DESCRIPTION
If data is appended while a file is read via SFTP, SftpInputStreamAsync
would enter an infinite loop if requestOffset >= fileSize + bufferSize.
Fix this and issue only sequential read requests once we detect that
we're beyond the expected EOF.