### PR TITLE
GH-283: Fix handling of CoreModuleProperties.PASSWORD_PROMPTS

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,17 +25,18 @@
 ## Bug fixes
 
 * [GH-268](https://github.com/apache/mina-sshd/issues/268) (Regression in 2.9.0) Heartbeat should throw an exception if no reply arrives within the timeout.
-* [GH-275](https://github.com/apache/mina-sshd/issues/275) SFTP: be more lenient when reading SSH_FXP_STATUS replies.
+* [GH-275](https://github.com/apache/mina-sshd/issues/275) SFTP: be more lenient when reading `SSH_FXP_STATUS` replies.
 * [GH-282](https://github.com/apache/mina-sshd/issues/282) Correct setting file permissions on newly written host key files on Windows.
+* [GH-283](https://github.com/apache/mina-sshd/issues/283) Fix handling of `CoreModuleProperties.PASSWORD_PROMPTS`.
 * [GH-285](https://github.com/apache/mina-sshd/issues/285) Fix compilation failure on Java 19.
-* [GH-294](https://github.com/apache/mina-sshd/issues/294) Fix memory leak in SftpFileSystemProvider.
+* [GH-294](https://github.com/apache/mina-sshd/issues/294) Fix memory leak in `SftpFileSystemProvider`.
 * [GH-297](https://github.com/apache/mina-sshd/issues/297) Auto-configure file password provider for reading encrypted SSH keys.
 * [GH-298](https://github.com/apache/mina-sshd/issues/298) Server side heartbeat not working.
-* [GH-300](https://github.com/apache/mina-sshd/issues/300) Read the channel id in SSH_MSG_CHANNEL_OPEN_CONFIRMATION as unsigned int.
+* [GH-300](https://github.com/apache/mina-sshd/issues/300) Read the channel id in `SSH_MSG_CHANNEL_OPEN_CONFIRMATION` as unsigned int.
 
 
-* [SSHD-1315](https://issues.apache.org/jira/browse/SSHD-1315) Do not log sensitive data at log level TRACE.
-* [SSHD-1316](https://issues.apache.org/jira/browse/SSHD-1316) Possible OOM in ChannelPipedInputStream (fix channel window).
+* [SSHD-1315](https://issues.apache.org/jira/browse/SSHD-1315) Do not log sensitive data at log level `TRACE`.
+* [SSHD-1316](https://issues.apache.org/jira/browse/SSHD-1316) Possible OOM in `ChannelPipedInputStream` (fix channel window).
 
 
 ## Major code re-factoring
@@ -45,3 +46,11 @@
 ## Minor code helpers
 
 ## Behavioral changes and enhancements
+
+* `CoreModuleProperties.PASSWORD_PROMPTS` is now also used for password authentication. Previous versions used it only for keyboard-interactive authentication.
+  The semantics has been clarified to be the equivalent of the OpenSSH configuration `NumberOfPasswordPrompts`, which is actually the number of authentication
+  *attempts*. (In keyboard-interactive authentication, there may be several prompts per authentication attempt.) Only interactive authentication attempts
+  using `UserInteraction` count towards the limit. Attempts fulfilled by explicitly provided passwords (via `session.addPasswordIdentity()` or
+  `session.setPasswordIdentityProvider()`) are *not* counted. The default value of the property is unchanged and is 3, as in OpenSSH. The limit is applied
+  independently for both authentication mechanisms: with the default setting, there can be three keyboard-interactive authentication attempts, plus three
+  more password authentication attempts if both methods are configured and applicable.

--- a/sshd-core/src/main/java/org/apache/sshd/client/auth/keyboard/UserAuthKeyboardInteractive.java
+++ b/sshd-core/src/main/java/org/apache/sshd/client/auth/keyboard/UserAuthKeyboardInteractive.java
@@ -20,7 +20,6 @@ package org.apache.sshd.client.auth.keyboard;
 
 import java.util.Iterator;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.sshd.client.auth.AbstractUserAuth;
 import org.apache.sshd.client.session.ClientSession;
@@ -28,7 +27,6 @@ import org.apache.sshd.common.PropertyResolverUtils;
 import org.apache.sshd.common.RuntimeSshException;
 import org.apache.sshd.common.SshConstants;
 import org.apache.sshd.common.util.GenericUtils;
-import org.apache.sshd.common.util.ValidateUtils;
 import org.apache.sshd.common.util.buffer.Buffer;
 import org.apache.sshd.core.CoreModuleProperties;
 
@@ -42,10 +40,11 @@ public class UserAuthKeyboardInteractive extends AbstractUserAuth {
     public static final String NAME = UserAuthKeyboardInteractiveFactory.NAME;
 
     private final AtomicBoolean requestPending = new AtomicBoolean(false);
-    private final AtomicInteger trialsCount = new AtomicInteger(0);
-    private final AtomicInteger emptyCount = new AtomicInteger(0);
     private Iterator<String> passwords;
-    private int maxTrials;
+    private int maxAttempts;
+    private int nOfAttempts;
+    private boolean wasChallenged;
+    private boolean withUserInteraction;
 
     public UserAuthKeyboardInteractive() {
         super(NAME);
@@ -55,8 +54,10 @@ public class UserAuthKeyboardInteractive extends AbstractUserAuth {
     public void init(ClientSession session, String service) throws Exception {
         super.init(session, service);
         passwords = ClientSession.passwordIteratorOf(session);
-        maxTrials = CoreModuleProperties.PASSWORD_PROMPTS.getRequired(session);
-        ValidateUtils.checkTrue(maxTrials > 0, "Non-positive max. trials: %d", maxTrials);
+        maxAttempts = Math.max(1, CoreModuleProperties.PASSWORD_PROMPTS.getRequired(session));
+        nOfAttempts = 0;
+        wasChallenged = false;
+        withUserInteraction = false;
     }
 
     @Override
@@ -71,7 +72,15 @@ public class UserAuthKeyboardInteractive extends AbstractUserAuth {
             return false;
         }
 
-        if (!verifyTrialsCount(session, service, SshConstants.SSH_MSG_USERAUTH_REQUEST, trialsCount.get(), maxTrials)) {
+        nOfAttempts++;
+        if (wasChallenged && !withUserInteraction) {
+            // We did increment on the previous attempt, but then had no user interaction for the challenge(s). The
+            // count is one too high.
+            nOfAttempts--;
+        }
+        wasChallenged = false;
+        withUserInteraction = false;
+        if (!verifyTrialsCount(session, service, SshConstants.SSH_MSG_USERAUTH_REQUEST, nOfAttempts, maxAttempts)) {
             return false;
         }
 
@@ -123,12 +132,6 @@ public class UserAuthKeyboardInteractive extends AbstractUserAuth {
             log.debug(
                     "processAuthDataRequest({})[{}] SSH_MSG_USERAUTH_INFO_REQUEST name={}, instruction={}, language={}, num-prompts={}",
                     session, service, name, instruction, lang, num);
-        }
-
-        // SSHD-866
-        int retriesCount = (num > 0) ? trialsCount.incrementAndGet() : emptyCount.incrementAndGet();
-        if (!verifyTrialsCount(session, service, cmd, retriesCount, maxTrials)) {
-            return false;
         }
 
         String[] prompt = (num > 0) ? new String[num] : GenericUtils.EMPTY_STRING_ARRAY;
@@ -222,8 +225,7 @@ public class UserAuthKeyboardInteractive extends AbstractUserAuth {
      *                     responsibility to enforce this we do not validate the response (other than logging it as a
      *                     warning...)
      */
-    protected String[] getUserResponses(
-            String name, String instruction, String lang, String[] prompt, boolean[] echo) {
+    protected String[] getUserResponses(String name, String instruction, String lang, String[] prompt, boolean[] echo) {
         ClientSession session = getClientSession();
         int num = GenericUtils.length(prompt);
         boolean debugEnabled = log.isDebugEnabled();
@@ -240,6 +242,8 @@ public class UserAuthKeyboardInteractive extends AbstractUserAuth {
             return GenericUtils.EMPTY_STRING_ARRAY;
         }
 
+        wasChallenged = true;
+
         if (PropertyResolverUtils.getBooleanProperty(
                 session, UserInteraction.AUTO_DETECT_PASSWORD_PROMPT,
                 UserInteraction.DEFAULT_AUTO_DETECT_PASSWORD_PROMPT)) {
@@ -252,6 +256,7 @@ public class UserAuthKeyboardInteractive extends AbstractUserAuth {
             }
         }
 
+        withUserInteraction = true;
         UserInteraction ui = session.getUserInteraction();
         try {
             if ((ui != null) && ui.isInteractionAllowed(session)) {

--- a/sshd-core/src/main/java/org/apache/sshd/core/CoreModuleProperties.java
+++ b/sshd-core/src/main/java/org/apache/sshd/core/CoreModuleProperties.java
@@ -98,7 +98,8 @@ public final class CoreModuleProperties {
             = Property.string("preferred-auths");
 
     /**
-     * Specifies the number of interactive prompts before giving up. The argument to this keyword must be an integer.
+     * Specifies the number of interactive attempts at password or keyboard-interactive user authentication before
+     * giving up. The argument to this keyword must be an integer; if &lt;= 0, the value 1 is substituted.
      */
     public static final Property<Integer> PASSWORD_PROMPTS
             = Property.integer("password-prompts", 3);

--- a/sshd-core/src/test/java/org/apache/sshd/common/auth/PasswordAuthenticationTest.java
+++ b/sshd-core/src/test/java/org/apache/sshd/common/auth/PasswordAuthenticationTest.java
@@ -495,6 +495,6 @@ public class PasswordAuthenticationTest extends AuthenticationTestSupport {
         }
 
         assertEquals("Mismatched invocation count", 1, exhaustedCount.getAndSet(0));
-        assertEquals("Mismatched retries count", 4 /* 3 attempts + null */, attemptsCount.getAndSet(0));
+        assertEquals("Mismatched retries count", 3, attemptsCount.getAndSet(0));
     }
 }


### PR DESCRIPTION
GH-283: Fix handling of CoreModuleProperties.PASSWORD_PROMPTS

The setting was not considered in password authentication, and in
keyboard-interactive authentication counted the number of non-empty
challenges, which could lead to an extra authentication request
message to be sent, or to keyboard-interactive authentication being
aborted too early.

The property is supposed to correspond to the OpenSSH configuration
NumberOfPasswordPrompts, which despite the name counts not the number
of prompts but the number of times password or keyboard-interactive
authentication is attempted. For password authentication, this is
the same (if one ignores possible password-change requests), but in
keyboard-interactive authentication, there may be several prompts
per attempt.

Fix the implementation in Apache MINA sshd to respect the limit in
both password and keyboard-interactive authentication, and in both
apply the limit to the count of interactive authentication attempts.

If password identities are provided on a session non-interactively
(via addPasswordIdentity(), or via a custom PasswordIdentityProvider
set with setPasswordIdentityProvider()), any authentication attempts
that are answered non-interactively do not count towards the limit.

Fixes #283.