### PR TITLE
[SSHD-1293] Fix unbinding port forwarding for auto-alloc port

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,7 @@
 
 ## Bug fixes
 
+* [SSHD-1293](https://issues.apache.org/jira/browse/SSHD-1293) ExplicitPortForwardingTracker does not unbind auto-allocated port
 * [SSHD-1294](https://issues.apache.org/jira/browse/SSHD-1294) Close MinaServiceFactory instances properly
 
 ## Major code re-factoring

--- a/sshd-core/src/main/java/org/apache/sshd/client/session/forward/ExplicitPortForwardingTracker.java
+++ b/sshd-core/src/main/java/org/apache/sshd/client/session/forward/ExplicitPortForwardingTracker.java
@@ -56,7 +56,7 @@ public class ExplicitPortForwardingTracker extends PortForwardingTracker impleme
         if (open.getAndSet(false)) {
             PortForwardingManager manager = getClientSession();
             if (isLocalForwarding()) {
-                manager.stopLocalPortForwarding(getLocalAddress());
+                manager.stopLocalPortForwarding(getBoundAddress());
             } else {
                 manager.stopRemotePortForwarding(getRemoteAddress());
             }

--- a/sshd-core/src/test/java/org/apache/sshd/common/forward/PortForwardingTest.java
+++ b/sshd-core/src/test/java/org/apache/sshd/common/forward/PortForwardingTest.java
@@ -48,6 +48,7 @@ import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
@@ -551,6 +552,7 @@ public class PortForwardingTest extends BaseTestSupport {
         AtomicReference<SshdSocketAddress> remoteAddressHolder = new AtomicReference<>();
         AtomicReference<SshdSocketAddress> boundAddressHolder = new AtomicReference<>();
         AtomicInteger tearDownSignal = new AtomicInteger(0);
+        AtomicBoolean tearDownSignalInvoked = new AtomicBoolean();
         @SuppressWarnings("checkstyle:anoninnerlength")
         PortForwardingEventListener listener = new PortForwardingEventListener() {
             @Override
@@ -560,6 +562,7 @@ public class PortForwardingTest extends BaseTestSupport {
                     throws IOException {
                 assertTrue("Unexpected remote tunnel has been torn down: address=" + address, localForwarding);
                 assertEquals("Tear down indication not invoked", 1, tearDownSignal.get());
+                tearDownSignalInvoked.set(true);
             }
 
             @Override
@@ -659,6 +662,7 @@ public class PortForwardingTest extends BaseTestSupport {
                 tracker.close();
             }
             assertFalse("Tracker not marked as closed", tracker.isOpen());
+            assertTrue("Tear down signal did not occur", tearDownSignalInvoked.get());
         } finally {
             client.removePortForwardingEventListener(listener);
         }


### PR DESCRIPTION
This fixes de-allocating / unbinding a local port forwarding binding when using a dynamic auto-allocated port.

The information "localAddress" is controlled by the user and may contain still a port `0` which means auto-allocating a local port; the actual local port is available in 'boundAddress". However, "DefaultForwarder" tracks
the actual port mappings only.

I have run the tests locally with a Java 8 without issues.

Related issue https://issues.apache.org/jira/browse/SSHD-1293

I also added an additional commit modifying the test covering the missing signal. If you are fine with this, I'd squash them. Or maybe as an additional test?