### PR TITLE
ChannelAsyncOutputStream: fix closing gracefully

### DIFF
--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -74,3 +74,11 @@ jobs:
 
       - name: Build with maven
         run: mvn --errors --activate-profiles ci --no-transfer-progress package
+
+      - name: Archive test results and logs
+        # if: success() || failure() to also get the test results on successful runs.
+        if: failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-results-${{ matrix.java }}-${{ matrix.os }}
+          path: sshd-*/target/surefire-*

--- a/sshd-core/src/main/java/org/apache/sshd/server/channel/ChannelSession.java
+++ b/sshd-core/src/main/java/org/apache/sshd/server/channel/ChannelSession.java
@@ -126,8 +126,9 @@ public class ChannelSession extends AbstractServerChannel {
     @Override
     protected Closeable getInnerCloseable() {
         return builder()
-                .sequential(new CommandCloseable(), super.getInnerCloseable())
+                .close(new CommandCloseable())
                 .parallel(asyncOut, asyncErr)
+                .close(super.getInnerCloseable())
                 .run(toString(), this::closeImmediately0)
                 .build();
     }

--- a/sshd-core/src/test/java/org/apache/sshd/common/forward/PortForwardingTest.java
+++ b/sshd-core/src/test/java/org/apache/sshd/common/forward/PortForwardingTest.java
@@ -81,6 +81,7 @@ import org.apache.sshd.util.test.CoreTestSupportUtils;
 import org.apache.sshd.util.test.JSchLogger;
 import org.apache.sshd.util.test.SimpleUserInfo;
 import org.junit.AfterClass;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.FixMethodOrder;
@@ -327,8 +328,14 @@ public class PortForwardingTest extends BaseTestSupport {
         }
     }
 
+    private boolean isMina() {
+        return "MinaServiceFactoryFactory".equals(getIoServiceProvider().getClass().getSimpleName());
+    }
+
     @Test
     public void testRemoteForwardingSecondTimeInSameSession() throws Exception {
+        // TODO: remove assumption once DIRMINA-1169 is fixed in the MINA version we are using
+        Assume.assumeFalse("Skipped for MINA transport; can work reliably only once DIRMINS-1169 is fixed", isMina());
         Session session = createSession();
         try {
             int forwardedPort = CoreTestSupportUtils.getFreePort();


### PR DESCRIPTION
Window expansions can occur even when the channel is already closing. Abort writing only if the stream is closed immediately, or is already closed.