### PR TITLE
GH-298: Start service in AbstractServerSession

### DIFF
--- a/sshd-core/src/main/java/org/apache/sshd/server/session/AbstractServerSession.java
+++ b/sshd-core/src/main/java/org/apache/sshd/server/session/AbstractServerSession.java
@@ -287,7 +287,7 @@ public abstract class AbstractServerSession extends AbstractSession implements S
 
             throw new SshException(SshConstants.SSH2_DISCONNECT_SERVICE_NOT_AVAILABLE, "Unknown service: " + name);
         }
-        currentService.set(service, factory.getName(), false);
+        currentService.set(service, factory.getName(), true);
     }
 
     @Override


### PR DESCRIPTION
Services need to be started. In particular, the connection service starts its heartbeat, if configured, when started. It was already noticed in commit e74e2041 that the server-side did not start services, but at that time the effect was not recognized because tests were too unstable back then. A test for server-side heartbeats was also missing.

Fixes #298.