### PR TITLE
GH-300: SSH_MSG_CHANNEL_OPEN_CONFIRMATION: channel ID is unsigned

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,7 @@
 * [GH-294](https://github.com/apache/mina-sshd/issues/294) Fix memory leak in SftpFileSystemProvider.
 * [GH-297](https://github.com/apache/mina-sshd/issues/297) Auto-configure file password provider for reading encrypted SSH keys.
 * [GH-298](https://github.com/apache/mina-sshd/issues/298) Server side heartbeat not working.
+* [GH-300](https://github.com/apache/mina-sshd/issues/300) Read the channel id in SSH_MSG_CHANNEL_OPEN_CONFIRMATION as unsigned int.
 
 
 * [SSHD-1315](https://issues.apache.org/jira/browse/SSHD-1315) Do not log sensitive data at log level TRACE.

--- a/sshd-core/src/main/java/org/apache/sshd/common/session/helpers/AbstractConnectionService.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/session/helpers/AbstractConnectionService.java
@@ -527,7 +527,7 @@ public abstract class AbstractConnectionService
             return; // debug breakpoint
         }
 
-        int sender = buffer.getInt();
+        long sender = buffer.getUInt();
         long rwsize = buffer.getUInt();
         long rmpsize = buffer.getUInt();
         if (log.isDebugEnabled()) {


### PR DESCRIPTION
Fix reading the id from the message, and add a test in which the server uses artificially high channel IDs beyond Integer.MAX_VALUE.

Fixes #300.