### PR TITLE
Window: always consume right away on reception

### DIFF
--- a/sshd-core/src/main/java/org/apache/sshd/agent/local/AgentForwardedChannel.java
+++ b/sshd-core/src/main/java/org/apache/sshd/agent/local/AgentForwardedChannel.java
@@ -33,7 +33,7 @@ import org.apache.sshd.common.PropertyResolverUtils;
 import org.apache.sshd.common.SshConstants;
 import org.apache.sshd.common.SshException;
 import org.apache.sshd.common.channel.ChannelOutputStream;
-import org.apache.sshd.common.channel.Window;
+import org.apache.sshd.common.channel.LocalWindow;
 import org.apache.sshd.common.session.Session;
 import org.apache.sshd.common.util.ValidateUtils;
 import org.apache.sshd.common.util.buffer.Buffer;
@@ -100,8 +100,8 @@ public class AgentForwardedChannel extends AbstractClientChannel {
             outputStream.write(buffer.array(), buffer.rpos(), reqLen);
             outputStream.flush();
 
-            Window wLocal = getLocalWindow();
-            wLocal.consumeAndCheck(reqLen);
+            LocalWindow wLocal = getLocalWindow();
+            wLocal.check();
             return waitForMessageBuffer();
         }
     }

--- a/sshd-core/src/main/java/org/apache/sshd/agent/unix/AgentForwardedChannel.java
+++ b/sshd-core/src/main/java/org/apache/sshd/agent/unix/AgentForwardedChannel.java
@@ -25,7 +25,7 @@ import org.apache.sshd.client.channel.AbstractClientChannel;
 import org.apache.sshd.common.Closeable;
 import org.apache.sshd.common.SshConstants;
 import org.apache.sshd.common.channel.ChannelOutputStream;
-import org.apache.sshd.common.channel.Window;
+import org.apache.sshd.common.channel.LocalWindow;
 import org.apache.sshd.common.util.ValidateUtils;
 import org.apache.tomcat.jni.Socket;
 import org.apache.tomcat.jni.Status;
@@ -80,8 +80,8 @@ public class AgentForwardedChannel extends AbstractClientChannel implements Runn
     @Override
     protected synchronized void doWriteData(byte[] data, int off, long len) throws IOException {
         ValidateUtils.checkTrue(len <= Integer.MAX_VALUE, "Data length exceeds int boundaries: %d", len);
-        Window wLocal = getLocalWindow();
-        wLocal.consumeAndCheck(len);
+        LocalWindow wLocal = getLocalWindow();
+        wLocal.check();
 
         int result = Socket.send(socket, data, off, (int) len);
         if (result < Status.APR_SUCCESS) {

--- a/sshd-core/src/main/java/org/apache/sshd/common/channel/Channel.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/channel/Channel.java
@@ -60,9 +60,9 @@ public interface Channel
      */
     long getRecipient();
 
-    Window getLocalWindow();
+    LocalWindow getLocalWindow();
 
-    Window getRemoteWindow();
+    RemoteWindow getRemoteWindow();
 
     List<RequestHandler<Channel>> getRequestHandlers();
 

--- a/sshd-core/src/main/java/org/apache/sshd/common/channel/ChannelAsyncInputStream.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/channel/ChannelAsyncInputStream.java
@@ -137,8 +137,8 @@ public class ChannelAsyncInputStream extends AbstractCloseable implements IoInpu
         if (nbRead > 0) {
             Channel channel = getChannel();
             try {
-                Window wLocal = channel.getLocalWindow();
-                wLocal.consumeAndCheck(nbRead);
+                LocalWindow wLocal = channel.getLocalWindow();
+                wLocal.check();
             } catch (IOException e) {
                 Session session = channel.getSession();
                 session.exceptionCaught(e);

--- a/sshd-core/src/main/java/org/apache/sshd/common/channel/ChannelAsyncOutputStream.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/channel/ChannelAsyncOutputStream.java
@@ -272,7 +272,7 @@ public class ChannelAsyncOutputStream extends AbstractCloseable implements IoOut
             return null;
         }
         Channel channel = getChannel();
-        Window remoteWindow = channel.getRemoteWindow();
+        RemoteWindow remoteWindow = channel.getRemoteWindow();
         // An erratum on RFC 4254 at https://www.rfc-editor.org/errata/rfc4254 claims that the 4 bytes for the data
         // length had to be included in window computations. Which raises the question of what should happen if the
         // remaining window size is < 4. If the peer waits for the window size to drop to zero before sending its window

--- a/sshd-core/src/main/java/org/apache/sshd/common/channel/ChannelOutputStream.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/channel/ChannelOutputStream.java
@@ -63,7 +63,7 @@ public class ChannelOutputStream extends OutputStream implements java.nio.channe
 
     private final AbstractChannel channelInstance;
     private final ChannelStreamWriter packetWriter;
-    private final Window remoteWindow;
+    private final RemoteWindow remoteWindow;
     private final Duration maxWaitTimeout;
     private final byte cmd;
     private final boolean eofOnClose;
@@ -75,24 +75,21 @@ public class ChannelOutputStream extends OutputStream implements java.nio.channe
     private int lastSize;
     private boolean isFlushing;
 
-    public ChannelOutputStream(
-                               AbstractChannel channel, Window remoteWindow, Logger log, byte cmd, boolean eofOnClose) {
+    public ChannelOutputStream(AbstractChannel channel, RemoteWindow remoteWindow, Logger log, byte cmd, boolean eofOnClose) {
         this(channel, remoteWindow,
              CoreModuleProperties.WAIT_FOR_SPACE_TIMEOUT.getRequired(channel),
              log, cmd, eofOnClose);
     }
 
-    public ChannelOutputStream(
-                               AbstractChannel channel, Window remoteWindow, long maxWaitTimeout, Logger log, byte cmd,
+    public ChannelOutputStream(AbstractChannel channel, RemoteWindow remoteWindow, long maxWaitTimeout, Logger log, byte cmd,
                                boolean eofOnClose) {
         this(channel, remoteWindow,
              Duration.ofMillis(maxWaitTimeout),
              log, cmd, eofOnClose);
     }
 
-    public ChannelOutputStream(
-                               AbstractChannel channel, Window remoteWindow, Duration maxWaitTimeout, Logger log, byte cmd,
-                               boolean eofOnClose) {
+    public ChannelOutputStream(AbstractChannel channel, RemoteWindow remoteWindow, Duration maxWaitTimeout, Logger log,
+                               byte cmd, boolean eofOnClose) {
         this.channelInstance = Objects.requireNonNull(channel, "No channel");
         this.packetWriter = channelInstance.resolveChannelStreamWriter(channel, cmd);
         this.remoteWindow = Objects.requireNonNull(remoteWindow, "No remote window");

--- a/sshd-core/src/main/java/org/apache/sshd/common/channel/ChannelPipedInputStream.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/channel/ChannelPipedInputStream.java
@@ -41,7 +41,7 @@ import org.apache.sshd.core.CoreModuleProperties;
  * @author <a href="mailto:dev@mina.apache.org">Apache MINA SSHD Project</a>
  */
 public class ChannelPipedInputStream extends InputStream implements ChannelPipedSink {
-    private final Window localWindow;
+    private final LocalWindow localWindow;
     private final byte[] b = new byte[1];
     private final AtomicBoolean open = new AtomicBoolean(true);
 
@@ -59,15 +59,15 @@ public class ChannelPipedInputStream extends InputStream implements ChannelPiped
 
     private long timeout;
 
-    public ChannelPipedInputStream(PropertyResolver resolver, Window localWindow) {
+    public ChannelPipedInputStream(PropertyResolver resolver, LocalWindow localWindow) {
         this(localWindow, CoreModuleProperties.WINDOW_TIMEOUT.getRequired(resolver));
     }
 
-    public ChannelPipedInputStream(Window localWindow, Duration windowTimeout) {
+    public ChannelPipedInputStream(LocalWindow localWindow, Duration windowTimeout) {
         this(localWindow, Objects.requireNonNull(windowTimeout, "No window timeout provided").toMillis());
     }
 
-    public ChannelPipedInputStream(Window localWindow, long windowTimeout) {
+    public ChannelPipedInputStream(LocalWindow localWindow, long windowTimeout) {
         this.localWindow = Objects.requireNonNull(localWindow, "No local window provided");
         this.timeout = windowTimeout;
     }
@@ -160,7 +160,7 @@ public class ChannelPipedInputStream extends InputStream implements ChannelPiped
             lock.unlock();
         }
         if (localWindow.isOpen()) {
-            localWindow.consumeAndCheck(len);
+            localWindow.check();
         }
         return len;
     }

--- a/sshd-core/src/main/java/org/apache/sshd/common/channel/LocalWindow.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/channel/LocalWindow.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sshd.common.channel;
+
+import java.io.IOException;
+import java.io.StreamCorruptedException;
+
+import org.apache.sshd.common.PropertyResolver;
+import org.apache.sshd.common.util.buffer.BufferUtils;
+import org.apache.sshd.core.CoreModuleProperties;
+
+/**
+ * A {@link Window} that describes how much data this side is prepared to receive from the peer. Initialized when the
+ * channel is created. This side reduces the window by the amount of data received on reception; if it receives more
+ * data than allowed, it closes the channel. Once the data received has been processed, for instance, passed on, this
+ * side checks the current window size and if it is low, increases it and sends an SSH_MSG_CHANNEL_WINDOW_ADJUST message
+ * to the peer, who then is allowed to send more data again.
+ *
+ * @author <a href="mailto:dev@mina.apache.org">Apache MINA SSHD Project</a>
+ */
+public class LocalWindow extends Window {
+
+    private final AbstractChannel channel;
+
+    public LocalWindow(AbstractChannel channel, boolean isClient) {
+        super(channel, isClient);
+        this.channel = channel;
+    }
+
+    @Override // Co-variant override
+    public AbstractChannel getChannel() {
+        return channel;
+    }
+
+    /**
+     * Initializes the {@link LocalWindow} with the packet and window sizes from the {@code resolver}.
+     *
+     * @param size       the initial window size
+     * @param packetSize the peer's advertised maximum packet size
+     * @param resolver   {@PropertyResolver} to access properties
+     */
+    public void init(PropertyResolver resolver) {
+        init(CoreModuleProperties.WINDOW_SIZE.getRequired(resolver),
+                CoreModuleProperties.MAX_PACKET_SIZE.getRequired(resolver),
+                resolver);
+    }
+
+    @Override
+    public void consume(long len) throws IOException {
+        BufferUtils.validateUint32Value(len, "Invalid consumption length: %d");
+        checkInitialized("consume");
+
+        long remainLen;
+        synchronized (lock) {
+            remainLen = getSize() - len;
+            if (remainLen >= 0L) {
+                updateSize(remainLen);
+            }
+        }
+        if (remainLen < 0L) {
+            throw new StreamCorruptedException(
+                    "consume(" + this + ") required length (" + len + ") above available: " + (remainLen + len));
+        }
+        if (log.isDebugEnabled()) {
+            log.debug("Consume {} by {} down to {}", this, len, remainLen);
+        }
+    }
+
+    public void check() throws IOException {
+        checkInitialized("check");
+
+        long maxFree = getMaxSize();
+        long adjustSize = -1L;
+        AbstractChannel channel = getChannel();
+        synchronized (lock) {
+            // TODO make the adjust factor configurable via FactoryManager property
+            long size = getSize();
+            if (size < (maxFree / 2)) {
+                adjustSize = maxFree - size;
+                channel.sendWindowAdjust(adjustSize);
+                updateSize(maxFree);
+            }
+        }
+
+        if (adjustSize >= 0L) {
+            if (log.isDebugEnabled()) {
+                log.debug("Increase {} by {} up to {}", this, adjustSize, maxFree);
+            }
+        }
+    }
+
+}

--- a/sshd-core/src/main/java/org/apache/sshd/common/channel/RemoteWindow.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/channel/RemoteWindow.java
@@ -1,0 +1,236 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sshd.common.channel;
+
+import java.net.SocketTimeoutException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Objects;
+import java.util.function.Predicate;
+
+import org.apache.sshd.common.PropertyResolver;
+import org.apache.sshd.common.util.GenericUtils;
+import org.apache.sshd.common.util.ValidateUtils;
+import org.apache.sshd.common.util.buffer.BufferUtils;
+
+/**
+ * A {@link Window} reflecting this side's view of the peer's {@link LocalWindow}. A {@code RemoteWindow} is initialized
+ * when the peer announces its packet and window sizes in the initial message exchange when opening a channel. Whenever
+ * this side wants to send data, it checks whether the remote window has still enough space; if not, it sends only as
+ * much data as possible. When data is sent, the remote window size is reduced by the number of data bytes sent. When
+ * the window size drops to zero, no data is sent at all, and this side will have to wait for an
+ * SSH_MSG_CHANNEL_WINDOW_ADJUST message from the peer, which will increase the available window size again.
+ *
+ * @author <a href="mailto:dev@mina.apache.org">Apache MINA SSHD Project</a>
+ */
+public class RemoteWindow extends Window {
+
+    /**
+     * Default {@link Predicate} used to test if space became available
+     */
+    private static final Predicate<Window> SPACE_AVAILABLE_PREDICATE = Window.largerThan(0);
+
+    public RemoteWindow(Channel channel, boolean isClient) {
+        super(channel, isClient);
+    }
+
+    /**
+     * Initializes the {@link RemoteWindow} with the packet and window sizes received from the peer.
+     *
+     * @param size       the initial window size
+     * @param packetSize the peer's advertised maximum packet size
+     * @param resolver   {@PropertyResolver} to access properties
+     */
+    @Override
+    public void init(long size, long packetSize, PropertyResolver resolver) {
+        super.init(size, packetSize, resolver);
+    }
+
+    @Override
+    public void consume(long len) {
+        BufferUtils.validateUint32Value(len, "Invalid consumption length: %d");
+        checkInitialized("consume");
+
+        long remainLen;
+        synchronized (lock) {
+            remainLen = getSize() - len;
+            if (remainLen >= 0L) {
+                updateSize(remainLen);
+            }
+        }
+        if (remainLen < 0L) {
+            throw new IllegalStateException(
+                    "consume(" + this + ") required length (" + len + ") above available: " + (remainLen + len));
+        }
+        if (log.isDebugEnabled()) {
+            log.debug("Consume {} by {} down to {}", this, len, remainLen);
+        }
+    }
+
+    public void expand(long increment) {
+        BufferUtils.validateUint32Value(increment, "Invalid window expansion size: %d");
+        checkInitialized("expand");
+
+        long initialSize;
+        long expandedSize;
+        synchronized (lock) {
+            /*
+             * See RFC-4254 section 5.2:
+             *
+             * "Implementations MUST correctly handle window sizes of up to 2^32 - 1 bytes. The window MUST NOT be
+             * increased above 2^32 - 1 bytes.
+             */
+            initialSize = getSize();
+            expandedSize = Math.min(initialSize + increment, BufferUtils.MAX_UINT32_VALUE);
+            updateSize(expandedSize);
+        }
+
+        if (expandedSize - initialSize != increment) {
+            log.warn("expand({}) window increase from {} by {} too large, set to {}", this, initialSize, increment,
+                    expandedSize);
+        } else if (log.isDebugEnabled()) {
+            log.debug("expand({}) increase window from {} by {} up to {}", this, initialSize, increment, expandedSize);
+        }
+    }
+
+    /**
+     * Waits for enough data to become available to consume the specified size
+     *
+     * @param  len                    Size of data to consume
+     * @param  maxWaitTime            Max. time (millis) to wait for enough data to become available
+     * @throws InterruptedException   If interrupted while waiting
+     * @throws WindowClosedException  If window closed while waiting
+     * @throws SocketTimeoutException If timeout expired before enough data became available
+     * @see                           #waitForCondition(Predicate, Duration)
+     * @see                           #consume(long)
+     */
+    public void waitAndConsume(long len, long maxWaitTime)
+            throws InterruptedException, WindowClosedException, SocketTimeoutException {
+        waitAndConsume(len, Duration.ofMillis(maxWaitTime));
+    }
+
+    /**
+     * Waits for enough data to become available to consume the specified size
+     *
+     * @param  len                    Size of data to consume
+     * @param  maxWaitTime            Max. time to wait for enough data to become available
+     * @throws InterruptedException   If interrupted while waiting
+     * @throws WindowClosedException  If window closed while waiting
+     * @throws SocketTimeoutException If timeout expired before enough data became available
+     * @see                           #waitForCondition(Predicate, Duration)
+     * @see                           #consume(long)
+     */
+    public void waitAndConsume(long len, Duration maxWaitTime)
+            throws InterruptedException, WindowClosedException, SocketTimeoutException {
+        BufferUtils.validateUint32Value(len, "Invalid wait consume length: %d", len);
+        checkInitialized("waitAndConsume");
+        if (len == 0) {
+            return;
+        }
+        boolean debugEnabled = log.isDebugEnabled();
+        synchronized (lock) {
+            waitForCondition(largerThan(len - 1), maxWaitTime);
+
+            if (debugEnabled) {
+                log.debug("waitAndConsume({}) - requested={}, available={}", this, len, getSize());
+            }
+
+            consume(len);
+        }
+    }
+
+    /**
+     * Waits until some data becomes available or timeout expires
+     *
+     * @param  maxWaitTime            Max. time (millis) to wait for space to become available
+     * @return                        Amount of available data - always positive
+     * @throws InterruptedException   If interrupted while waiting
+     * @throws WindowClosedException  If window closed while waiting
+     * @throws SocketTimeoutException If timeout expired before space became available
+     * @see                           #waitForCondition(Predicate, Duration)
+     */
+    public long waitForSpace(long maxWaitTime) throws InterruptedException, WindowClosedException, SocketTimeoutException {
+        return waitForSpace(Duration.ofMillis(maxWaitTime));
+    }
+
+    /**
+     * Waits until some data becomes available or timeout expires
+     *
+     * @param  maxWaitTime            Max. time to wait for space to become available
+     * @return                        Amount of available data - always positive
+     * @throws InterruptedException   If interrupted while waiting
+     * @throws WindowClosedException  If window closed while waiting
+     * @throws SocketTimeoutException If timeout expired before space became available
+     * @see                           #waitForCondition(Predicate, Duration)
+     */
+    public long waitForSpace(Duration maxWaitTime) throws InterruptedException, WindowClosedException, SocketTimeoutException {
+        checkInitialized("waitForSpace");
+
+        long available;
+        synchronized (lock) {
+            waitForCondition(SPACE_AVAILABLE_PREDICATE, maxWaitTime);
+            available = getSize();
+        }
+
+        if (log.isDebugEnabled()) {
+            log.debug("waitForSpace({}) available: {}", this, available);
+        }
+
+        return available;
+    }
+
+    /**
+     * Waits up to a specified amount of time for a condition to be satisfied and signaled via the lock. <B>Note:</B>
+     * assumes that lock is acquired when this method is called.
+     *
+     * @param  predicate              The {@link Predicate} to check if the condition has been satisfied - the argument
+     *                                to the predicate is {@code this} reference
+     * @param  maxWaitTime            Max. time to wait for the condition to be satisfied
+     * @throws WindowClosedException  If window closed while waiting
+     * @throws InterruptedException   If interrupted while waiting
+     * @throws SocketTimeoutException If timeout expired before condition was satisfied
+     * @see                           #isOpen()
+     */
+    protected void waitForCondition(Predicate<? super Window> predicate, Duration maxWaitTime)
+            throws WindowClosedException, InterruptedException, SocketTimeoutException {
+        Objects.requireNonNull(predicate, "No condition");
+        ValidateUtils.checkTrue(GenericUtils.isPositive(maxWaitTime), "Non-positive max. wait time: %s",
+                maxWaitTime.toString());
+
+        Instant cur = Instant.now();
+        Instant waitEnd = cur.plus(maxWaitTime);
+        // The loop takes care of spurious wakeups
+        while (isOpen() && (cur.compareTo(waitEnd) < 0)) {
+            if (predicate.test(this)) {
+                return;
+            }
+
+            Duration rem = Duration.between(cur, waitEnd);
+            lock.wait(rem.toMillis(), rem.getNano() % 1_000_000);
+            cur = Instant.now();
+        }
+
+        if (!isOpen()) {
+            throw new WindowClosedException(toString());
+        }
+
+        throw new SocketTimeoutException("waitForCondition(" + this + ") timeout exceeded: " + maxWaitTime);
+    }
+
+}

--- a/sshd-core/src/main/java/org/apache/sshd/common/session/helpers/AbstractConnectionService.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/session/helpers/AbstractConnectionService.java
@@ -45,8 +45,8 @@ import org.apache.sshd.common.SshConstants;
 import org.apache.sshd.common.channel.Channel;
 import org.apache.sshd.common.channel.ChannelFactory;
 import org.apache.sshd.common.channel.ChannelListener;
+import org.apache.sshd.common.channel.LocalWindow;
 import org.apache.sshd.common.channel.RequestHandler;
-import org.apache.sshd.common.channel.Window;
 import org.apache.sshd.common.channel.exception.SshChannelNotFoundException;
 import org.apache.sshd.common.channel.exception.SshChannelOpenException;
 import org.apache.sshd.common.forward.Forwarder;
@@ -775,7 +775,7 @@ public abstract class AbstractConnectionService
                 // Do not rely on the OpenFuture. We must be sure that we get the SSH_MSG_CHANNEL_OPEN_CONFIRMATION out
                 // before anything else.
                 try {
-                    Window window = channel.getLocalWindow();
+                    LocalWindow window = channel.getLocalWindow();
                     if (debugEnabled) {
                         log.debug(
                                 "channelOpenSuccess({}) send SSH_MSG_CHANNEL_OPEN_CONFIRMATION recipient={}, sender={}, window-size={}, packet-size={}",

--- a/sshd-core/src/main/java/org/apache/sshd/common/session/helpers/AbstractSession.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/session/helpers/AbstractSession.java
@@ -542,9 +542,9 @@ public abstract class AbstractSession extends SessionHelper {
 
     protected void doHandleMessage(Buffer buffer) throws Exception {
         int cmd = buffer.getUByte();
-        if (log.isTraceEnabled()) {
-            log.trace("doHandleMessage({}) process {}",
-                    this, SshConstants.getCommandMessageName(cmd));
+        if (log.isDebugEnabled()) {
+            log.debug("doHandleMessage({}) process #{} {}", this, seqi - 1,
+                    SshConstants.getCommandMessageName(cmd));
         }
 
         switch (cmd) {

--- a/sshd-core/src/main/java/org/apache/sshd/server/channel/AbstractServerChannel.java
+++ b/sshd-core/src/main/java/org/apache/sshd/server/channel/AbstractServerChannel.java
@@ -30,8 +30,8 @@ import org.apache.sshd.common.FactoryManager;
 import org.apache.sshd.common.SshConstants;
 import org.apache.sshd.common.channel.AbstractChannel;
 import org.apache.sshd.common.channel.Channel;
+import org.apache.sshd.common.channel.RemoteWindow;
 import org.apache.sshd.common.channel.RequestHandler;
-import org.apache.sshd.common.channel.Window;
 import org.apache.sshd.common.session.Session;
 import org.apache.sshd.common.util.ExceptionUtils;
 import org.apache.sshd.common.util.buffer.Buffer;
@@ -61,7 +61,7 @@ public abstract class AbstractServerChannel extends AbstractChannel implements S
 
         Session s = getSession();
         FactoryManager manager = Objects.requireNonNull(s.getFactoryManager(), "No factory manager");
-        Window wRemote = getRemoteWindow();
+        RemoteWindow wRemote = getRemoteWindow();
         wRemote.init(rwSize, packetSize, manager);
         configureWindow();
         return doInit(buffer);

--- a/sshd-core/src/main/java/org/apache/sshd/server/channel/PipeDataReceiver.java
+++ b/sshd-core/src/main/java/org/apache/sshd/server/channel/PipeDataReceiver.java
@@ -25,7 +25,7 @@ import java.io.OutputStream;
 import org.apache.sshd.common.PropertyResolver;
 import org.apache.sshd.common.channel.ChannelPipedInputStream;
 import org.apache.sshd.common.channel.ChannelPipedOutputStream;
-import org.apache.sshd.common.channel.Window;
+import org.apache.sshd.common.channel.LocalWindow;
 import org.apache.sshd.common.util.io.output.LoggingFilterOutputStream;
 import org.apache.sshd.common.util.logging.AbstractLoggingBean;
 
@@ -39,7 +39,7 @@ public class PipeDataReceiver extends AbstractLoggingBean implements ChannelData
     private InputStream in;
     private OutputStream out;
 
-    public PipeDataReceiver(PropertyResolver resolver, Window localWindow) {
+    public PipeDataReceiver(PropertyResolver resolver, LocalWindow localWindow) {
         ChannelPipedInputStream in = new ChannelPipedInputStream(resolver, localWindow);
         this.in = in;
         this.out = new ChannelPipedOutputStream(in);

--- a/sshd-core/src/main/java/org/apache/sshd/server/x11/ChannelForwardedX11.java
+++ b/sshd-core/src/main/java/org/apache/sshd/server/x11/ChannelForwardedX11.java
@@ -29,7 +29,7 @@ import org.apache.sshd.common.Closeable;
 import org.apache.sshd.common.SshConstants;
 import org.apache.sshd.common.SshException;
 import org.apache.sshd.common.channel.ChannelOutputStream;
-import org.apache.sshd.common.channel.Window;
+import org.apache.sshd.common.channel.LocalWindow;
 import org.apache.sshd.common.io.IoSession;
 import org.apache.sshd.common.session.Session;
 import org.apache.sshd.common.util.ValidateUtils;
@@ -62,7 +62,7 @@ public class ChannelForwardedX11 extends AbstractClientChannel {
 
         InetAddress remoteAddress = remote.getAddress();
         String remoteHost = remoteAddress.getHostAddress();
-        Window wLocal = getLocalWindow();
+        LocalWindow wLocal = getLocalWindow();
         String type = getChannelType();
         Buffer buffer = session.createBuffer(SshConstants.SSH_MSG_CHANNEL_OPEN,
                 remoteHost.length() + type.length() + Integer.SIZE);
@@ -97,8 +97,8 @@ public class ChannelForwardedX11 extends AbstractClientChannel {
     protected synchronized void doWriteData(byte[] data, int off, long len) throws IOException {
         ValidateUtils.checkTrue(len <= Integer.MAX_VALUE,
                 "Data length exceeds int boundaries: %d", len);
-        Window wLocal = getLocalWindow();
-        wLocal.consumeAndCheck(len);
+        LocalWindow wLocal = getLocalWindow();
+        wLocal.check();
         // use a clone in case data buffer is re-used
         Buffer packet = ByteArrayBuffer.getCompactClone(data, off, (int) len);
         serverSession.writeBuffer(packet);

--- a/sshd-core/src/test/java/org/apache/sshd/common/channel/ChannelAsyncOutputStreamTest.java
+++ b/sshd-core/src/test/java/org/apache/sshd/common/channel/ChannelAsyncOutputStreamTest.java
@@ -45,7 +45,7 @@ import org.mockito.Mockito;
 public class ChannelAsyncOutputStreamTest extends BaseTestSupport {
 
     private static final String CLIENT_WITH_COMPATIBILITY_ISSUE = "specialClient";
-    private Window remoteWindow;
+    private RemoteWindow remoteWindow;
     private ChannelStreamWriter channelStreamWriter;
     private AbstractChannel channel;
     private Session session;
@@ -59,7 +59,7 @@ public class ChannelAsyncOutputStreamTest extends BaseTestSupport {
     public void setUp() throws Exception {
         channel = Mockito.mock(AbstractChannel.class);
         channelStreamWriter = Mockito.mock(ChannelStreamWriter.class);
-        remoteWindow = new Window(channel, null, true, true);
+        remoteWindow = new RemoteWindow(channel, true);
         ioWriteFuture = Mockito.mock(IoWriteFuture.class);
         session = Mockito.mock(Session.class);
 

--- a/sshd-core/src/test/java/org/apache/sshd/common/channel/ChannelPipedInputStreamTest.java
+++ b/sshd-core/src/test/java/org/apache/sshd/common/channel/ChannelPipedInputStreamTest.java
@@ -72,7 +72,7 @@ public class ChannelPipedInputStreamTest extends BaseTestSupport {
 
     private static ChannelPipedInputStream createTestStream() {
         AbstractChannel channel = new BogusChannel();
-        Window window = new Window(channel, null, true, true);
+        LocalWindow window = new LocalWindow(channel, true);
         window.init(PropertyResolverUtils.toPropertyResolver(Collections.emptyMap()));
         return new ChannelPipedInputStream(channel, window);
     }

--- a/sshd-core/src/test/java/org/apache/sshd/common/channel/WindowInitTest.java
+++ b/sshd-core/src/test/java/org/apache/sshd/common/channel/WindowInitTest.java
@@ -97,11 +97,10 @@ public class WindowInitTest extends BaseTestSupport {
         return params;
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testInitializationFailure() throws IOException {
-        try (Window w = new Window(MOCK_CHANNEL, null, true, true)) {
-            w.init(initialSize, packetSize, PropertyResolver.EMPTY);
-            fail("Unexpected success for initialSize=" + initialSize + ", packetSize=" + packetSize);
+        try (RemoteWindow w = new RemoteWindow(MOCK_CHANNEL, true)) {
+            assertThrows(IllegalArgumentException.class, () -> w.init(initialSize, packetSize, PropertyResolver.EMPTY));
         }
     }
 }

--- a/sshd-core/src/test/java/org/apache/sshd/common/channel/WindowTest.java
+++ b/sshd-core/src/test/java/org/apache/sshd/common/channel/WindowTest.java
@@ -174,11 +174,14 @@ public class WindowTest extends BaseTestSupport {
                                  new InputStreamReader(channel.getInvertedOut(), StandardCharsets.UTF_8))) {
 
                         for (int i = 0; i < nbMessages; i++) {
+                            long clientRemoteSize = clientRemote.getSize();
                             writer.write(message);
                             writer.write("\n");
                             writer.flush();
 
-                            waitForWindowNotEquals(clientLocal, serverRemote, "client local", "server remote",
+                            assertTrue("Client remote window should have changed",
+                                    clientRemote.getSize() != clientRemoteSize);
+                            waitForWindowEquals(clientRemote, serverLocal, "client remote", "server local",
                                     TimeUnit.SECONDS.toMillis(3L));
 
                             String line = reader.readLine();
@@ -288,10 +291,13 @@ public class WindowTest extends BaseTestSupport {
                     IoOutputStream output = channel.getAsyncIn();
                     IoInputStream input = channel.getAsyncOut();
                     for (int i = 0; i < nbMessages; i++) {
+                        long clientRemoteSize = clientRemote.getSize();
                         Buffer buffer = new ByteArrayBuffer(bytes);
                         output.writeBuffer(buffer).verify(DEFAULT_TIMEOUT);
 
-                        waitForWindowNotEquals(clientLocal, serverRemote, "client local", "server remote",
+                        assertTrue("Client remote window should have changed",
+                                clientRemote.getSize() != clientRemoteSize);
+                        waitForWindowEquals(clientRemote, serverLocal, "client remote", "server local",
                                 TimeUnit.SECONDS.toMillis(3L));
 
                         Buffer buf = new ByteArrayBuffer(16);

--- a/sshd-core/src/test/java/org/apache/sshd/common/channel/WindowTimeoutTest.java
+++ b/sshd-core/src/test/java/org/apache/sshd/common/channel/WindowTimeoutTest.java
@@ -91,7 +91,7 @@ public class WindowTimeoutTest extends BaseTestSupport {
 
     @Test
     public void testWindowWaitForSpaceTimeout() throws Exception {
-        try (Window window = channel.getLocalWindow()) {
+        try (RemoteWindow window = channel.getRemoteWindow()) {
             window.init(CoreModuleProperties.WINDOW_SIZE.getRequiredDefault(),
                     CoreModuleProperties.MAX_PACKET_SIZE.getRequiredDefault(),
                     PropertyResolver.EMPTY);
@@ -122,7 +122,7 @@ public class WindowTimeoutTest extends BaseTestSupport {
 
     @Test
     public void testWindowWaitAndConsumeTimeout() throws Exception {
-        try (Window window = channel.getLocalWindow()) {
+        try (RemoteWindow window = channel.getRemoteWindow()) {
             window.init(CoreModuleProperties.WINDOW_SIZE.getRequiredDefault(),
                     CoreModuleProperties.MAX_PACKET_SIZE.getRequiredDefault(),
                     PropertyResolver.EMPTY);

--- a/sshd-core/src/test/java/org/apache/sshd/server/ServerTest.java
+++ b/sshd-core/src/test/java/org/apache/sshd/server/ServerTest.java
@@ -52,7 +52,7 @@ import org.apache.sshd.client.session.ClientSessionImpl;
 import org.apache.sshd.common.auth.UserAuthMethodFactory;
 import org.apache.sshd.common.channel.Channel;
 import org.apache.sshd.common.channel.ChannelListener;
-import org.apache.sshd.common.channel.Window;
+import org.apache.sshd.common.channel.RemoteWindow;
 import org.apache.sshd.common.channel.WindowClosedException;
 import org.apache.sshd.common.io.IoSession;
 import org.apache.sshd.common.kex.KexProposalOption;
@@ -413,7 +413,7 @@ public class ServerTest extends BaseTestSupport {
                 try (Channel channel = GenericUtils.head(channels)) {
                     final long maxTimeoutValue = idleTimeoutValue + disconnectTimeoutValue + TimeUnit.SECONDS.toMillis(3L);
                     final long maxWaitNanos = TimeUnit.MILLISECONDS.toNanos(maxTimeoutValue);
-                    Window wRemote = channel.getRemoteWindow();
+                    RemoteWindow wRemote = channel.getRemoteWindow();
                     for (long totalNanoTime = 0L; wRemote.getSize() > 0;) {
                         long nanoStart = System.nanoTime();
                         Thread.sleep(1L);

--- a/sshd-core/src/test/java/org/apache/sshd/util/test/AsyncEchoShellFactory.java
+++ b/sshd-core/src/test/java/org/apache/sshd/util/test/AsyncEchoShellFactory.java
@@ -24,7 +24,7 @@ import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 
 import org.apache.sshd.common.channel.BufferedIoOutputStream;
-import org.apache.sshd.common.channel.Window;
+import org.apache.sshd.common.channel.LocalWindow;
 import org.apache.sshd.common.io.IoInputStream;
 import org.apache.sshd.common.io.IoOutputStream;
 import org.apache.sshd.common.session.Session;
@@ -153,8 +153,8 @@ public class AsyncEchoShellFactory implements ShellFactory {
                         Session session1 = channel.getSession();
                         if (future.isWritten()) {
                             try {
-                                Window wLocal = channel.getLocalWindow();
-                                wLocal.consumeAndCheck(bytes.length);
+                                LocalWindow wLocal = channel.getLocalWindow();
+                                wLocal.check();
                             } catch (IOException e) {
                                 session1.exceptionCaught(e);
                             }

--- a/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/impl/DefaultSftpClient.java
+++ b/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/impl/DefaultSftpClient.java
@@ -47,7 +47,6 @@ import org.apache.sshd.common.SshException;
 import org.apache.sshd.common.channel.Channel;
 import org.apache.sshd.common.channel.ChannelAsyncOutputStream;
 import org.apache.sshd.common.future.CloseFuture;
-import org.apache.sshd.common.io.AbstractIoWriteFuture;
 import org.apache.sshd.common.io.IoOutputStream;
 import org.apache.sshd.common.io.IoWriteFuture;
 import org.apache.sshd.common.session.ConnectionService;
@@ -559,6 +558,7 @@ public class DefaultSftpClient extends AbstractSftpClient {
             addPendingRequest(Channel.CHANNEL_SUBSYSTEM, wantReply);
             writePacket(buffer);
 
+            setStreaming(Streaming.Async);
             asyncIn = createAsyncInput(session);
             setOut(createStdOutputStream(session));
             setErr(createErrOutputStream(session));
@@ -583,27 +583,6 @@ public class DefaultSftpClient extends AbstractSftpClient {
                     return result;
                 }
             };
-        }
-
-        @Override
-        public IoWriteFuture writePacket(Buffer buffer) throws IOException {
-            if (asyncIn == null) {
-                return super.writePacket(buffer);
-            }
-            // We need to allow writing while closing in order to be able to flush the ChannelAsyncOutputStream.
-            if (!asyncIn.isClosed()) {
-                Session s = getSession();
-                return s.writePacket(buffer);
-            }
-
-            if (log.isDebugEnabled()) {
-                log.debug("writePacket({}) Discarding output packet because channel state={}; output stream is closed", this,
-                        state);
-            }
-            AbstractIoWriteFuture errorFuture = new AbstractIoWriteFuture(toString(), null) {
-            };
-            errorFuture.setValue(new EOFException("Channel is closed"));
-            return errorFuture;
         }
 
         protected OutputStream createStdOutputStream(Session session) {

--- a/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/impl/SftpInputStreamAsync.java
+++ b/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/impl/SftpInputStreamAsync.java
@@ -31,7 +31,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.sshd.common.SshConstants;
 import org.apache.sshd.common.channel.Channel;
-import org.apache.sshd.common.channel.Window;
+import org.apache.sshd.common.channel.LocalWindow;
 import org.apache.sshd.common.session.Session;
 import org.apache.sshd.common.util.buffer.Buffer;
 import org.apache.sshd.common.util.buffer.ByteArrayBuffer;
@@ -223,7 +223,7 @@ public class SftpInputStreamAsync extends InputStreamWithChannel implements Sftp
     protected void sendRequests() throws IOException {
         AbstractSftpClient client = getClient();
         Channel channel = client.getChannel();
-        Window localWindow = channel.getLocalWindow();
+        LocalWindow localWindow = channel.getLocalWindow();
         long windowSize = localWindow.getMaxSize();
         Session session = client.getSession();
         byte[] id = handle.getIdentifier();

--- a/sshd-sftp/src/main/java/org/apache/sshd/sftp/server/SftpSubsystem.java
+++ b/sshd-sftp/src/main/java/org/apache/sshd/sftp/server/SftpSubsystem.java
@@ -49,7 +49,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.apache.sshd.common.Factory;
 import org.apache.sshd.common.FactoryManager;
 import org.apache.sshd.common.channel.BufferedIoOutputStream;
-import org.apache.sshd.common.channel.Window;
+import org.apache.sshd.common.channel.LocalWindow;
 import org.apache.sshd.common.digest.BuiltinDigests;
 import org.apache.sshd.common.digest.DigestFactory;
 import org.apache.sshd.common.file.FileSystemAware;
@@ -292,16 +292,15 @@ public class SftpSubsystem
         long buffersCount = 0L;
         try {
             ChannelSession channel = getServerChannelSession();
-            Window localWindow = channel.getLocalWindow();
+            LocalWindow localWindow = channel.getLocalWindow();
             while (true) {
                 Buffer buffer = requests.take();
                 if (buffer == CLOSE) {
                     break;
                 }
-                int len = buffer.available();
                 buffersCount++;
                 process(buffer);
-                localWindow.consumeAndCheck(len);
+                localWindow.check();
             }
         } catch (Throwable t) {
             if (!closed.get()) { // Ignore


### PR DESCRIPTION
When channel data is received, the window size must be decremented right away. If we do this only once we've processed the received data, it's possible that we buffer a lot data if the peer (by mistake or malicious intent) ignores our window and just keeps on sending data.

However, sending back a SSH_MSG_CHANNEL_WINDOW_ADJUST message must occur only after the received data has been processed or forwarded.

Make Window an abstract class, and have two concrete subclasses for RemoteWindow and LocalWindow. This is safer, since we should never call check() on a remote window, or expand() on a local window. Also, do not let Window implement java.nio.channel.Channel. Just because it has a close() and an isOpen() method, a Window is not a channel.

Change all uses appropriately and replace all calls to consumeAndCheck() by check(). In AbstractChannel, call consume() right away when data is received on the SSH channel.

Refactor the way a channel's writePacket() method decides whether to write a packet. Introduce a new mayWrite() method so that less overriding in subclasses of AbstractChannel is needed when asynchronous streams are needed. (In that case, there may be pending writes that may need to be flushed, so writing must not stop on isClosing() but only on isClosed().)