### PR TITLE
GH-282: Fix ACL for host key file on Windows

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,7 @@
 
 * [GH-268](https://github.com/apache/mina-sshd/issues/268) (Regression in 2.9.0) Heartbeat should throw an exception if no reply arrives within the timeout.
 * [GH-275](https://github.com/apache/mina-sshd/issues/275) SFTP: be more lenient when reading SSH_FXP_STATUS replies.
+* [GH-282](https://github.com/apache/mina-sshd/issues/282) Correct setting file permissions on newly written host key files on Windows.
 * [GH-285](https://github.com/apache/mina-sshd/issues/285) Fix compilation failure on Java 19.
 
 ## Major code re-factoring


### PR DESCRIPTION
Apparently it is possible on Windows that the ACL for a file have no entry for the file owner. (Typically the owner is then member of a group, and there is an entry for the group.) The previous code would in such cases remove all access permissions from all entries, resulting in a file that even the owner could no longer access.

Change the logic: not only remove all permissions for non-owner entries but also add an explicit entry for the owner, giving it full access permissions.

Fixes #282.