### PR TITLE
[SSHD-1307] Make Nio2Session.shutdownOutputStream() asynchronous

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,7 @@
 * [SSHD-1297](https://issues.apache.org/jira/browse/SSHD-1297) Avoid OutOfMemoryError when reading a public key from a corrupted Buffer
 * [SSHD-1302](https://issues.apache.org/jira/browse/SSHD-1302) Reading from Channel.getInvertedOut() after EOF was reached throws IOException instead of returning -1
 * [SSHD-1303](https://issues.apache.org/jira/browse/SSHD-1303) Reading from redirected Channel.getInvertedErr() delivers stdout; should be at EOF
+* [SSHD-1307](https://issues.apache.org/jira/browse/SSHD-1307) [NIO2] TCP/IP port forwarding: shut down output stream only after pending writes have been written
 
 ## Major code re-factoring
 
@@ -43,20 +44,23 @@
 * MINA I/O back-end: use `CoreModuleProperties.NIO2_READ_BUFFER_SIZE` for the initial read buffer size, if set.
   A new `CoreModuleProperties.MIN_READ_BUFFER_SIZE` can be set to control the minimum read buffer size (64
   bytes by default in Apache MINA).
+* NIO2 I/O back-end: in TCP/IP port forwarding, shut down the output stream of a socket when a `SSH_MSG_CHANNEL_EOF` message
+  is received  on the SSH channel only after still pending writes have completed. See [SSHD-1307](https://issues.apache.org/jira/browse/SSHD-1307).
+  The MINA and Netty I/O back-ends already did so.
 
 <!-- --><a id="channelwindows0"></a>
 
 ### Channel windows
 
 Previous versions of Apache MINA sshd (from 2.6.0 to 2.9.1) did not always fully use up a channel window
-and waited for a `SSH_MSG_CHANNEL_WINDOW_ADJUST` message from the peer instead. It did so if the available
+and waited for a `SSH_MSG_CHANNEL_WINDOW_ADJUST` message from the peer instead. They did so if the available
 window size was smaller than the packet size of the channel, and also smaller than the amount of data still
 to be written. There were settings to change this behavior and always fully use up a channel window: these
 settings were
 
-* `SftpModuleProperties.CHUNK_IF_WINDOW_LESS_THAN_PACKET`
 * `CoreModuleProperties.ASYNC_SERVER_STDOUT_CHUNK_BELOW_WINDOW_SIZE`
 * `CoreModuleProperties.ASYNC_SERVER_STDERR_CHUNK_BELOW_WINDOW_SIZE`
+* `SftpModuleProperties.CHUNK_IF_WINDOW_LESS_THAN_PACKET`
 
 By default, they were `false`; if set to `true`, the window would be used fully.
 


### PR DESCRIPTION
Nio2Session.shutdownOutputStream() can be invoked while there are still writes in progress. The output is shut down in TCP/IP port forwarding to propagate an SSH_MSG_CHANNEL_EOF from the channel to whatever is on the other side of the forwarded port; see SSHD-1055. However, writing through the socket is asynchronous, so a channel may get the following sequence of events:

1. receive last SSH_MSG_CHANNEL_DATA
2. Nio2Session.writeBuffer() enqueues the write request
3. SSH_MSG_CHANNEL_DATA handling completes
4. receive SSH_MSG_CHANNEL_EOF
5. call Nio2Session.shutdownOutputStream()

If (5) shuts down the output immediately but the write request from (2) has not been written yet, that write attempt will fail with a ClosedChannelException.

The output stream on the socket should not be shut down immediately but only once already pending writes have been done. This is already the case with the MINA and Netty transport back-ends, which only schedule a shutdown request on their write queue.

Implement the same for the NIO2 transport. A write future with a null buffer signifies a shutdown request; true write requests always have a non-null buffer. Make shutdownOutputStream() only enqueue such a shutdown request on the session's write queue; the output will be shut down once startWriting() pops this shutdown request from the write queue.