### PR TITLE
[SSHD-1303] AbstractClientChannel: use null stream for redirected stderr

### DIFF
--- a/sshd-common/src/main/java/org/apache/sshd/common/io/IoReadFuture.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/io/IoReadFuture.java
@@ -26,12 +26,25 @@ import org.apache.sshd.common.util.buffer.Buffer;
  * @author <a href="mailto:dev@mina.apache.org">Apache MINA SSHD Project</a>
  */
 public interface IoReadFuture extends SshFuture<IoReadFuture>, VerifiableFuture<IoReadFuture> {
+
+    /**
+     * Retrieves the buffer data was read into.
+     *
+     * @return the buffer, {@code null} if {@link #isDone()} {@code == false}
+     */
     Buffer getBuffer();
 
+    /**
+     * Retrieves the number of bytes read.
+     *
+     * @return The number of bytes read, or -1 if the source of the read has been exhausted (is at EOF), or zero if the
+     *         read is not done yet ({@link #isDone()} {@code == false})
+     */
     int getRead();
 
     /**
-     * Returns the cause of the read failure.
+     * Returns the cause of the read failure. An {@link java.io.EOFException} indicates that nothing was read because
+     * the source of the read is exhausted.
      *
      * @return {@code null} if the read operation is not finished yet, or if the read attempt is successful (use
      *         {@link #isDone()} to distinguish between the two).


### PR DESCRIPTION
If a channel's error stream has been redirected to the output stream, return null streams from getAsyncErr() and getInvertedErr(). Since they are redirected, application code should never see any data on them.

Also document the IoReadFuture better, and change the single implementation of that interface to match. While the future is not done, operations return null or zero. EOF is signaled by getRead() == -1, or getException() returning an EOFException.