### PR TITLE
GH-268: Fix ClientConnectionService.sendHeartBeat()

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,8 @@
 
 ## Bug fixes
 
+* [GH-268](https://github.com/apache/mina-sshd/issues/268) (Regression in 2.9.0) Heartbeat should throw an exception if no reply arrives within the timeout.
+
 ## Major code re-factoring
 
 ## Potential compatibility issues

--- a/sshd-core/src/main/java/org/apache/sshd/common/future/GlobalRequestFuture.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/future/GlobalRequestFuture.java
@@ -21,7 +21,6 @@ package org.apache.sshd.common.future;
 import org.apache.sshd.common.SshConstants;
 import org.apache.sshd.common.SshException;
 import org.apache.sshd.common.io.IoWriteFuture;
-import org.apache.sshd.common.util.GenericUtils;
 import org.apache.sshd.common.util.buffer.Buffer;
 
 /**
@@ -110,15 +109,6 @@ public class GlobalRequestFuture extends DefaultSshFuture<GlobalRequestFuture>
     }
 
     /**
-     * Fulfills this future, marking it as failed.
-     *
-     * @param message An explanation of the failure reason
-     */
-    public void fail(String message) {
-        setValue(new SshException(GenericUtils.isEmpty(message) ? "Global request failure; unknown reason" : message));
-    }
-
-    /**
      * Retrieves the {@link ReplyHandler} of this future, if any.
      *
      * @return the handler, or {@code null} if none was set
@@ -163,7 +153,7 @@ public class GlobalRequestFuture extends DefaultSshFuture<GlobalRequestFuture>
             if (ioe != null) {
                 setValue(ioe);
             } else {
-                fail("Could not write global request " + getId() + " seqNo=" + getSequenceNumber());
+                setValue(new SshException("Could not write global request " + getId() + " seqNo=" + getSequenceNumber()));
             }
         }
     }

--- a/sshd-core/src/main/java/org/apache/sshd/common/global/GlobalRequestException.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/global/GlobalRequestException.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sshd.common.global;
+
+import org.apache.sshd.common.SshConstants;
+
+/**
+ * An exception that can be set on a {@link org.apache.sshd.common.future.GlobalRequestFuture} to indicate that the
+ * server sent back a failure reply.
+ */
+public class GlobalRequestException extends Exception {
+
+    private static final long serialVersionUID = 225802262556424684L;
+
+    private final int code;
+
+    /**
+     * Creates a new {@link GlobalRequestException} with the given SSH message code.
+     *
+     * @param code SSH message code to set; normally {@link SshConstants#SSH_MSG_UNIMPLEMENTED} or
+     *             {@link SshConstants#SSH_MSG_REQUEST_FAILURE}
+     */
+    public GlobalRequestException(int code) {
+        super(SshConstants.getCommandMessageName(code));
+        this.code = code;
+    }
+
+    /**
+     * Retrieves the SSH message code.
+     *
+     * @return the code, normally {@link SshConstants#SSH_MSG_UNIMPLEMENTED} or
+     *         {@link SshConstants#SSH_MSG_REQUEST_FAILURE}
+     */
+    public int getCode() {
+        return code;
+    }
+}

--- a/sshd-core/src/test/java/org/apache/sshd/common/session/GlobalRequestTest.java
+++ b/sshd-core/src/test/java/org/apache/sshd/common/session/GlobalRequestTest.java
@@ -35,6 +35,7 @@ import org.apache.sshd.common.SshConstants;
 import org.apache.sshd.common.channel.RequestHandler;
 import org.apache.sshd.common.config.keys.KeyUtils;
 import org.apache.sshd.common.future.GlobalRequestFuture;
+import org.apache.sshd.common.global.GlobalRequestException;
 import org.apache.sshd.common.session.helpers.AbstractConnectionServiceRequestHandler;
 import org.apache.sshd.common.signature.Signature;
 import org.apache.sshd.common.util.GenericUtils;
@@ -197,7 +198,7 @@ public class GlobalRequestTest extends BaseTestSupport {
                     case 0: {
                         j++;
                         Buffer reply = request.getBuffer();
-                        assertTrue("Expected success for request " + i, reply != null);
+                        assertNotNull("Expected success for request " + i, reply);
                         assertEquals("Expected a success", (byte) ('1' + j - 1), reply.getByte());
                         break;
                     }
@@ -205,14 +206,20 @@ public class GlobalRequestTest extends BaseTestSupport {
                         j++;
                         failure = request.getException();
                         assertNotNull("Expected failure for request " + i, failure);
-                        assertEquals("Unexpected failure reason for request " + i, "SSH_MSG_REQUEST_FAILURE",
-                                failure.getMessage());
+                        assertTrue("Unexpected failure type", failure instanceof GlobalRequestException);
+                        assertEquals("Unexpected failure reason for request " + i, SshConstants.SSH_MSG_REQUEST_FAILURE,
+                                ((GlobalRequestException) failure).getCode());
+                        assertTrue("Unexpected failure message for request " + i,
+                                failure.getMessage().contains("SSH_MSG_REQUEST_FAILURE"));
                         break;
                     default:
                         failure = request.getException();
                         assertNotNull("Expected failure for request " + i, failure);
-                        assertEquals("Unexpected failure reason for request " + i, "SSH_MSG_UNIMPLEMENTED",
-                                failure.getMessage());
+                        assertTrue("Unexpected failure type", failure instanceof GlobalRequestException);
+                        assertEquals("Unexpected failure reason for request " + i, SshConstants.SSH_MSG_UNIMPLEMENTED,
+                                ((GlobalRequestException) failure).getCode());
+                        assertTrue("Unexpected failure message for request " + i,
+                                failure.getMessage().contains("SSH_MSG_UNIMPLEMENTED"));
                         break;
                 }
             }


### PR DESCRIPTION
If a reply is requested, but none arrives within the timeout, throw an
exception and terminate the connection.

This rolls back the changes made in ClientConnectionService in commit
de2f8fef2e. It's quite all right to use the synchronous implementation of
Session.request() because heartbeats are not sent from I/O threads.

However, commit de2f8fef2e broke the contract specified in interface
Session, which says Session.request() must return "the buffer if the
request was successful, `null` otherwise." The implementation from
commit de2f8fef2e threw an exception instead.

This was wrong, and is corrected now in this commit. Note that this
means that a caller cannot distinguish between the server replying
SSH_MSG_UNIMPLEMENTED or SSH_MSG_REQUEST_FAILURE.

Where such distinction is needed, use an asynchronous global request
instead.

Fixes #268.