### PR TITLE
[SSHD-1302] AbstractClientChannel: don't close inverted output streams

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,8 @@
 * [SSHD-1293](https://issues.apache.org/jira/browse/SSHD-1293) ExplicitPortForwardingTracker does not unbind auto-allocated port
 * [SSHD-1294](https://issues.apache.org/jira/browse/SSHD-1294) Close MinaServiceFactory instances properly
 * [SSHD-1297](https://issues.apache.org/jira/browse/SSHD-1297) Avoid OutOfMemoryError when reading a public key from a corrupted Buffer
+* [SSHD-1302](https://issues.apache.org/jira/browse/SSHD-1302) Reading from Channel.getInvertedOut() after EOF was reached throws IOException instead of returning -1
+* [SSHD-1303](https://issues.apache.org/jira/browse/SSHD-1303) Reading from redirected Channel.getInvertedErr() delivers stdout; should be at EOF
 
 ## Major code re-factoring
 

--- a/sshd-core/src/main/java/org/apache/sshd/client/channel/AbstractClientChannel.java
+++ b/sshd-core/src/main/java/org/apache/sshd/client/channel/AbstractClientChannel.java
@@ -218,14 +218,9 @@ public abstract class AbstractClientChannel extends AbstractChannel implements C
                     if (openFuture == null) {
                         gracefulFuture.setClosed();
                     }
-                    // Close inverted streams after
-                    // If the inverted stream is closed before, there's a small time window
-                    // in which we have:
-                    // ChannelPipedInputStream#closed = true
-                    // ChannelPipedInputStream#writerClosed = false
-                    // which leads to an IOException("Pipe closed") when reading.
                     IoUtils.closeQuietly(in, out, err);
-                    IoUtils.closeQuietly(invertedIn, invertedOut, invertedErr);
+                    IoUtils.closeQuietly(invertedIn);
+                    // Don't close invertedOut and invertedErr; it's the application's business to do so!
                 })
                 .parallel(asyncIn, asyncOut, asyncErr)
                 .close(super.getInnerCloseable())

--- a/sshd-core/src/main/java/org/apache/sshd/client/channel/ClientChannel.java
+++ b/sshd-core/src/main/java/org/apache/sshd/client/channel/ClientChannel.java
@@ -30,6 +30,7 @@ import java.util.Set;
 import org.apache.sshd.client.future.OpenFuture;
 import org.apache.sshd.client.session.ClientSession;
 import org.apache.sshd.client.session.ClientSessionHolder;
+import org.apache.sshd.common.SshConstants;
 import org.apache.sshd.common.channel.Channel;
 import org.apache.sshd.common.channel.StreamingChannel;
 import org.apache.sshd.common.io.IoInputStream;
@@ -61,36 +62,135 @@ public interface ClientChannel extends Channel, StreamingChannel, ClientSessionH
     IoInputStream getAsyncErr();
 
     /**
-     * Access to an output stream to send data directly to the remote channel. This can be used instead of using
-     * {@link #setIn(java.io.InputStream)} method and having the channel polling for data in that stream.
+     * Obtains an {@link OutputStream} to send data directly to the remote end of the channel. This can be used instead
+     * of using {@link #setIn(InputStream)} method and having the channel polling for data in that stream.
+     * <p>
+     * When the channel closes, it will {@link OutputStream#close() close} the returned stream.
+     * </p>
+     * <p>
+     * This method should be called only after the channel has been opened.
+     * </p>
      *
-     * @return an OutputStream to be used to send data
+     * @return an {@link OutputStream} for sending data, or {@code null} if an input stream was set via
+     *         {@link #setIn(InputStream)}
+     * @see    #setIn(InputStream)
      */
     OutputStream getInvertedIn();
 
+    /**
+     * Obtains an {@link InputStream} to read received {@link SshConstants#SSH_MSG_CHANNEL_DATA} data directly from the
+     * channel. This is an alternative to {@link #setOut(OutputStream)}. If the error stream is redirected to the output
+     * stream via {@link #setRedirectErrorStream(boolean) setRedirectErrorStream(true)}, this stream will also receive
+     * {@link SshConstants#SSH_MSG_CHANNEL_EXTENDED_DATA} data.
+     * <p>
+     * When the channel closes, it will <em>not</em> close the returned stream. It is the caller's responsibility to
+     * close the returned stream if needed. Closing the stream while the channel is open may cause the channel to be
+     * closed forcibly if more data arrives. The stream remains open after the channel has closed, so that the caller
+     * can read the last arrived data even afterwards.
+     * </p>
+     * <p>
+     * As with all external processes, the application should read this stream to avoid that the channel blocks when the
+     * stream's buffer is full. The buffer size for the returned stream is bounded by the channel's local window size.
+     * If the caller does not read this stream, the channel will block once the local window is exhausted.
+     * </p>
+     * <p>
+     * This method should be called only after the channel has been opened.
+     * </p>
+     *
+     * @return an {@link InputStream} for reading received data, or {@code null} if an output stream was set via
+     *         {@link #setOut(OutputStream)}
+     * @see    #setOut(OutputStream)
+     * @see    #setRedirectErrorStream(boolean)
+     */
     InputStream getInvertedOut();
 
+    /**
+     * Obtains an {@link InputStream} to read received {@link SshConstants#SSH_MSG_CHANNEL_EXTENDED_DATA} data directly
+     * from the channel. This is an alternative to {@link #setErr(OutputStream)}. If the error stream is redirected to
+     * the output stream via {@link #setRedirectErrorStream(boolean) setRedirectErrorStream(true)}, the returned stream
+     * will not receive any data and be always at EOF.
+     * <p>
+     * When the channel closes, it will <em>not</em> close the returned stream. It is the caller's responsibility to
+     * close the returned stream if needed. Closing the stream while the channel is open may cause the channel to be
+     * closed forcibly if more data arrives. The stream remains open after the channel has closed, so that the caller
+     * can read the last arrived data even afterwards.
+     * </p>
+     * <p>
+     * As with all external processes, the application should read this stream (unless it was redirected) to avoid that
+     * the channel blocks when the stream's buffer is full. The buffer size for the returned stream is bounded by the
+     * channel's local window size. If the caller does not read this stream, the channel will block once the local
+     * window is exhausted.
+     * </p>
+     * <p>
+     * This method should be called only after the channel has been opened.
+     * </p>
+     *
+     * @return an {@link InputStream} for reading received data, or {@code null} if an output stream was set via
+     *         {@link #setErr(OutputStream)}
+     * @see    #setErr(OutputStream)
+     * @see    #setRedirectErrorStream(boolean)
+     */
     InputStream getInvertedErr();
 
     /**
-     * Set an input stream that will be read by this channel and forwarded to the remote channel. Note that using such a
-     * stream will create an additional thread for pumping the stream which will only be able to end when that stream is
-     * actually closed or some data is read. It is recommended to use the {@link #getInvertedIn()} method instead and
-     * write data directly.
+     * Sets an {@link InputStream} that will be read by this channel and forwarded to the remote channel. Note that
+     * using such a stream will create an additional thread for pumping the stream which will only be able to end when
+     * that stream is actually closed or EOF on the stream is reached. It is recommended to use the
+     * {@link #getInvertedIn()} method instead and write data directly.
+     * <p>
+     * The stream must be set before the channel is opened. When the channel closes, it will {@link InputStream#close()
+     * close} the given stream.
+     * </p>
      *
-     * @param in an InputStream to be polled and forwarded
+     * @param in an {@link InputStream} to be polled and forwarded
+     * @see      #getInvertedIn()
      */
     void setIn(InputStream in);
 
+    /**
+     * Sets an output stream for the channel to write received {@link SshConstants#SSH_MSG_CHANNEL_DATA} data to. For
+     * remote command execution, this is typically the remote command's {@code stdout}. If the error stream is
+     * redirected to the output stream via {@link #setRedirectErrorStream(boolean) setRedirectErrorStream(true)}, this
+     * stream will also receive {@link SshConstants#SSH_MSG_CHANNEL_EXTENDED_DATA} data.
+     * <p>
+     * The stream must be set before the channel is opened. When the channel closes, it will {@link OutputStream#close()
+     * close} the given stream.
+     * </p>
+     * <p>
+     * If no stream is set by the time the channel is opened, the channel will internally forward data to a stream that
+     * can be read via the {@link InputStream} obtained via {@link #getInvertedOut()}.
+     * </p>
+     *
+     * @param out the {@link OutputStream}
+     * @see       #getInvertedOut()
+     * @see       #setRedirectErrorStream(boolean)
+     */
     void setOut(OutputStream out);
 
+    /**
+     * Sets an output stream for the channel to write received {@link SshConstants#SSH_MSG_CHANNEL_EXTENDED_DATA} data
+     * to. For remote command execution, this is typically the remote command's {@code stderr}.
+     * <p>
+     * The stream must be set before the channel is opened. When the channel closes, it will {@link OutputStream#close()
+     * close} the given stream.
+     * </p>
+     * <p>
+     * If no stream is set by the time the channel is opened, the channel will internally forward data to a stream that
+     * can be read via the {@link InputStream} obtained via {@link #getInvertedErr()}. (Or it might forward the data to
+     * the output stream if {@link #setRedirectErrorStream(boolean) setRedirectErrorStream(true)} is set.)
+     * </p>
+     *
+     * @param err the {@link OutputStream}
+     * @see       #getInvertedErr()
+     * @see       #setRedirectErrorStream(boolean)
+     */
     void setErr(OutputStream err);
 
     /**
-     * @param redirectErrorStream If {@code true} then STDERR stream is set to be the same as STDOUT unless
-     *                            {@link #setErr(OutputStream)} was called. <B>Note:</B> the call must occur
-     *                            <U>before</U> channel is opened. Calling it afterwards has no effect - i.e., the last
-     *                            state before opening the stream determines the channel's behavior.
+     * Defines whether to redirect the error stream into the output stream; has no effect if
+     * {@link #setErr(OutputStream)} has also been called by the time the channel is opened.
+     *
+     * @param redirectErrorStream whether to redirect the error stream to the output stream.
      */
     void setRedirectErrorStream(boolean redirectErrorStream);
 

--- a/sshd-core/src/test/java/org/apache/sshd/common/channel/ChannelPipedInputStreamTest.java
+++ b/sshd-core/src/test/java/org/apache/sshd/common/channel/ChannelPipedInputStreamTest.java
@@ -53,6 +53,7 @@ public class ChannelPipedInputStreamTest extends BaseTestSupport {
             assertEquals("Mismatched reported read size", b.length, stream.read(readBytes));
             assertStreamEquals(b, readBytes);
             assertEquals("Unexpected data still available", -1, stream.available());
+            assertEquals("Unexpectedly not at EOF", -1, stream.read());
         }
     }
 


### PR DESCRIPTION
Closing them when the channel closes leads to the strange situation that the application reads from an already closed InputStream. That's not a good idea.

It's the caller's responsibility to close the input stream obtained from Channel.getInvertedOut() or getInvertedErr(). And of course it should do so only after it has read all the data it wanted, and the channel is closed.

It's not a real problem if the stream is not closed (for instance, if the application never even called getInvertedOut() and never read anything). Closing doesn't do much anyway except awaking a potentially waiting read() call. Moreover, if the channel is short-lived and didn't transmit a lot of data, the application may well start reading from the stream only after the underlying SSH channel is already closed.

One problem with this ChannelPipedInputStream is that it may buffer up to a full SSH channel window. If the window size is large, that may consume a lot of memory if the application only reads infrequently (or doesn't read at all). However, not reading from such a stream is bad practice anyway if there is any chance that there might be a substantial amount of data; as with processes, it may lead to a blocked execution when buffers fill up or the channel window is exhausted.