### PR TITLE
GH-263: Fix race condition in BufferedIoOutputStream

### DIFF
--- a/sshd-core/src/main/java/org/apache/sshd/common/channel/ChannelAsyncOutputStream.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/channel/ChannelAsyncOutputStream.java
@@ -294,7 +294,9 @@ public class ChannelAsyncOutputStream extends AbstractCloseable implements IoOut
         if (chunkLength < stillToSend && !(f instanceof BufferedFuture)) {
             // We can send only part of the data remaining: copy the buffer (if it hasn't been copied before) because
             // the original may be re-used, then send the bit we can send, and queue up a future for sending the rest.
-            f = new BufferedFuture(future.getId(), new ByteArrayBuffer(buffer.getCompactData()));
+            Buffer copied = new ByteArrayBuffer(stillToSend);
+            copied.putBuffer(buffer, false);
+            f = new BufferedFuture(future.getId(), copied);
             f.addListener(w -> future.setValue(w.getException() != null ? w.getException() : w.isWritten()));
         }
         if (chunkLength <= 0) {


### PR DESCRIPTION
Don't try to write a future that's already done in startWrite(). Just skip it and try the next one, if any.

Fixes #263.

Bug: https://github.com/apache/mina-sshd/issues/263