### PR TITLE
[SSHD-1315] Improve logging

### DIFF
--- a/sshd-common/src/main/java/org/apache/sshd/common/util/buffer/Buffer.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/util/buffer/Buffer.java
@@ -247,8 +247,27 @@ public abstract class Buffer implements Readable {
     }
 
     public void dumpHex(SimplifiedLog logger, Level level, String prefix, PropertyResolver resolver) {
+        byte[] data = array();
+        int rpos = rpos();
+        int length = available();
+        if (length > 0) {
+            int cmd = data[rpos] & 0xFF;
+            if (isSensitiveData(cmd)) {
+                return;
+            }
+        }
         BufferUtils.dumpHex(
-                logger, level, prefix, resolver, BufferUtils.DEFAULT_HEX_SEPARATOR, array(), rpos(), available());
+                logger, level, prefix, resolver, BufferUtils.DEFAULT_HEX_SEPARATOR, data, rpos, length);
+    }
+
+    private static boolean isSensitiveData(int cmd) {
+        switch (cmd) {
+            case SshConstants.SSH_MSG_USERAUTH_REQUEST:
+            case SshConstants.SSH_MSG_USERAUTH_INFO_RESPONSE:
+                return true;
+            default:
+                return false;
+        }
     }
 
     /*

--- a/sshd-core/src/main/java/org/apache/sshd/client/auth/keyboard/UserAuthKeyboardInteractive.java
+++ b/sshd-core/src/main/java/org/apache/sshd/client/auth/keyboard/UserAuthKeyboardInteractive.java
@@ -173,7 +173,8 @@ public class UserAuthKeyboardInteractive extends AbstractUserAuth {
         for (int index = 0; index < numResponses; index++) {
             String r = rep[index];
             if (traceEnabled) {
-                log.trace("processAuthDataRequest({})[{}] response #{}: {}", session, service, index + 1, r);
+                log.trace("processAuthDataRequest({})[{}] response #{}: {}", session, service, index + 1,
+                        (index < num && echo[index]) ? r : "(hidden)");
             }
             buffer.putString(r);
         }

--- a/sshd-core/src/main/java/org/apache/sshd/server/auth/keyboard/UserAuthKeyboardInteractive.java
+++ b/sshd-core/src/main/java/org/apache/sshd/server/auth/keyboard/UserAuthKeyboardInteractive.java
@@ -116,12 +116,8 @@ public class UserAuthKeyboardInteractive extends AbstractUserAuth {
         }
 
         List<String> responses = (num <= 0) ? Collections.emptyList() : new ArrayList<>(num);
-        boolean traceEnabled = log.isTraceEnabled();
         for (int index = 1; index <= num; index++) {
             String value = buffer.getString();
-            if (traceEnabled) {
-                log.trace("doAuth({}@{}) response {}/{}: {}", username, session, index, num, value);
-            }
             responses.add(value);
         }
 


### PR DESCRIPTION
With trace logging on, sensitive data in keyboard-interactive or in password user authentication ended up being logged via two paths both in a client or in a server.

In a client:
- when logging outgoing packets just before they are encrypted
- when logging challenge responses in keyboard-interactive auth

In a server:
- when logging incoming packets just after having been decrypted
- when logging received challenge responses (keyboard-interactive auth)

Avoid this by not logging raw packet contents for
SSH_MSG_USERAUTH_REQUEST and SSH_MSG_USERAUTH_INFO_RESPONSE. In the client, log challenge responses with echo=false as "(hidden)", and in the server don't log the received challenge responses at all, only their number.

All these log messages are active only for trace logging, which is intended for detailed debugging. There is no reason to use trace logging on a production instance (it also may impact performance quite negatively).