### PR TITLE
GH-285: Fix compilation failure on Java 19

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,7 @@
 
 * [GH-268](https://github.com/apache/mina-sshd/issues/268) (Regression in 2.9.0) Heartbeat should throw an exception if no reply arrives within the timeout.
 * [GH-275](https://github.com/apache/mina-sshd/issues/275) SFTP: be more lenient when reading SSH_FXP_STATUS replies.
+* [GH-285](https://github.com/apache/mina-sshd/issues/285) Fix compilation failure on Java 19.
 
 ## Major code re-factoring
 

--- a/sshd-common/src/main/java/org/apache/sshd/common/util/threads/CloseableExecutorService.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/util/threads/CloseableExecutorService.java
@@ -19,6 +19,7 @@
 
 package org.apache.sshd.common.util.threads;
 
+import java.io.IOException;
 import java.time.Duration;
 import java.util.Objects;
 import java.util.concurrent.ExecutorService;
@@ -30,5 +31,10 @@ public interface CloseableExecutorService extends ExecutorService, Closeable {
     default boolean awaitTermination(Duration timeout) throws InterruptedException {
         Objects.requireNonNull(timeout, "No timeout specified");
         return awaitTermination(timeout.toMillis(), TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    default void close() throws IOException {
+        Closeable.super.close();
     }
 }


### PR DESCRIPTION
`ExecutorService` implements `AutoCloseable` in Java 19 and provides a default method for `close()`. This conflicts in `CloseableExecutorService`, which mixes in `org.apache.sshd.common.Closeable`, which has its own default method for `close()`.

As a minimum fix add overrides of `close()` as needed, explicitly calling the Apache MINA sshd variant of `close()`.

Fixes #285.