### PR TITLE
[SSHD-1297] Improvements for reading public keys

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,6 +32,8 @@
 
 ## Minor code helpers
 
+* New utility method `KeyUtils.loadPublicKey()` to read a public key file.
+
 ## Behavioral changes and enhancements
 
 * Netty I/O back-end: respect configurations for `CoreModuleProperties.SOCKET_BACKLOG` and `CoreModuleProperties.SOCKET_REUSEADDR`.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,7 @@
 
 * [SSHD-1293](https://issues.apache.org/jira/browse/SSHD-1293) ExplicitPortForwardingTracker does not unbind auto-allocated port
 * [SSHD-1294](https://issues.apache.org/jira/browse/SSHD-1294) Close MinaServiceFactory instances properly
+* [SSHD-1297](https://issues.apache.org/jira/browse/SSHD-1297) Avoid OutOfMemoryError when reading a public key from a corrupted Buffer
 
 ## Major code re-factoring
 

--- a/sshd-common/src/main/java/org/apache/sshd/common/config/keys/KeyUtils.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/config/keys/KeyUtils.java
@@ -319,6 +319,25 @@ public final class KeyUtils {
     }
 
     /**
+     * Reads a single {@link PublicKey} from a public key file.
+     *
+     * @param  path                     {@link Path} of the file to read; must not be {@code null}
+     * @return                          the {@link PublicKey}, may be {@code null} if the file is empty
+     * @throws IOException              if the file cannot be read or parsed
+     * @throws GeneralSecurityException if the file contents cannot be read as a single {@link PublicKey}
+     */
+    public static PublicKey loadPublicKey(Path path) throws IOException, GeneralSecurityException {
+        List<AuthorizedKeyEntry> keys = AuthorizedKeyEntry.readAuthorizedKeys(Objects.requireNonNull(path));
+        if (GenericUtils.isEmpty(keys)) {
+            return null;
+        }
+        if (keys.size() > 1) {
+            throw new InvalidKeySpecException("Public key file contains multiple entries: " + path);
+        }
+        return keys.get(0).resolvePublicKey(null, PublicKeyEntryResolver.IGNORING);
+    }
+
+    /**
      * @param  keyType                  The key type - {@code OpenSSH} name - e.g., {@code ssh-rsa, ssh-dss}
      * @param  keySize                  The key size (in bits)
      * @return                          A {@link KeyPair} of the specified type and size

--- a/sshd-common/src/main/java/org/apache/sshd/common/util/buffer/Buffer.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/util/buffer/Buffer.java
@@ -513,11 +513,7 @@ public abstract class Buffer implements Readable {
      */
     public PublicKey getPublicKey(BufferPublicKeyParser<? extends PublicKey> parser) throws SshException {
         int ow = wpos();
-        int len = getInt();
-        if (len < 0) {
-            throw new SshException("Illogical public key length: " + len);
-        }
-
+        int len = ensureAvailable(getInt());
         wpos(rpos() + len);
         try {
             return getRawPublicKey(parser);

--- a/sshd-common/src/test/java/org/apache/sshd/common/util/buffer/BufferTest.java
+++ b/sshd-common/src/test/java/org/apache/sshd/common/util/buffer/BufferTest.java
@@ -100,4 +100,14 @@ public class BufferTest extends JUnitTestSupport {
             assertEquals("Value not wiped at index=" + index, 0, bytes[index]);
         }
     }
+
+    @Test
+    public void testGetPublicKeyCorrupted() {
+        ByteArrayBuffer buffer = new ByteArrayBuffer(8);
+        buffer.putInt(Integer.MAX_VALUE - 10000);
+        buffer.putInt(0);
+        Throwable e = assertThrows(Throwable.class, () -> buffer.getPublicKey());
+        assertFalse(e instanceof OutOfMemoryError);
+        assertEquals(8, buffer.array().length);
+    }
 }


### PR DESCRIPTION
Avoid OOMEs when reading from a Buffer when the key length is out of bounds, and provide a utility method to read a public key file.