### PR TITLE
GH-285: Fix compilation failure on Java 19

### DIFF
--- a/sshd-common/src/main/java/org/apache/sshd/common/util/threads/CloseableExecutorService.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/util/threads/CloseableExecutorService.java
@@ -20,6 +20,7 @@
 package org.apache.sshd.common.util.threads;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.time.Duration;
 import java.util.Objects;
 import java.util.concurrent.ExecutorService;
@@ -34,7 +35,11 @@ public interface CloseableExecutorService extends ExecutorService, Closeable {
     }
 
     @Override
-    default void close() throws IOException {
-        Closeable.super.close();
+    default void close() {
+        try {
+            Closeable.super.close();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
     }
 }


### PR DESCRIPTION
Follow-up to 03986c5b8a31e6f32843067f14e983a361cb6759

Bug: https://github.com/apache/mina-sshd/issues/285