### PR TITLE
SFTP: parsing of SSH_FXP_STATUS

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,7 @@
 ## Bug fixes
 
 * [GH-268](https://github.com/apache/mina-sshd/issues/268) (Regression in 2.9.0) Heartbeat should throw an exception if no reply arrives within the timeout.
+* [GH-275](https://github.com/apache/mina-sshd/issues/275) SFTP: be more lenient when reading SSH_FXP_STATUS replies.
 
 ## Major code re-factoring
 

--- a/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/impl/DefaultSftpClient.java
+++ b/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/impl/DefaultSftpClient.java
@@ -416,12 +416,7 @@ public class DefaultSftpClient extends AbstractSftpClient {
                 extensions.put(name, data);
             }
         } else if (type == SftpConstants.SSH_FXP_STATUS) {
-            SftpStatus status = SftpStatus.parse(buffer);
-            if (traceEnabled) {
-                log.trace("handleInitResponse({})[id={}] - status: {}", clientChannel, id, status);
-            }
-
-            throwStatusException(SftpConstants.SSH_FXP_INIT, id, status);
+            throwStatusException(SftpConstants.SSH_FXP_INIT, id, SftpStatus.parse(buffer));
         } else {
             IOException err = handleUnexpectedPacket(
                     SftpConstants.SSH_FXP_INIT, SftpConstants.SSH_FXP_VERSION, id, type, length, buffer);

--- a/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/impl/DefaultSftpClient.java
+++ b/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/impl/DefaultSftpClient.java
@@ -416,15 +416,12 @@ public class DefaultSftpClient extends AbstractSftpClient {
                 extensions.put(name, data);
             }
         } else if (type == SftpConstants.SSH_FXP_STATUS) {
-            int substatus = buffer.getInt();
-            String msg = buffer.getString();
-            String lang = buffer.getString();
+            SftpStatus status = SftpStatus.parse(buffer);
             if (traceEnabled) {
-                log.trace("handleInitResponse({})[id={}] - status: {} [{}] {}",
-                        clientChannel, id, SftpConstants.getStatusName(substatus), lang, msg);
+                log.trace("handleInitResponse({})[id={}] - status: {}", clientChannel, id, status);
             }
 
-            throwStatusException(SftpConstants.SSH_FXP_INIT, id, substatus, msg, lang);
+            throwStatusException(SftpConstants.SSH_FXP_INIT, id, status);
         } else {
             IOException err = handleUnexpectedPacket(
                     SftpConstants.SSH_FXP_INIT, SftpConstants.SSH_FXP_VERSION, id, type, length, buffer);

--- a/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/impl/SftpInputStreamAsync.java
+++ b/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/impl/SftpInputStreamAsync.java
@@ -333,13 +333,11 @@ public class SftpInputStreamAsync extends InputStreamWithChannel implements Sftp
             buf.wpos(rpos + dlen);
             this.buffer = buf;
         } else if (type == SftpConstants.SSH_FXP_STATUS) {
-            int substatus = buf.getInt();
-            String msg = buf.getString();
-            String lang = buf.getString();
-            if (substatus == SftpConstants.SSH_FX_EOF) {
+            SftpStatus status = SftpStatus.parse(buf);
+            if (status.getStatusCode() == SftpConstants.SSH_FX_EOF) {
                 eofIndicator = true;
             } else {
-                client.checkResponseStatus(SshConstants.SSH_MSG_CHANNEL_DATA, id, substatus, msg, lang);
+                client.checkResponseStatus(SshConstants.SSH_MSG_CHANNEL_DATA, id, status);
             }
         } else {
             IOException err = client.handleUnexpectedPacket(SshConstants.SSH_MSG_CHANNEL_DATA,

--- a/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/impl/SftpStatus.java
+++ b/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/impl/SftpStatus.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sshd.sftp.client.impl;
+
+import org.apache.sshd.common.util.buffer.Buffer;
+import org.apache.sshd.sftp.common.SftpConstants;
+
+/**
+ * A representation of a SSH_FXP_STATUS record.
+ */
+public final class SftpStatus {
+
+    private final int statusCode;
+
+    private final String language;
+
+    private final String message;
+
+    private SftpStatus(int statusCode, String message, String language) {
+        this.statusCode = statusCode;
+        this.message = message;
+        this.language = language;
+    }
+
+    public int getStatusCode() {
+        return statusCode;
+    }
+
+    public String getLanguage() {
+        return language;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public boolean isOk() {
+        return statusCode == SftpConstants.SSH_FX_OK;
+    }
+
+    @Override
+    public String toString() {
+        return "SSH_FXP_STATUS[" + SftpConstants.getStatusName(statusCode) + " ,language=" + language + " ,message=" + message
+               + ']';
+    }
+
+    public static SftpStatus parse(Buffer buffer) {
+        int code = buffer.getInt();
+        // Treat the message and language tag as optional. These fields did not exist in SFTP v0-2, and there are
+        // apparently SFTP v3 servers that sometimes send SSH_FXP_STATUS without them.
+        String message = buffer.available() > 0 ? buffer.getString() : null;
+        String language = buffer.available() > 0 ? buffer.getString() : null;
+        return new SftpStatus(code, message, language);
+    }
+}

--- a/sshd-sftp/src/test/java/org/apache/sshd/sftp/client/impl/SftpStatusTest.java
+++ b/sshd-sftp/src/test/java/org/apache/sshd/sftp/client/impl/SftpStatusTest.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sshd.sftp.client.impl;
+
+import org.apache.sshd.common.util.buffer.Buffer;
+import org.apache.sshd.common.util.buffer.ByteArrayBuffer;
+import org.apache.sshd.sftp.common.SftpConstants;
+import org.apache.sshd.util.test.NoIoTestCase;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for {@link SftpStatus}.
+ */
+@Category(NoIoTestCase.class)
+public class SftpStatusTest {
+
+    public SftpStatusTest() {
+        super();
+    }
+
+    @Test
+    public void testOkStatus() {
+        Buffer buffer = new ByteArrayBuffer();
+        buffer.putInt(SftpConstants.SSH_FX_OK);
+        buffer.putString("An error message");
+        buffer.putString("en");
+        SftpStatus status = SftpStatus.parse(buffer);
+        assertEquals("Unexpected status code", SftpConstants.SSH_FX_OK, status.getStatusCode());
+        assertEquals("Unexpected error message", "An error message", status.getMessage());
+        assertEquals("Unexpected language tag", "en", status.getLanguage());
+        assertTrue("Status should be OK", status.isOk());
+    }
+
+    @Test
+    public void testOkStatusNoMessage() {
+        Buffer buffer = new ByteArrayBuffer();
+        buffer.putInt(SftpConstants.SSH_FX_OK);
+        SftpStatus status = SftpStatus.parse(buffer);
+        assertEquals("Unexpected status code", SftpConstants.SSH_FX_OK, status.getStatusCode());
+        assertNull("Unexpected error message", status.getMessage());
+        assertNull("Unexpected language tag", status.getLanguage());
+        assertTrue("Status should be OK", status.isOk());
+    }
+
+    @Test
+    public void testNokStatus() {
+        Buffer buffer = new ByteArrayBuffer();
+        buffer.putInt(SftpConstants.SSH_FX_EOF);
+        buffer.putString("An error message");
+        buffer.putString("en");
+        SftpStatus status = SftpStatus.parse(buffer);
+        assertEquals("Unexpected status code", SftpConstants.SSH_FX_EOF, status.getStatusCode());
+        assertEquals("Unexpected error message", "An error message", status.getMessage());
+        assertEquals("Unexpected language tag", "en", status.getLanguage());
+        assertFalse("Status should be OK", status.isOk());
+    }
+
+    @Test
+    public void testNokStatusNoMessage() {
+        Buffer buffer = new ByteArrayBuffer();
+        buffer.putInt(SftpConstants.SSH_FX_FAILURE);
+        SftpStatus status = SftpStatus.parse(buffer);
+        assertEquals("Unexpected status code", SftpConstants.SSH_FX_FAILURE, status.getStatusCode());
+        assertNull("Unexpected error message", status.getMessage());
+        assertNull("Unexpected language tag", status.getLanguage());
+        assertFalse("Status should be OK", status.isOk());
+    }
+}


### PR DESCRIPTION
Treat the error message and the language tag as optional. It appears that there are SFTP v3 servers that send status records without these fields. Also improve the client-side logging of SFTP requests and responses.

Fixes #275.