### PR TITLE
[SSHD-1173] Simplify writing in ChannelAsyncOutputStream

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,7 @@
 
 ## Bug fixes
 
+* [SSHD-1173](https://issues.apache.org/jira/browse/SSHD-1173) Not fully using up a channel window may lead to hangs (see [Channel windows](#channelwindows0) below)
 * [SSHD-1293](https://issues.apache.org/jira/browse/SSHD-1293) ExplicitPortForwardingTracker does not unbind auto-allocated port
 * [SSHD-1294](https://issues.apache.org/jira/browse/SSHD-1294) Close MinaServiceFactory instances properly
 * [SSHD-1297](https://issues.apache.org/jira/browse/SSHD-1297) Avoid OutOfMemoryError when reading a public key from a corrupted Buffer
@@ -40,3 +41,28 @@
 * MINA I/O back-end: use `CoreModuleProperties.NIO2_READ_BUFFER_SIZE` for the initial read buffer size, if set.
   A new `CoreModuleProperties.MIN_READ_BUFFER_SIZE` can be set to control the minimum read buffer size (64
   bytes by default in Apache MINA).
+
+<!-- --><a id="channelwindows0"></a>
+
+### Channel windows
+
+Previous versions of Apache MINA sshd (from 2.6.0 to 2.9.1) did not always fully use up a channel window
+and waited for a `SSH_MSG_CHANNEL_WINDOW_ADJUST` message from the peer instead. It did so if the available
+window size was smaller than the packet size of the channel, and also smaller than the amount of data still
+to be written. There were settings to change this behavior and always fully use up a channel window: these
+settings were
+
+* `SftpModuleProperties.CHUNK_IF_WINDOW_LESS_THAN_PACKET`
+* `CoreModuleProperties.ASYNC_SERVER_STDOUT_CHUNK_BELOW_WINDOW_SIZE`
+* `CoreModuleProperties.ASYNC_SERVER_STDERR_CHUNK_BELOW_WINDOW_SIZE`
+
+By default, they were `false`; if set to `true`, the window would be used fully.
+
+Not using up a channel window may lead to hangs with peers that send the `SSH_MSG_CHANNEL_WINDOW_ADJUST` message
+only when the window size is very low, or even zero. The SSH RFCs do not mandate any particular point at which
+an implementation should adjust the window. OpenSSH and Apache MINA sshd itself do so when half of the window
+is used up, but there are other implementations that do so only when the available window size becomes zero.
+
+In this version, the above settings have been removed. Apache MINA sshd behaves always as if they were `true`, i.e.,
+if there is some window space and there is data to write, data will be written. See Apache MINA sshd issues
+[SSHD-1123](https://issues.apache.org/jira/browse/SSHD-1123) and [SSHD-1173](https://issues.apache.org/jira/browse/SSHD-1173).

--- a/sshd-core/src/main/java/org/apache/sshd/client/channel/AbstractClientChannel.java
+++ b/sshd-core/src/main/java/org/apache/sshd/client/channel/AbstractClientChannel.java
@@ -417,12 +417,14 @@ public abstract class AbstractClientChannel extends AbstractChannel implements C
         if (asyncOut != null) {
             asyncOut.write(new ByteArrayBuffer(data, off, (int) len));
         } else if (out != null) {
-            out.write(data, off, (int) len);
-            out.flush();
-
-            if (invertedOut == null) {
-                Window wLocal = getLocalWindow();
-                wLocal.consumeAndCheck(len);
+            try {
+                out.write(data, off, (int) len);
+                out.flush();
+            } finally {
+                if (invertedOut == null) {
+                    Window wLocal = getLocalWindow();
+                    wLocal.consumeAndCheck(len);
+                }
             }
         } else {
             throw new IllegalStateException("No output stream for channel");
@@ -441,12 +443,14 @@ public abstract class AbstractClientChannel extends AbstractChannel implements C
         if (asyncErr != null) {
             asyncErr.write(new ByteArrayBuffer(data, off, (int) len));
         } else if (err != null) {
-            err.write(data, off, (int) len);
-            err.flush();
-
-            if (invertedErr == null) {
-                Window wLocal = getLocalWindow();
-                wLocal.consumeAndCheck(len);
+            try {
+                err.write(data, off, (int) len);
+                err.flush();
+            } finally {
+                if (invertedErr == null) {
+                    Window wLocal = getLocalWindow();
+                    wLocal.consumeAndCheck(len);
+                }
             }
         } else {
             throw new IllegalStateException("No error stream for channel");

--- a/sshd-core/src/main/java/org/apache/sshd/core/CoreModuleProperties.java
+++ b/sshd-core/src/main/java/org/apache/sshd/core/CoreModuleProperties.java
@@ -238,24 +238,6 @@ public final class CoreModuleProperties {
     public static final Property<Boolean> REQUEST_SUBSYSTEM_REPLY
             = Property.bool("channel-subsystem-want-reply", true);
 
-    /**
-     * If should chunk data sent via {@code ChannelAsyncOutputStream} when reported remote STDOUT stream window size is
-     * less than its packet size
-     *
-     * @see <A HREF="https://issues.apache.org/jira/browse/SSHD-1123">SSHD-1123</A>
-     */
-    public static final Property<Boolean> ASYNC_SERVER_STDOUT_CHUNK_BELOW_WINDOW_SIZE
-            = Property.bool("server-async-stdout-chunk-below-window-size", false);
-
-    /**
-     * If should chunk data sent via {@code ChannelAsyncOutputStream} when reported remote STDERR stream window size is
-     * less than its packet size
-     *
-     * @see <A HREF="https://issues.apache.org/jira/browse/SSHD-1123">SSHD-1123</A>
-     */
-    public static final Property<Boolean> ASYNC_SERVER_STDERR_CHUNK_BELOW_WINDOW_SIZE
-            = Property.bool("server-async-stderr-chunk-below-window-size", false);
-
     public static final Property<Integer> PROP_DHGEX_CLIENT_MIN_KEY
             = Property.integer("dhgex-client-min");
 

--- a/sshd-core/src/main/java/org/apache/sshd/server/forward/TcpipServerChannel.java
+++ b/sshd-core/src/main/java/org/apache/sshd/server/forward/TcpipServerChannel.java
@@ -446,8 +446,7 @@ public class TcpipServerChannel extends AbstractServerChannel implements Forward
         public void exceptionCaught(IoSession session, Throwable cause) throws Exception {
             boolean immediately = !session.isOpen();
             if (log.isDebugEnabled()) {
-                log.debug("exceptionCaught({}) signal close immediately={} due to {}[{}]", TcpipServerChannel.this, immediately,
-                        cause.getClass().getSimpleName(), cause.getMessage());
+                log.debug("exceptionCaught({}) signal close immediately={}", TcpipServerChannel.this, immediately, cause);
             }
             close(immediately);
         }

--- a/sshd-core/src/test/java/org/apache/sshd/common/channel/ChannelAsyncOutputStreamTest.java
+++ b/sshd-core/src/test/java/org/apache/sshd/common/channel/ChannelAsyncOutputStreamTest.java
@@ -100,14 +100,8 @@ public class ChannelAsyncOutputStreamTest extends BaseTestSupport {
     }
 
     @Test
-    public void testNoChunkingIfRemoteWindowSmallerThanPacketSize() throws IOException {
-        ChannelAsyncOutputStream channelAsyncOutputStream = new ChannelAsyncOutputStream(channel, (byte) 0);
-        checkChangeOfRemoteWindowSizeOnBufferWrite(channelAsyncOutputStream, 30000, 32000, 50000, 30000);
-    }
-
-    @Test
     public void testChunkingIfRemoteWindowSmallerThanPacketSize() throws IOException {
-        ChannelAsyncOutputStream channelAsyncOutputStream = new ChannelAsyncOutputStream(channel, (byte) 0, true);
+        ChannelAsyncOutputStream channelAsyncOutputStream = new ChannelAsyncOutputStream(channel, (byte) 0);
         checkChangeOfRemoteWindowSizeOnBufferWrite(channelAsyncOutputStream, 30000, 32000, 50000, 0);
     }
 

--- a/sshd-sftp/src/main/java/org/apache/sshd/sftp/SftpModuleProperties.java
+++ b/sshd-sftp/src/main/java/org/apache/sshd/sftp/SftpModuleProperties.java
@@ -229,15 +229,6 @@ public final class SftpModuleProperties {
     public static final Property<Integer> SFTP_VERSION
             = SshServerConfigFileReader.SFTP_FORCED_VERSION_PROP;
 
-    /**
-     * Determines the chunking behaviour, if the remote window size is smaller than the packet size. Can be used to
-     * establish compatibility with certain clients, that wait until the window size is 0 before adjusting it.
-     *
-     * @see <A HREF="https://issues.apache.org/jira/browse/SSHD-1123">SSHD-1123</A>
-     */
-    public static final Property<Boolean> CHUNK_IF_WINDOW_LESS_THAN_PACKET
-            = Property.bool("sftp-chunk-if-window-less-than-packet", false);
-
     private SftpModuleProperties() {
         throw new UnsupportedOperationException("No instance");
     }

--- a/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/impl/DefaultSftpClient.java
+++ b/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/impl/DefaultSftpClient.java
@@ -566,8 +566,7 @@ public class DefaultSftpClient extends AbstractSftpClient {
 
         protected ChannelAsyncOutputStream createAsyncInput(Session session) {
             return new ChannelAsyncOutputStream(
-                    this, SshConstants.SSH_MSG_CHANNEL_DATA,
-                    SftpModuleProperties.CHUNK_IF_WINDOW_LESS_THAN_PACKET.getRequired(session)) {
+                    this, SshConstants.SSH_MSG_CHANNEL_DATA) {
                 @SuppressWarnings("synthetic-access")
                 @Override
                 protected CloseFuture doCloseGracefully() {


### PR DESCRIPTION
Remove the option not to send a chunk when the remote window is smaller than the packet size, and we're trying to write more than the remote widow size bytes. This option may lead to hangs with peers that wait with sending their window adjustment until the window size is very low, or even zero.

RFC 4254 does not mandate any particular point at which an SSH implementation should send a window adjustment. Implementations doing so only once the window has been fully consumed are well within the bounds of the specification.

Therefore remove this option altogether, and always send some data if the window size is > 0. Refactor the writePacket() method to make it much simpler and clearer.

Client options removed:

* SftpModuleProperties.CHUNK_IF_WINDOW_LESS_THAN_PACKET
* CoreModuleProperties.ASYNC_SERVER_STDOUT_CHUNK_BELOW_WINDOW_SIZE
* CoreModuleProperties.ASYNC_SERVER_STDERR_CHUNK_BELOW_WINDOW_SIZE
* ChannelAsyncOutputStream(Channel, byte, boolean) constructor

These options were by default all false, potentially leading to hangs as described above. Already [SSHD-1123] had pointed out that problem, and bug [SSHD-1207] might also be caused by this. The feature was introduced in [SSHD-979] in commit e85b67e0 and later modified in commit 536d0663.