### PR TITLE
[SSHD-1287] SFTP: better default buffer size handling

### DIFF
--- a/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/impl/AbstractSftpClient.java
+++ b/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/impl/AbstractSftpClient.java
@@ -1172,7 +1172,7 @@ public abstract class AbstractSftpClient
         if (bufferSize <= 0) {
             bufferSize = getReadBufferSize();
         }
-        if (bufferSize < MIN_WRITE_BUFFER_SIZE) {
+        if (bufferSize < MIN_READ_BUFFER_SIZE) {
             throw new IllegalArgumentException("Insufficient read buffer size: " + bufferSize + ", min.="
                                                + MIN_READ_BUFFER_SIZE);
         }
@@ -1182,12 +1182,6 @@ public abstract class AbstractSftpClient
         }
 
         return new SftpInputStreamAsync(this, bufferSize, path, mode);
-    }
-
-    @Override
-    public InputStream read(String path, Collection<OpenMode> mode) throws IOException {
-        int packetSize = (int) getChannel().getRemoteWindow().getPacketSize();
-        return read(path, packetSize, mode);
     }
 
     @Override
@@ -1207,18 +1201,12 @@ public abstract class AbstractSftpClient
         return new SftpOutputStreamAsync(this, bufferSize, path, mode);
     }
 
-    @Override
-    public OutputStream write(String path, Collection<OpenMode> mode) throws IOException {
-        int packetSize = (int) getChannel().getRemoteWindow().getPacketSize();
-        return write(path, packetSize, mode);
-    }
-
     protected int getReadBufferSize() {
         return (int) getClientChannel().getLocalWindow().getPacketSize() - 13;
     }
 
     protected int getWriteBufferSize() {
-        return (int) getClientChannel().getLocalWindow().getPacketSize() - 13;
+        return (int) getClientChannel().getRemoteWindow().getPacketSize() - 13;
     }
 
 }

--- a/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/impl/SftpInputStreamAsync.java
+++ b/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/impl/SftpInputStreamAsync.java
@@ -281,13 +281,15 @@ public class SftpInputStreamAsync extends InputStreamWithChannel implements Sftp
             SftpClient client = getClient();
             int cur = 0;
             while (cur < nb) {
-                int dlen = client.read(handle, clientOffset, data, cur, nb - cur, eof);
+                int dlen = client.read(handle, clientOffset + cur, data, cur, nb - cur, eof);
+                if (dlen > 0) {
+                    cur += dlen;
+                }
                 Boolean eofSignal = eof.getAndSet(null);
                 if ((dlen < 0) || ((eofSignal != null) && eofSignal.booleanValue())) {
                     eofIndicator = true;
                     break;
                 }
-                cur += dlen;
             }
 
             if (traceEnabled) {


### PR DESCRIPTION
Use the local window's packet size for reading, and the remote window's packet size for writing (both minus a bit for protocol overhead) as the default SFTP buffer size.

Fix SftpInputStreamAsync to also work for buffer sizes greater than twice what the server will ever return. Previously, the stream read data from the wrong offset in that case.