### PR TITLE
[SSHD-1290] ChannelAsyncOutputStream: improve logging

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,3 +24,4 @@
 * [SSHD-1285](https://issues.apache.org/jira/browse/SSHD-1285) 2.9.0 release broken on Java 8
 * [SSHD-1288](https://issues.apache.org/jira/browse/SSHD-1288) SFTP: fix reading files that are being written
 * [SSHD-1289](https://issues.apache.org/jira/browse/SSHD-1289) Deadlock during session exit
+* [SSHD-1290](https://issues.apache.org/jira/browse/SSHD-1290) Better logging in ChannelAsyncOutputStream


### PR DESCRIPTION
More precise logging in onWritten() to distinguish the cases better.