### PR TITLE
Fix the channel window logic

### DIFF
--- a/sshd-core/src/main/java/org/apache/sshd/agent/local/AgentForwardedChannel.java
+++ b/sshd-core/src/main/java/org/apache/sshd/agent/local/AgentForwardedChannel.java
@@ -101,7 +101,7 @@ public class AgentForwardedChannel extends AbstractClientChannel {
             outputStream.flush();
 
             LocalWindow wLocal = getLocalWindow();
-            wLocal.check();
+            wLocal.release(reqLen);
             return waitForMessageBuffer();
         }
     }

--- a/sshd-core/src/main/java/org/apache/sshd/agent/unix/AgentForwardedChannel.java
+++ b/sshd-core/src/main/java/org/apache/sshd/agent/unix/AgentForwardedChannel.java
@@ -81,7 +81,7 @@ public class AgentForwardedChannel extends AbstractClientChannel implements Runn
     protected synchronized void doWriteData(byte[] data, int off, long len) throws IOException {
         ValidateUtils.checkTrue(len <= Integer.MAX_VALUE, "Data length exceeds int boundaries: %d", len);
         LocalWindow wLocal = getLocalWindow();
-        wLocal.check();
+        wLocal.release(len);
 
         int result = Socket.send(socket, data, off, (int) len);
         if (result < Status.APR_SUCCESS) {

--- a/sshd-core/src/main/java/org/apache/sshd/client/channel/AbstractClientChannel.java
+++ b/sshd-core/src/main/java/org/apache/sshd/client/channel/AbstractClientChannel.java
@@ -438,7 +438,7 @@ public abstract class AbstractClientChannel extends AbstractChannel implements C
             } finally {
                 if (invertedOut == null) {
                     LocalWindow wLocal = getLocalWindow();
-                    wLocal.check();
+                    wLocal.release(len);
                 }
             }
         } else {
@@ -464,7 +464,7 @@ public abstract class AbstractClientChannel extends AbstractChannel implements C
             } finally {
                 if (invertedErr == null) {
                     LocalWindow wLocal = getLocalWindow();
-                    wLocal.check();
+                    wLocal.release(len);
                 }
             }
         } else {

--- a/sshd-core/src/main/java/org/apache/sshd/client/channel/ChannelDirectTcpip.java
+++ b/sshd-core/src/main/java/org/apache/sshd/client/channel/ChannelDirectTcpip.java
@@ -120,7 +120,7 @@ public class ChannelDirectTcpip extends AbstractClientChannel {
         pipe.flush();
 
         LocalWindow wLocal = getLocalWindow();
-        wLocal.check();
+        wLocal.release(len);
     }
 
     public SshdSocketAddress getLocalSocketAddress() {

--- a/sshd-core/src/main/java/org/apache/sshd/common/channel/ChannelAsyncInputStream.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/channel/ChannelAsyncInputStream.java
@@ -138,7 +138,7 @@ public class ChannelAsyncInputStream extends AbstractCloseable implements IoInpu
             Channel channel = getChannel();
             try {
                 LocalWindow wLocal = channel.getLocalWindow();
-                wLocal.check();
+                wLocal.release(nbRead);
             } catch (IOException e) {
                 Session session = channel.getSession();
                 session.exceptionCaught(e);

--- a/sshd-core/src/main/java/org/apache/sshd/common/channel/ChannelPipedInputStream.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/channel/ChannelPipedInputStream.java
@@ -160,7 +160,7 @@ public class ChannelPipedInputStream extends InputStream implements ChannelPiped
             lock.unlock();
         }
         if (localWindow.isOpen()) {
-            localWindow.check();
+            localWindow.release(len);
         }
         return len;
     }

--- a/sshd-core/src/main/java/org/apache/sshd/common/channel/LocalWindow.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/channel/LocalWindow.java
@@ -20,6 +20,7 @@ package org.apache.sshd.common.channel;
 
 import java.io.IOException;
 import java.io.StreamCorruptedException;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.sshd.common.PropertyResolver;
 import org.apache.sshd.common.util.buffer.BufferUtils;
@@ -37,6 +38,10 @@ import org.apache.sshd.core.CoreModuleProperties;
 public class LocalWindow extends Window {
 
     private final AbstractChannel channel;
+
+    private final AtomicLong adjustment = new AtomicLong();
+
+    private long released;
 
     public LocalWindow(AbstractChannel channel, boolean isClient) {
         super(channel, isClient);
@@ -59,6 +64,7 @@ public class LocalWindow extends Window {
         init(CoreModuleProperties.WINDOW_SIZE.getRequired(resolver),
                 CoreModuleProperties.MAX_PACKET_SIZE.getRequired(resolver),
                 resolver);
+        released = 0;
     }
 
     @Override
@@ -82,25 +88,52 @@ public class LocalWindow extends Window {
         }
     }
 
-    public void check() throws IOException {
+    /**
+     * Updates the window once data that has arrived in a channel has been read, making available room for the sender
+     * too send more data, sending a window adjust message if necessary.
+     *
+     * @param  len         length of data read from the channel
+     * @throws IOException if sending a window adjust message fails
+     */
+    public void release(long len) throws IOException {
         checkInitialized("check");
-
+        if (len < 0) {
+            throw new IllegalArgumentException("LocalWindow: number of released bytes must be positive, was " + len);
+        }
         long maxFree = getMaxSize();
-        long adjustSize = -1L;
-        AbstractChannel channel = getChannel();
+        long packetSize = getPacketSize();
+        boolean trySend = false;
         synchronized (lock) {
-            // TODO make the adjust factor configurable via FactoryManager property
-            long size = getSize();
-            if (size < (maxFree / 2)) {
-                adjustSize = maxFree - size;
-                channel.sendWindowAdjust(adjustSize);
-                updateSize(maxFree);
+            released += len;
+            // If the reader from the channel reads in small chunks (for instance, single bytes), we'll get called
+            // frequently with very small "len". In such a case, the reader is likely to be (much) slower than the
+            // sender, and we may end up sending a window adjustment for every single byte. Avoid that by requiring
+            // at least some halfway reasonable amount having been released before sending a window adjustment.
+            if (released > packetSize / 2 || released > maxFree / 10 || released > 16 * 1024) {
+                // TODO make the adjust factor configurable via FactoryManager property
+                long size = getSize();
+                // Same logic as in OpenSSH
+                if (size < maxFree / 2 || maxFree - size > 3 * packetSize) {
+                    // Math.min() is just belt and suspenders; size + released <= maxFree should always be true
+                    long newSize = Math.min(size + released, maxFree);
+                    if (newSize > size) { // This, too, should always be true
+                        long adjustSize = adjustment.addAndGet(newSize - size);
+                        if (log.isDebugEnabled()) {
+                            log.debug("Increase {}: released now {}, total {}, adjustment {}, new size {}", this, len, released,
+                                    adjustSize, newSize);
+                        }
+                        released = 0;
+                        trySend = true;
+                        updateSize(newSize);
+                    }
+                }
             }
         }
-
-        if (adjustSize >= 0L) {
-            if (log.isDebugEnabled()) {
-                log.debug("Increase {} by {} up to {}", this, adjustSize, maxFree);
+        // If a window adjust message is to be sent do it outside of the lock.
+        if (trySend) {
+            long adjustSize = adjustment.getAndSet(0);
+            if (adjustSize > 0) {
+                getChannel().sendWindowAdjust(adjustSize);
             }
         }
     }

--- a/sshd-core/src/main/java/org/apache/sshd/server/channel/ChannelSession.java
+++ b/sshd-core/src/main/java/org/apache/sshd/server/channel/ChannelSession.java
@@ -250,7 +250,7 @@ public class ChannelSession extends AbstractServerChannel {
             int r = receiver.data(this, data, off, reqLen);
             if (r > 0) {
                 LocalWindow wLocal = getLocalWindow();
-                wLocal.check();
+                wLocal.release(r);
             }
         } else {
             ValidateUtils.checkTrue(len <= (Integer.MAX_VALUE - Long.SIZE),

--- a/sshd-core/src/main/java/org/apache/sshd/server/x11/ChannelForwardedX11.java
+++ b/sshd-core/src/main/java/org/apache/sshd/server/x11/ChannelForwardedX11.java
@@ -97,7 +97,7 @@ public class ChannelForwardedX11 extends AbstractClientChannel {
         ValidateUtils.checkTrue(len <= Integer.MAX_VALUE,
                 "Data length exceeds int boundaries: %d", len);
         LocalWindow wLocal = getLocalWindow();
-        wLocal.check();
+        wLocal.release(len);
         // use a clone in case data buffer is re-used
         Buffer packet = ByteArrayBuffer.getCompactClone(data, off, (int) len);
         serverSession.writeBuffer(packet);

--- a/sshd-core/src/test/java/org/apache/sshd/util/test/AsyncEchoShellFactory.java
+++ b/sshd-core/src/test/java/org/apache/sshd/util/test/AsyncEchoShellFactory.java
@@ -154,7 +154,7 @@ public class AsyncEchoShellFactory implements ShellFactory {
                         if (future.isWritten()) {
                             try {
                                 LocalWindow wLocal = channel.getLocalWindow();
-                                wLocal.check();
+                                wLocal.release(bytes.length);
                             } catch (IOException e) {
                                 session1.exceptionCaught(e);
                             }

--- a/sshd-sftp/src/main/java/org/apache/sshd/sftp/server/SftpSubsystem.java
+++ b/sshd-sftp/src/main/java/org/apache/sshd/sftp/server/SftpSubsystem.java
@@ -298,9 +298,10 @@ public class SftpSubsystem
                 if (buffer == CLOSE) {
                     break;
                 }
+                int len = buffer.available();
                 buffersCount++;
                 process(buffer);
-                localWindow.check();
+                localWindow.release(len);
             }
         } catch (Throwable t) {
             if (!closed.get()) { // Ignore


### PR DESCRIPTION
The previous implementation would always reset the window to the maximum size when it had dropped to below half the maximum size.

This was wrong and defeated the purpose of having a window. The window size is reduced upon reception of the data, and incremented when the reader from the channel has read some data. With a slow reader and a fast sender, the window would be opened fully even if the reader had not read the previously accumulated data. As a result, internal buffers could exceed the window size by a lot.

(Consider the very good description in ChannelDataReceiver: if the exit toll booth always tells the entry the bridge was free again, far too many cars would be let onto the bridge. With a real bridge, there'd be a gigantic traffic jam; with Apache MINA sshd, the bridge (the internal buffers) would just get longer and longer.)

Change the algorithm to increase the window size only by as much as has actually been read by the channel reader. Use the same logic as OpenSSH: send a window adjustment message when the available size is smaller than half the full window size, or if more than three full SSH packets have been buffered.

To avoid sending a window adjustment for very small amounts, require a minimum size for the adjustment (more than half a packet, or more than a tenth of the full window, or more than 16kB -- because packet size and full window size are configurable, a single minimum value is not good enough.)

If there are multiple threads reading (for instance, one from stdout and one from stderr), make sure that normally only one will cause a window adjustment to be sent.