### PR TITLE
GH-293: Handle SFTP buffer sizes > server limit better

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,6 +29,7 @@
 * [GH-282](https://github.com/apache/mina-sshd/issues/282) Correct setting file permissions on newly written host key files on Windows.
 * [GH-283](https://github.com/apache/mina-sshd/issues/283) Fix handling of `CoreModuleProperties.PASSWORD_PROMPTS`.
 * [GH-285](https://github.com/apache/mina-sshd/issues/285) Fix compilation failure on Java 19.
+* [GH-293](https://github.com/apache/mina-sshd/issues/293) Handle SFTP buffer sizes larger than the server limit better.
 * [GH-294](https://github.com/apache/mina-sshd/issues/294) Fix memory leak in `SftpFileSystemProvider`.
 * [GH-297](https://github.com/apache/mina-sshd/issues/297) Auto-configure file password provider for reading encrypted SSH keys.
 * [GH-298](https://github.com/apache/mina-sshd/issues/298) Server side heartbeat not working.

--- a/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/impl/SftpInputStreamAsync.java
+++ b/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/impl/SftpInputStreamAsync.java
@@ -49,7 +49,6 @@ import org.slf4j.LoggerFactory;
 public class SftpInputStreamAsync extends InputStreamWithChannel implements SftpClientHolder {
     protected final Logger log;
     protected final byte[] bb = new byte[1];
-    protected final int bufferSize;
     protected final long fileSize;
     protected Buffer buffer;
     protected CloseableHandle handle;
@@ -57,6 +56,10 @@ public class SftpInputStreamAsync extends InputStreamWithChannel implements Sftp
     protected long clientOffset;
     protected final Deque<SftpAckData> pendingReads = new LinkedList<>();
     protected boolean eofIndicator;
+    protected int bufferSize;
+    protected int maxReceived;
+    protected long shortReads;
+    protected boolean bufferAdjusted;
 
     private final AbstractSftpClient clientInstance;
     private final String path;
@@ -180,10 +183,13 @@ public class SftpInputStreamAsync extends InputStreamWithChannel implements Sftp
                 if (eofIndicator) {
                     break;
                 }
+                boolean backtracked = false;
                 if (!pendingReads.isEmpty()) {
-                    fillData();
+                    backtracked = fillData();
                 }
-                if (!eofIndicator) {
+                if (!eofIndicator && !backtracked) {
+                    // Do not send additional requests if we had missing data that we had to fetch synchronously, and we
+                    // do have more outstanding requests to avoid jumping back and forth in the file all the time.
                     sendRequests();
                 }
             } else {
@@ -252,14 +258,14 @@ public class SftpInputStreamAsync extends InputStreamWithChannel implements Sftp
         }
     }
 
-    protected void fillData() throws IOException {
+    protected boolean fillData() throws IOException {
         SftpAckData ack = pendingReads.pollFirst();
         boolean traceEnabled = log.isTraceEnabled();
         if (ack == null) {
             if (traceEnabled) {
                 log.trace("fillData({}) no pending ack", this);
             }
-            return;
+            return false;
         }
 
         if (traceEnabled) {
@@ -269,6 +275,7 @@ public class SftpInputStreamAsync extends InputStreamWithChannel implements Sftp
         pollBuffer(ack);
 
         if (!alreadyEof && clientOffset < ack.offset) {
+            shortReads++;
             // we are actually missing some data
             // so request is synchronously
             byte[] data = new byte[(int) (ack.offset - clientOffset + buffer.available())];
@@ -302,7 +309,40 @@ public class SftpInputStreamAsync extends InputStreamWithChannel implements Sftp
             } else {
                 buffer.rpos(buffer.wpos());
             }
+            if (!eofIndicator && !bufferAdjusted) {
+                int newBufferSize = adjustBufferIfNeeded(bufferSize, shortReads, maxReceived, ack.offset - clientOffset);
+                if (newBufferSize > 0 && newBufferSize < bufferSize) {
+                    int originalSize = bufferSize;
+                    bufferSize = newBufferSize;
+                    bufferAdjusted = true;
+                    if (log.isDebugEnabled()) {
+                        log.debug("adjustBufferIfNeeded({}) changing SFTP buffer size: {} -> {}", this, originalSize,
+                                bufferSize);
+                    }
+                } else if (newBufferSize > bufferSize) {
+                    throw new IllegalStateException("New buffer size " + newBufferSize + " > existing size " + bufferSize);
+                }
+            }
+            return !pendingReads.isEmpty();
         }
+        return false;
+    }
+
+    /**
+     * Dynamically adjust the SFTP buffer size, if it is too large. Although it is possible to reduce the buffer size to
+     * a single byte, in practice some sane lower limit (like, 8kB) should be maintained.
+     *
+     * @param  currentBufferSize the current SFTP buffer size
+     * @param  nOfShortReads     the number of short reads so far
+     * @param  maxBufferReceived the maximum number of bytes the server returned in any previous read request
+     * @param  gap               the size of the gap just filled
+     * @return                   a new buffer size in the range [1..currentBufferSize].
+     */
+    protected int adjustBufferIfNeeded(int currentBufferSize, long nOfShortReads, int maxBufferReceived, long gap) {
+        if (currentBufferSize > 8 * 1024 && nOfShortReads > 4) {
+            return Math.max(8 * 1204, maxBufferReceived);
+        }
+        return currentBufferSize;
     }
 
     protected void pollBuffer(SftpAckData ack) throws IOException {
@@ -329,6 +369,7 @@ public class SftpInputStreamAsync extends InputStreamWithChannel implements Sftp
                 }
                 buf.rpos(rpos);
                 buf.wpos(rpos + dlen);
+                maxReceived = Math.max(dlen, maxReceived);
                 this.buffer = buf;
                 break;
             case SftpConstants.SSH_FXP_STATUS:
@@ -366,7 +407,7 @@ public class SftpInputStreamAsync extends InputStreamWithChannel implements Sftp
                 }
             } finally {
                 if (debugEnabled) {
-                    log.debug("close({}) closing file handle", this);
+                    log.debug("close({}) closing file handle; {} short reads", this, shortReads);
                 }
                 handle.close();
             }


### PR DESCRIPTION
If a client uses an SFTP buffer size greater than the maximum amount of data the server is willing to return for an individual read request, data will be delivered with "holes". For instance, if the server limit is 63kB, and the client uses a buffer size of 64kB, it will issue requests to read 64kb at offset 0, then 64kB at offset 65536, and so on. But it will get only 63kB at offset 0 and 63kB at offset 65536. When it notices that, it'll request the missing 1kB at offset 64512 synchronously.

In a large file, this can lead to jumping back and forth in the file frequently if the client issues new requests after having read missing data, because the very next read again will be short, but the server may have already skipped forward again to satisfy the new requests.

Avoid that by not issuing new requests until the client has caught up. That way, the server has to move backwards in the file far less often and can serve the data much faster and smoother.

Additionally, reduce the buffer size if gaps are detected to the maximum returned so far by the server. A gap means the server returned less data than the client requested, which can have three reasons:

* EOF was reached. Reducing the buffer size is fine.
* Server limit was exceeded. Reducing avoids future gaps.
* (Transient) server error.

Because of the third possibility, the buffer size is reduced only after the fourth gap.

(An alternative or additional improvement in this area might be to make the server-side implementation smarter about re-ordering read requests. The current implementation just serves them as they come, but the SFTP draft RFCs explicitly allow some re-ordering. The server could use a priority queue ordered by offset, trying on _its_ side to avoid excessive back and forth. Some care would have to be taken to deal with overlapping read and write requests.)

Fixes #293.