### PR TITLE
GH-297: SshClient: auto-configure for encrypted key identities

### DIFF
--- a/sshd-common/src/main/java/org/apache/sshd/common/keyprovider/MultiKeyIdentityProvider.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/keyprovider/MultiKeyIdentityProvider.java
@@ -32,10 +32,15 @@ import org.apache.sshd.common.session.SessionContext;
  * @author <a href="mailto:dev@mina.apache.org">Apache MINA SSHD Project</a>
  */
 public class MultiKeyIdentityProvider implements KeyIdentityProvider {
+
     protected final Iterable<? extends KeyIdentityProvider> providers;
 
     public MultiKeyIdentityProvider(Iterable<? extends KeyIdentityProvider> providers) {
         this.providers = providers;
+    }
+
+    public Iterable<? extends KeyIdentityProvider> getProviders() {
+        return providers == null ? Collections::emptyIterator : providers;
     }
 
     @Override


### PR DESCRIPTION
Automatically configure KeyIdentityProviders to use the FilePasswordProvider set on the client if they don't have an explicit password provider already.

This simplifies setting up a client to deal with encrypted private keys: set a FilePasswordProvider on the client, and set a FileKeyPairProvider with the key file(s), and off it goes.

Previously, setting a FilePasswordProvider on an SshClient only had an effect for identity files specified in a HostConfigEntry. For other use cases, a FilePasswordProvider had to be set explicitly on the FileKeyPairProvider. (Which is still possible, and takes precedence over the new auto-configuration.)

This also makes it possible to use SshClientMain with an encrypted private key given on the command-line via the -i option.

Fixes #297.