### PR TITLE
Fix: close session when timeout during connect

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,7 @@
 ## Bug fixes
 
 * [SSHD-1294](https://issues.apache.org/jira/browse/SSHD-1294) Close MinaServiceFactory instances properly
+* [SSHD-1295](https://issues.apache.org/jira/browse/SSHD-1295) Close sessions when ConnectFuture.verify() timed out
 
 ## Major code re-factoring
 

--- a/sshd-core/src/main/java/org/apache/sshd/client/future/ConnectFuture.java
+++ b/sshd-core/src/main/java/org/apache/sshd/client/future/ConnectFuture.java
@@ -18,6 +18,8 @@
  */
 package org.apache.sshd.client.future;
 
+import java.util.concurrent.TimeoutException;
+
 import org.apache.sshd.client.session.ClientSession;
 import org.apache.sshd.client.session.ClientSessionHolder;
 import org.apache.sshd.common.future.SshFuture;
@@ -78,4 +80,13 @@ public interface ConnectFuture
      * Cancels the connection attempt and notifies all threads waiting for this future.
      */
     void cancel();
+
+    /**
+     * Like {@link #setSession(ClientSession)} but sets the session only if there has been no time-out on the future
+     * yet. This method is invoked by SSHD internally. Please do not call this method directly.
+     *
+     * @param  session          The {@link ClientSession}
+     * @throws TimeoutException if a {@link #verify(long)} has already timed out on the future
+     */
+    void setSessionIfNotTimeout(ClientSession session) throws TimeoutException;
 }

--- a/sshd-core/src/main/java/org/apache/sshd/client/future/DefaultConnectFuture.java
+++ b/sshd-core/src/main/java/org/apache/sshd/client/future/DefaultConnectFuture.java
@@ -20,6 +20,7 @@ package org.apache.sshd.client.future;
 
 import java.io.IOException;
 import java.util.Objects;
+import java.util.concurrent.TimeoutException;
 
 import org.apache.sshd.client.session.ClientSession;
 import org.apache.sshd.common.RuntimeSshException;
@@ -89,5 +90,11 @@ public class DefaultConnectFuture extends DefaultVerifiableSshFuture<ConnectFutu
     public void setException(Throwable exception) {
         Objects.requireNonNull(exception, "No exception provided");
         setValue(exception);
+    }
+
+    @Override
+    public void setSessionIfNotTimeout(ClientSession session) throws TimeoutException {
+        Objects.requireNonNull(session, "No client session provided");
+        setValueIfNotTimedOut(session);
     }
 }


### PR DESCRIPTION
Hi there, 

We have encouraged an issue in which the SSHD doesn’t close the session when connecting timeout. 



The code we are using is attached here. https://gist.github.com/onyas/fda8ccf2d373c743ccec8f648782d078  
The TCP socket is still ESTABLISHED after `sshClient.connect()` threw an exception. 
<img width="624" alt="image" src="https://user-images.githubusercontent.com/1592582/187923401-b6d21969-b3a9-4f45-8ec6-03d709a3dc89.png">

If I set the timeout to 1 millisecond, the `sshClient.connnect()` will throw an exception, since it’s timeout so the session is still null, and it doesn't help if we call `session.close()`. 

And we know we cloud call `sshClient.stop()`, but in our scenario, we reuse the same instance so we couldn’t do that.

After checking the source code, we find the SSHD didn’t close the session when timeout. So I created this pull request to help close the session. 

Please help review and thanks. 