### PR TITLE
Cancellation and time-outs of futures

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -37,6 +37,7 @@
 * [GH-313](https://github.com/apache/mina-sshd/issues/313) Log exceptions in the SFTP subsystem before sending a failure status reply.
 
 
+* [SSHD-1295](https://issues.apache.org/jira/browse/SSHD-1295) Fix cancellation of futures and add options to cancel futures on time-outs.
 * [SSHD-1315](https://issues.apache.org/jira/browse/SSHD-1315) Do not log sensitive data at log level `TRACE`.
 * [SSHD-1316](https://issues.apache.org/jira/browse/SSHD-1316) Possible OOM in `ChannelPipedInputStream` (fix channel window).
 * [SSHD-1319](https://issues.apache.org/jira/browse/SSHD-1319) Use position in `SftpRemotePathChannel.transferFrom()`.
@@ -46,14 +47,141 @@
 
 ## Potential compatibility issues
 
+### Futures and cancellation or time-outs
+
+Apache MINA sshd is an asynchronous framework: for long-running operations, and
+in particular operations involving network communication, the API returns a
+future that client code can use to wait until the operation is complete. Waiting
+on a future is usually done with a `future.verify()` or `future.verify(timeout)`
+call. Futures can also be canceled.
+
+Previous versions did not implement cancellation correctly: while the future
+object itself was marked as "canceled", the underlying operation was not. The
+same problem also existed for time-outs: when `future.verify(timeout)` timed out,
+the underlying operation still continued to run asynchronously. This could
+lead to problems because if the underlying operation eventually succeeded,
+application code would be completely unaware. For instance in
+
+```
+  ClientSession session = client.connect(user, host, port).verify(timeout).getSession();
+```
+
+the application might get a time-out, but the underlying connect operation
+would continue to run, might succeed eventually, and then there would in fact
+be a `ClientSession` (and thus also a network connection, and a socket used up).
+But the application had no way to access that session to shut it down. The net
+effect was a socket leak.
+
+In this version, this has been corrected. By default, the future is canceled
+when a time-out occurs, and `future.cancel()` is propagated to the underlying
+operation and cancels it.
+
+Canceling an operation itself may not be possible immediately. For instance,
+an authentication attempt is a message exchange with the server. If the
+authentication request has already been sent when cancellation is requested,
+the sending of that request cannot be undone. The authentication can only be
+cancelled after the reply from the server has been received, and if that reply
+is an authentication success, cancellation isn't even possible anymore. Or
+consider requesting a port forwarding: that, too, is a request-reply message
+exchange. Once the request has been sent, there are two cases: if the server
+replies with a failure message, the port forwarding failed and since there is
+nothing to cancel, cancellation is not possible. If the reply indicates the
+tunnel was established, but `future.cancel()` had already been called, we have
+two options: either we shut down the just established tunnel again and say
+cancellation succeeded, or we say cancellation failed and report a successfully
+established tunnel. Because cancellations may be caused by time-outs, Apache
+MINA sshd chooses the first option and shuts down the tunnel again. Otherwise
+an application might get a time-out but still be left with an established
+tunnel.
+
+Cancellation is only possible while the operation has not completed yet. If
+a future is already done, it cannot be canceled anymore.
+
+The `cancel()` operation on a future is thus a _request_ to cancel the
+operation; it may or may not result in actually cancelling the operation.
+`cancel()` itself therefore returns a `CancelFuture` that client code can use
+to wait for the request having been handled, and then learn whether the
+operation was indeed canceled.
+
+Calls to `verify()` throw an `SshException` with a
+`java.util.concurrent.CancellationException` as cause if cancelled asynchronously
+via the `cancel()` method.
+
+Application code can control the behavior on time-outs. The `verify()` method
+takes besides a time-out duration newly also a number of `CancelOption`s as
+parameters.
+
+There are three possible values to cancel on a time-out, to cancel on an
+interruption, or not to cancel at all when either occurs. For backwards
+compatibility, the default behavior of `AuthFuture` and of `OpenFuture` is
+unchanged: to cancel on a time-out, client code must pass the
+`CancelOption.CANCEL_ON_TIMEOUT` flag.
+
+The default behavior of `ConnectFuture` _has_ been changed: by default, it _does_
+cancel the connection attempt if a time-out occurs. To avoid this, client code
+would have to pass the `CancelOption.NO_CANCELLATION` flag expressly. This change
+in behavior was done to avoid socket leaks, and it was deemed acceptable since
+a difference in behavior could only occur if existing client code called
+`AuthFuture.verify()` in different threads on the same future instance, or
+sequentially on the same future instance again after the first time-out. Both
+cases are highly unlikely to occur in existing client code. If existing code
+needs this behavior, it needs to be adapted to pass `CancelOption`s as may be
+appropriate for the precise use case.
+
 ## Minor code helpers
 
 ## Behavioral changes and enhancements
 
-* `CoreModuleProperties.PASSWORD_PROMPTS` is now also used for password authentication. Previous versions used it only for keyboard-interactive authentication.
-  The semantics has been clarified to be the equivalent of the OpenSSH configuration `NumberOfPasswordPrompts`, which is actually the number of authentication
-  *attempts*. (In keyboard-interactive authentication, there may be several prompts per authentication attempt.) Only interactive authentication attempts
-  using `UserInteraction` count towards the limit. Attempts fulfilled by explicitly provided passwords (via `session.addPasswordIdentity()` or
-  `session.setPasswordIdentityProvider()`) are *not* counted. The default value of the property is unchanged and is 3, as in OpenSSH. The limit is applied
-  independently for both authentication mechanisms: with the default setting, there can be three keyboard-interactive authentication attempts, plus three
-  more password authentication attempts if both methods are configured and applicable.
+* `CoreModuleProperties.PASSWORD_PROMPTS` is now also used for password
+  authentication. Previous versions used it only for keyboard-interactive
+  authentication. The semantics has been clarified to be the equivalent
+  of the OpenSSH configuration `NumberOfPasswordPrompts`, which is actually
+  the number of authentication *attempts*. (In keyboard-interactive
+  authentication, there may be several prompts per authentication attempt.)
+  Only interactive authentication attempts using `UserInteraction` count
+  towards the limit. Attempts fulfilled by explicitly provided passwords
+  (via `session.addPasswordIdentity()` or `session.setPasswordIdentityProvider()`)
+  are *not* counted. The default value of the property is unchanged and is
+  3, as in OpenSSH. The limit is applied independently for both authentication
+  mechanisms: with the default setting, there can be three keyboard-interactive
+  authentication attempts, plus three more password authentication attempts if
+  both methods are configured and applicable.
+
+### Connection time-outs
+
+Connection time-outs are normally handled in Apache MINA SSHD at the application
+level by passing a time-out to `ConnectFuture.verify()`:
+
+```
+ClientSession session = client.connect(user, host, port).verify(MY_TIMEOUT).getSession();
+```
+
+However, the actual I/O library used might have its own connection time-out.
+With large time-outs, the behavior depended on the actual implementation of
+the I/O back-end used:
+
+* The default NIO2 back-end has no default connection time-out at all, so the
+  `verify(MY_TIMEOUT)` call would always time-out after `MY_TIMEOUT` had elapsed.
+* Apache MINA has a default connection time-out of one minute, so even if
+  `MY_TIMEOUT` was larger, the time-out would still occur after one minute.
+* Netty has a default connection time-out of 30 seconds.
+
+In this version, a new property `CoreModuleProperties.IO_CONNECTION_TIMEOUT`
+can be set to control this I/O connection time-out. It can be set on an
+`SshClient` or `SshServer`; if set (and > 0), the I/O back-end is configured
+to use that value as its I/O connection time-out, and
+`ConnectFuture.verify(MY_TIMEOUT)` will always time-out at
+`Math.min(CoreModuleProperties.IO_CONNECTION_TIMEOUT, MY_TIMEOUT)`. The property
+is also effective for the NIO2 back-end; the default value is 1 minute.
+
+`verify()` throws an `SshException` if it fails or times out. The _cause_ of
+that exception is a `java.net.ConnectException` if the I/O connection time-out
+expired, and a `java.util.concurrent.TimeoutException` if the application
+time-out expired. (And if the future was canceled explicitly before any
+time-out was reached, the cause is a `java.util.concurrent.CancellationException`;
+see above.)
+
+The new `CancelOption`s discussed above apply only if the application
+time-out expires. If the connection attempt times out at I/O level, it is
+the responsibility of the I/O library to ensure no resources such as
+sockets are consumed, and there is no SSH session created either.

--- a/sshd-common/src/main/java/org/apache/sshd/common/future/AbstractSshFuture.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/future/AbstractSshFuture.java
@@ -22,10 +22,14 @@ package org.apache.sshd.common.future;
 import java.io.IOException;
 import java.io.InterruptedIOException;
 import java.io.StreamCorruptedException;
+import java.net.ConnectException;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
 
 import org.apache.sshd.common.SshException;
 import org.apache.sshd.common.util.ExceptionUtils;
+import org.apache.sshd.common.util.GenericUtils;
 import org.apache.sshd.common.util.logging.AbstractLoggingBean;
 import org.apache.sshd.common.util.threads.ThreadUtils;
 
@@ -34,10 +38,6 @@ import org.apache.sshd.common.util.threads.ThreadUtils;
  * @author     <a href="mailto:dev@mina.apache.org">Apache MINA SSHD Project</a>
  */
 public abstract class AbstractSshFuture<T extends SshFuture<T>> extends AbstractLoggingBean implements SshFuture<T> {
-    /**
-     * A default value to indicate the future has been canceled
-     */
-    protected static final Object CANCELED = new Object();
 
     private final Object id;
 
@@ -54,14 +54,14 @@ public abstract class AbstractSshFuture<T extends SshFuture<T>> extends Abstract
     }
 
     @Override
-    public boolean await(long timeoutMillis) throws IOException {
-        return await0(timeoutMillis, true) != null;
+    public boolean await(long timeoutMillis, CancelOption... options) throws IOException {
+        return await0(timeoutMillis, true, options) != null;
     }
 
     @Override
-    public boolean awaitUninterruptibly(long timeoutMillis) {
+    public boolean awaitUninterruptibly(long timeoutMillis, CancelOption... options) {
         try {
-            return await0(timeoutMillis, false) != null;
+            return await0(timeoutMillis, false, options) != null;
         } catch (InterruptedIOException e) {
             throw formatExceptionMessage(
                     msg -> new InternalError(msg, e),
@@ -103,21 +103,35 @@ public abstract class AbstractSshFuture<T extends SshFuture<T>> extends Abstract
      * @param  <R>          The generic result type
      * @param  expectedType The expected result type
      * @param  timeout      The timeout (millis) to wait for a result
+     * @param  options      Optional {@link CancelOptions} defining the behavior on time-out or interrupt.
      * @return              The (never {@code null}) result
      * @throws IOException  If failed to retrieve the expected result on time
      */
-    protected <R> R verifyResult(Class<? extends R> expectedType, long timeout) throws IOException {
-        Object value = await0(timeout, true);
+    protected <R> R verifyResult(Class<? extends R> expectedType, long timeout, CancelOption... options) throws IOException {
+        Object value = await0(timeout, true, options);
         if (value == null) {
-            throw formatExceptionMessage(
-                    SshException::new,
-                    "Failed to get operation result within specified timeout: %s",
+            TimeoutException cause = new TimeoutException("Timed out after " + timeout + " msec");
+            throw formatExceptionMessage(msg -> new SshException(msg, cause),
+                    "Failed to get operation result within specified timeout: %s msec",
                     timeout);
+        }
+
+        if (value == GenericUtils.NULL) {
+            return null;
         }
 
         Class<?> actualType = value.getClass();
         if (expectedType.isAssignableFrom(actualType)) {
             return expectedType.cast(value);
+        }
+
+        if (value instanceof CancelFuture) {
+            value = ((CancelFuture) value).getBackTrace();
+            if (value == null) {
+                // Should not really occur
+                value = new CancellationException("Operation was cancelled before");
+            }
+            actualType = CancellationException.class;
         }
 
         if (Throwable.class.isAssignableFrom(actualType)) {
@@ -127,7 +141,7 @@ public abstract class AbstractSshFuture<T extends SshFuture<T>> extends Abstract
                 throw new SshException(((SshException) t).getDisconnectCode(), t.getMessage(), t);
             }
 
-            Throwable cause = ExceptionUtils.resolveExceptionCause(t);
+            Throwable cause = t instanceof ConnectException ? t : ExceptionUtils.resolveExceptionCause(t);
             throw formatExceptionMessage(
                     msg -> new SshException(msg, cause),
                     "Failed (%s) to execute: %s",
@@ -144,11 +158,13 @@ public abstract class AbstractSshFuture<T extends SshFuture<T>> extends Abstract
      * @param  timeoutMillis          The delay we will wait for the Future to be ready
      * @param  interruptable          Tells if the wait can be interrupted or not. If {@code true} and the thread is
      *                                interrupted then an {@link InterruptedIOException} is thrown.
+     * @param  options                Optional {@link CancelOptions} defining the behavior on time-out or interrupt.
      * @return                        The non-{@code null} result object if the Future is ready, {@code null} if the
      *                                timeout expired and no result was received
      * @throws InterruptedIOException If the thread has been interrupted when it's not allowed.
      */
-    protected abstract Object await0(long timeoutMillis, boolean interruptable) throws InterruptedIOException;
+    protected abstract Object await0(long timeoutMillis, boolean interruptable, CancelOption... options)
+            throws InterruptedIOException;
 
     @SuppressWarnings("unchecked")
     protected SshFutureListener<T> asListener(Object o) {

--- a/sshd-common/src/main/java/org/apache/sshd/common/future/AbstractSshFuture.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/future/AbstractSshFuture.java
@@ -33,7 +33,7 @@ import org.apache.sshd.common.util.threads.ThreadUtils;
  * @param  <T> Type of future
  * @author     <a href="mailto:dev@mina.apache.org">Apache MINA SSHD Project</a>
  */
-public abstract class AbstractSshFuture<T extends SshFuture> extends AbstractLoggingBean implements SshFuture<T> {
+public abstract class AbstractSshFuture<T extends SshFuture<T>> extends AbstractLoggingBean implements SshFuture<T> {
     /**
      * A default value to indicate the future has been canceled
      */

--- a/sshd-common/src/main/java/org/apache/sshd/common/future/CancelFuture.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/future/CancelFuture.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sshd.common.future;
+
+import java.util.concurrent.CancellationException;
+
+/**
+ * Cancellations may not always be effective immediately. While a cancelled {@link Cancellable} future is considered
+ * canceled immediately, it may take some time until the underlying asynchronous operation is really canceled. A
+ * cancellation through {@link Cancellable#cancel()} returns a {@code CancelFuture} that can be used to wait for the
+ * cancellation to have been effected.
+ * <p>
+ * A {@code CancelFuture} is not cancellable itself.
+ * </p>
+ *
+ * @author <a href="mailto:dev@mina.apache.org">Apache MINA SSHD Project</a>
+ * @see    Cancellable
+ */
+public interface CancelFuture extends SshFuture<CancelFuture>, VerifiableFuture<Boolean> {
+
+    /**
+     * Obtains an exception describing the stack trace of where the cancellation was initiated.
+     *
+     * @return a {@link CancellationException}
+     */
+    CancellationException getBackTrace();
+
+    /**
+     * Tells whether the cancellation has been effected. ({@link #isDone()} {@code && !isCanceled()}) means the
+     * cancellation was not effected. In that case check the original operation for a success or failure value.
+     *
+     * @return {@code true} if the cancellation was done; {@code false} otherwise
+     */
+    boolean isCanceled();
+
+    /**
+     * Marks this {@link CancelFuture} as the cancellation having been effected.
+     * <p>
+     * This is a framework-internal method.
+     * </p>
+     */
+    void setCanceled();
+
+    /**
+     * Marks this {@link CancelFuture} as the cancellation having been effected.
+     * <p>
+     * This is a framework-internal method.
+     * </p>
+     *
+     * @param error optional {@link Throwable}, if non-{@code null}, it'll be attached to the backtrace.
+     */
+    void setCanceled(Throwable error);
+
+    /**
+     * Sets a {@link CancellationException} describing the stack trace of where the cancellation was initiated. Has no
+     * effect if a backtrace was already set, or the given backtrace is {@code null}.
+     * <p>
+     * This is a framework-internal method.
+     * </p>
+     *
+     * @param backTrace {@link CancellationException} to set
+     */
+    void setBackTrace(CancellationException backTrace);
+
+    /**
+     * Completes this future with a value indicating that the cancellation was not done.
+     */
+    void setNotCanceled();
+}

--- a/sshd-common/src/main/java/org/apache/sshd/common/future/CancelOption.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/future/CancelOption.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sshd.common.future;
+
+/**
+ * A {@code CancelOption} defines whether a {@link Cancellable} future that is waited upon shall be cancelled if waiting
+ * times out or is interrupted.
+ *
+ * @see VerifiableFuture
+ * @see WaitableFuture
+ */
+public enum CancelOption {
+
+    /**
+     * Indicates that when waiting on a future times out, the future shall be canceled.
+     */
+    CANCEL_ON_TIMEOUT,
+
+    /**
+     * Indicates that when waiting on a future is interrupted, the future shall be canceled.
+     */
+    CANCEL_ON_INTERRUPT,
+
+    /**
+     * Indicates that even if waiting on a future times out or is interrupted, it shall not be canceled.
+     * <p>
+     * {@link #CANCEL_ON_TIMEOUT} and {@link #CANCEL_ON_INTERRUPT} take predence over this flag. The main purpose of
+     * this flag is to be able to call {@code verify(timeout, NO_CANCELLATION)} to suppress cancelling a future on
+     * time-outs or interrupts altogether. By default, {@code verify(timeout)} will cancel the future on both time-outs
+     * and interrupts.
+     * </p>
+     */
+    NO_CANCELLATION
+}

--- a/sshd-common/src/main/java/org/apache/sshd/common/future/Cancellable.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/future/Cancellable.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sshd.common.future;
+
+/**
+ * Some operation that can be cancelled.
+ * <p>
+ * Classes implementing this interface that support state listeners are expected to notify the listeners when
+ * {@link #cancel()} changes the state of the operation.
+ * </p>
+ *
+ * @author <a href="mailto:dev@mina.apache.org">Apache MINA SSHD Project</a>
+ */
+public interface Cancellable extends WithException {
+
+    /**
+     * Attempts to cancel the operation.
+     *
+     * @return A {@link CancelFuture} that can be used to wait for the cancellation to have been effected, or
+     *         {@code null} if the future cannot be canceled or is already completed.
+     */
+    CancelFuture cancel();
+
+    /**
+     * Tells whether this operation was canceled.
+     *
+     * @return {@code true} if the operation was cancelled, {@code false} otherwise.
+     */
+    boolean isCanceled();
+
+    /**
+     * Retrieves the {@link CancelFuture}, if {@link #cancel()} had been called.
+     *
+     * @return The {@link CancelFuture} if the {@link Cancellable} has already been canceled, or {@code null} otherwise
+     */
+    CancelFuture getCancellation();
+}

--- a/sshd-common/src/main/java/org/apache/sshd/common/future/DefaultCancelFuture.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/future/DefaultCancelFuture.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sshd.common.future;
+
+import java.io.IOException;
+import java.util.Objects;
+import java.util.concurrent.CancellationException;
+
+/**
+ * A default implementation of a {@link CancelFuture}.
+ *
+ * @author <a href="mailto:dev@mina.apache.org">Apache MINA SSHD Project</a>
+ */
+public class DefaultCancelFuture extends DefaultSshFuture<CancelFuture> implements CancelFuture, VerifiableFuture<Boolean> {
+
+    private CancellationException backTrace;
+
+    protected DefaultCancelFuture(Object id) {
+        super(id, null);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return the value of {@link #isCanceled()}
+     */
+    @Override
+    public Boolean verify(long timeoutMillis, CancelOption... options) throws IOException {
+        return verifyResult(Boolean.class, timeoutMillis, options);
+    }
+
+    @Override
+    public void setCanceled() {
+        setCanceled(null);
+    }
+
+    @Override
+    public void setCanceled(Throwable error) {
+        synchronized (this) {
+            // Normally we create a backtrace right when we create the CancelFuture. If the future doesn't have a
+            // backtrace yet, at least record where the future was fulfilled.
+            if (backTrace == null) {
+                backTrace = new CancellationException("Canceled by framework");
+            }
+            if (error != null) {
+                backTrace.addSuppressed(error);
+            }
+        }
+        setValue(Boolean.TRUE);
+    }
+
+    @Override
+    public void setNotCanceled() {
+        setValue(Boolean.FALSE);
+    }
+
+    @Override
+    public boolean isCanceled() {
+        return Boolean.TRUE.equals(getValue());
+    }
+
+    @Override
+    public void setBackTrace(CancellationException backTrace) {
+        synchronized (this) {
+            if (this.backTrace == null) {
+                this.backTrace = Objects.requireNonNull(backTrace, "Cancellation backtrace must not be null");
+            }
+        }
+    }
+
+    @Override
+    public CancellationException getBackTrace() {
+        synchronized (this) {
+            return backTrace;
+        }
+    }
+}

--- a/sshd-common/src/main/java/org/apache/sshd/common/future/DefaultCancellableSshFuture.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/future/DefaultCancellableSshFuture.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sshd.common.future;
+
+import java.util.Objects;
+import java.util.concurrent.CancellationException;
+
+/**
+ * A default {@link Cancellable} future implementation.
+ *
+ * @param  <T> Type of future
+ * @author     <a href="mailto:dev@mina.apache.org">Apache MINA SSHD Project</a>
+ */
+public abstract class DefaultCancellableSshFuture<T extends SshFuture<T>>
+        extends DefaultVerifiableSshFuture<T>
+        implements Cancellable {
+
+    protected DefaultCancellableSshFuture(Object id, Object lock) {
+        super(id, lock);
+    }
+
+    @Override
+    public boolean isCanceled() {
+        return getValue() instanceof CancelFuture;
+    }
+
+    @Override
+    protected CancelFuture createCancellation() {
+        return new DefaultCancelFuture(getId());
+    }
+
+    @Override
+    public CancelFuture cancel() {
+        CancelFuture cancellation = createCancellation();
+        if (cancellation == null) {
+            return getCancellation();
+        }
+        cancellation.setBackTrace(new CancellationException("Programmatically canceled"));
+        setValue(cancellation);
+        return getCancellation();
+    }
+
+    @Override
+    public CancelFuture getCancellation() {
+        Object v = getValue();
+        return (v instanceof CancelFuture) ? (CancelFuture) v : null;
+    }
+
+    @Override
+    public Throwable getException() {
+        Object v = getValue();
+        return (v instanceof Throwable) ? (Throwable) v : null;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * If the {@code exception} cannot be set but the future is already canceled, the exception will be reported through
+     * this future's {@link CancelFuture}.
+     */
+    @Override
+    public void setException(Throwable exception) {
+        setValue(Objects.requireNonNull(exception, "No exception provided"));
+        if (getException() == null) {
+            CancelFuture cancellation = getCancellation();
+            if (cancellation != null) {
+                cancellation.setCanceled(exception);
+            }
+        }
+    }
+
+}

--- a/sshd-common/src/main/java/org/apache/sshd/common/future/DefaultSshFuture.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/future/DefaultSshFuture.java
@@ -31,7 +31,7 @@ import org.apache.sshd.common.util.ValidateUtils;
  * @param  <T> Type of future
  * @author     <a href="mailto:dev@mina.apache.org">Apache MINA SSHD Project</a>
  */
-public class DefaultSshFuture<T extends SshFuture> extends AbstractSshFuture<T> {
+public class DefaultSshFuture<T extends SshFuture<T>> extends AbstractSshFuture<T> {
     /**
      * A lock used by the wait() method
      */

--- a/sshd-common/src/main/java/org/apache/sshd/common/future/DefaultVerifiableSshFuture.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/future/DefaultVerifiableSshFuture.java
@@ -23,7 +23,7 @@ package org.apache.sshd.common.future;
  * @param  <T> Type of future
  * @author     <a href="mailto:dev@mina.apache.org">Apache MINA SSHD Project</a>
  */
-public abstract class DefaultVerifiableSshFuture<T extends SshFuture>
+public abstract class DefaultVerifiableSshFuture<T extends SshFuture<T>>
         extends DefaultSshFuture<T>
         implements VerifiableFuture<T> {
     protected DefaultVerifiableSshFuture(Object id, Object lock) {

--- a/sshd-common/src/main/java/org/apache/sshd/common/future/SshFuture.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/future/SshFuture.java
@@ -25,7 +25,7 @@ package org.apache.sshd.common.future;
  * @param  <T> Type of future
  * @author     <a href="mailto:dev@mina.apache.org">Apache MINA SSHD Project</a>
  */
-public interface SshFuture<T extends SshFuture> extends WaitableFuture {
+public interface SshFuture<T extends SshFuture<T>> extends WaitableFuture {
     /**
      * Adds an event <tt>listener</tt> which is notified when this future is completed. If the listener is added after
      * the completion, the listener is directly notified.

--- a/sshd-common/src/main/java/org/apache/sshd/common/future/VerifiableFuture.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/future/VerifiableFuture.java
@@ -35,12 +35,14 @@ public interface VerifiableFuture<T> {
     /**
      * Wait {@link Long#MAX_VALUE} msec. and verify that the operation was successful
      *
+     * @param  options     Optional {@link CancelOptions} defining the behavior on time-out or interrupt; ignored if the
+     *                     future is not {@link Cancellable}.
      * @return             The (same) future instance
      * @throws IOException If failed to verify successfully on time
      * @see                #verify(long)
      */
-    default T verify() throws IOException {
-        return verify(Long.MAX_VALUE);
+    default T verify(CancelOption... options) throws IOException {
+        return verify(Long.MAX_VALUE, options);
     }
 
     /**
@@ -48,32 +50,38 @@ public interface VerifiableFuture<T> {
      *
      * @param  timeout     The number of time units to wait
      * @param  unit        The wait {@link TimeUnit}
+     * @param  options     Optional {@link CancelOptions} defining the behavior on time-out or interrupt; ignored if the
+     *                     future is not {@link Cancellable}.
      * @return             The (same) future instance
      * @throws IOException If failed to verify successfully on time
      * @see                #verify(long)
      */
-    default T verify(long timeout, TimeUnit unit) throws IOException {
-        return verify(unit.toMillis(timeout));
+    default T verify(long timeout, TimeUnit unit, CancelOption... options) throws IOException {
+        return verify(unit.toMillis(timeout), options);
     }
 
     /**
      * Wait and verify that the operation was successful
      *
      * @param  timeout     The maximum duration to wait, <code>null</code> to wait forever
+     * @param  options     Optional {@link CancelOptions} defining the behavior on time-out or interrupt; ignored if the
+     *                     future is not {@link Cancellable}.
      * @return             The (same) future instance
      * @throws IOException If failed to verify successfully on time
      * @see                #verify(long)
      */
-    default T verify(Duration timeout) throws IOException {
-        return timeout != null ? verify(timeout.toMillis()) : verify();
+    default T verify(Duration timeout, CancelOption... options) throws IOException {
+        return timeout != null ? verify(timeout.toMillis(), options) : verify(options);
     }
 
     /**
      * Wait and verify that the operation was successful
      *
      * @param  timeoutMillis Wait timeout in milliseconds
+     * @param  options       Optional {@link CancelOptions} defining the behavior on time-out or interrupt; ignored if
+     *                       the future is not {@link Cancellable}.
      * @return               The (same) future instance
      * @throws IOException   If failed to verify successfully on time
      */
-    T verify(long timeoutMillis) throws IOException;
+    T verify(long timeoutMillis, CancelOption... options) throws IOException;
 }

--- a/sshd-common/src/main/java/org/apache/sshd/common/future/WaitableFuture.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/future/WaitableFuture.java
@@ -40,12 +40,14 @@ public interface WaitableFuture {
      * Wait {@link Long#MAX_VALUE} msec. for the asynchronous operation to complete. The attached listeners will be
      * notified when the operation is completed.
      *
+     * @param  options     Optional {@link CancelOptions} defining the behavior on time-out or interrupt; ignored if the
+     *                     future is not {@link Cancellable}.
      * @return             {@code true} if the operation is completed.
      * @throws IOException if failed - specifically {@link java.io.InterruptedIOException} if waiting was interrupted
      * @see                #await(long)
      */
-    default boolean await() throws IOException {
-        return await(Long.MAX_VALUE);
+    default boolean await(CancelOption... options) throws IOException {
+        return await(Long.MAX_VALUE, options);
     }
 
     /**
@@ -53,44 +55,52 @@ public interface WaitableFuture {
      *
      * @param  timeout     The number of time units to wait
      * @param  unit        The {@link TimeUnit} for waiting
+     * @param  options     Optional {@link CancelOptions} defining the behavior on time-out or interrupt; ignored if the
+     *                     future is not {@link Cancellable}.
      * @return             {@code true} if the operation is completed.
      * @throws IOException if failed - specifically {@link java.io.InterruptedIOException} if waiting was interrupted
      * @see                #await(long)
      */
-    default boolean await(long timeout, TimeUnit unit) throws IOException {
-        return await(unit.toMillis(timeout));
+    default boolean await(long timeout, TimeUnit unit, CancelOption... options) throws IOException {
+        return await(unit.toMillis(timeout), options);
     }
 
     /**
      * Wait for the asynchronous operation to complete with the specified timeout.
      *
      * @param  timeout     The maximum duration to wait, <code>null</code> to wait forever
+     * @param  options     Optional {@link CancelOptions} defining the behavior on time-out or interrupt; ignored if the
+     *                     future is not {@link Cancellable}.
      * @return             {@code true} if the operation is completed.
      * @throws IOException if failed - specifically {@link java.io.InterruptedIOException} if waiting was interrupted
      * @see                #await(long)
      */
-    default boolean await(Duration timeout) throws IOException {
-        return timeout != null ? await(timeout.toMillis()) : await();
+    default boolean await(Duration timeout, CancelOption... options) throws IOException {
+        return timeout != null ? await(timeout.toMillis(), options) : await(options);
     }
 
     /**
      * Wait for the asynchronous operation to complete with the specified timeout.
      *
      * @param  timeoutMillis Wait time in milliseconds
+     * @param  options       Optional {@link CancelOptions} defining the behavior on time-out or interrupt; ignored if
+     *                       the future is not {@link Cancellable}.
      * @return               {@code true} if the operation is completed.
      * @throws IOException   if failed - specifically {@link java.io.InterruptedIOException} if waiting was interrupted
      */
-    boolean await(long timeoutMillis) throws IOException;
+    boolean await(long timeoutMillis, CancelOption... options) throws IOException;
 
     /**
      * Wait {@link Long#MAX_VALUE} msec. for the asynchronous operation to complete uninterruptibly. The attached
      * listeners will be notified when the operation is completed.
      *
-     * @return {@code true} if the operation is completed.
-     * @see    #awaitUninterruptibly(long)
+     * @param  options Optional {@link CancelOptions} defining the behavior on time-out; ignored if the future is not
+     *                 {@link Cancellable}.
+     * @return         {@code true} if the operation is completed.
+     * @see            #awaitUninterruptibly(long)
      */
-    default boolean awaitUninterruptibly() {
-        return awaitUninterruptibly(Long.MAX_VALUE);
+    default boolean awaitUninterruptibly(CancelOption... options) {
+        return awaitUninterruptibly(Long.MAX_VALUE, options);
     }
 
     /**
@@ -98,30 +108,36 @@ public interface WaitableFuture {
      *
      * @param  timeout The number of time units to wait
      * @param  unit    The {@link TimeUnit} for waiting
+     * @param  options Optional {@link CancelOptions} defining the behavior on time-out; ignored if the future is not
+     *                 {@link Cancellable}.
      * @return         {@code true} if the operation is completed.
      * @see            #awaitUninterruptibly(long)
      */
-    default boolean awaitUninterruptibly(long timeout, TimeUnit unit) {
-        return awaitUninterruptibly(unit.toMillis(timeout));
+    default boolean awaitUninterruptibly(long timeout, TimeUnit unit, CancelOption... options) {
+        return awaitUninterruptibly(unit.toMillis(timeout), options);
     }
 
     /**
      * Wait for the asynchronous operation to complete with the specified timeout uninterruptibly.
      *
      * @param  timeoutMillis Wait time, <code>null</code> to wait forever
+     * @param  options       Optional {@link CancelOptions} defining the behavior on time-out; ignored if the future is
+     *                       not {@link Cancellable}.
      * @return               {@code true} if the operation is finished.
      */
-    default boolean awaitUninterruptibly(Duration timeoutMillis) {
-        return timeoutMillis != null ? awaitUninterruptibly(timeoutMillis.toMillis()) : awaitUninterruptibly();
+    default boolean awaitUninterruptibly(Duration timeoutMillis, CancelOption... options) {
+        return timeoutMillis != null ? awaitUninterruptibly(timeoutMillis.toMillis(), options) : awaitUninterruptibly(options);
     }
 
     /**
      * Wait for the asynchronous operation to complete with the specified timeout uninterruptibly.
      *
      * @param  timeoutMillis Wait time in milliseconds
+     * @param  options       Optional {@link CancelOptions} defining the behavior on time-out; ignored if the future is
+     *                       not {@link Cancellable}.
      * @return               {@code true} if the operation is finished.
      */
-    boolean awaitUninterruptibly(long timeoutMillis);
+    boolean awaitUninterruptibly(long timeoutMillis, CancelOption... options);
 
     /**
      * @return {@code true} if the asynchronous operation is completed. <B>Note:</B> it is up to the <B>caller</B> to

--- a/sshd-common/src/main/java/org/apache/sshd/common/future/WithException.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/future/WithException.java
@@ -16,28 +16,26 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.sshd.client.future;
-
-import org.apache.sshd.common.future.Cancellable;
-import org.apache.sshd.common.future.SshFuture;
-import org.apache.sshd.common.future.VerifiableFuture;
+package org.apache.sshd.common.future;
 
 /**
- * An {@link SshFuture} for asynchronous channel opening requests.
+ * Something that may carry a failure exception.
  *
  * @author <a href="mailto:dev@mina.apache.org">Apache MINA SSHD Project</a>
  */
-public interface OpenFuture extends SshFuture<OpenFuture>, VerifiableFuture<OpenFuture>, Cancellable {
+public interface WithException {
 
     /**
-     * @return <code>true</code> if the connect operation is finished successfully.
+     * Returns the cause of the failure.
+     *
+     * @return the {@link Throwable} of the failure, or {@code null} if not failed (yet).
      */
-    boolean isOpened();
+    Throwable getException();
 
     /**
-     * Sets the newly connected session and notifies all threads waiting for this future. This method is invoked by SSHD
-     * internally. Please do not call this method directly.
+     * Sets the exception that caused the operation to fail.
+     *
+     * @param exception The {@link Throwable} to set; must be non-{@code null}
      */
-    void setOpened();
-
+    void setException(Throwable exception);
 }

--- a/sshd-common/src/main/java/org/apache/sshd/common/io/AbstractIoWriteFuture.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/io/AbstractIoWriteFuture.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.util.Objects;
 
 import org.apache.sshd.common.SshException;
+import org.apache.sshd.common.future.CancelOption;
 import org.apache.sshd.common.future.DefaultVerifiableSshFuture;
 
 /**
@@ -36,7 +37,7 @@ public abstract class AbstractIoWriteFuture
     }
 
     @Override
-    public IoWriteFuture verify(long timeout) throws IOException {
+    public IoWriteFuture verify(long timeout, CancelOption... options) throws IOException {
         Boolean result = verifyResult(Boolean.class, timeout);
         if (!result) {
             throw formatExceptionMessage(

--- a/sshd-common/src/main/java/org/apache/sshd/common/io/IoConnectFuture.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/io/IoConnectFuture.java
@@ -18,9 +18,10 @@
  */
 package org.apache.sshd.common.io;
 
+import org.apache.sshd.common.future.Cancellable;
 import org.apache.sshd.common.future.SshFuture;
 
-public interface IoConnectFuture extends SshFuture<IoConnectFuture> {
+public interface IoConnectFuture extends SshFuture<IoConnectFuture>, Cancellable {
 
     /**
      * @return The current {@link IoSession} - may be {@code null} if connect operation not finished yet or attempt has
@@ -30,22 +31,9 @@ public interface IoConnectFuture extends SshFuture<IoConnectFuture> {
     IoSession getSession();
 
     /**
-     * Returns the cause of the connection failure.
-     *
-     * @return {@code null} if the connect operation is not finished yet, or if the connection attempt is successful.
-     * @see    #getSession()
-     */
-    Throwable getException();
-
-    /**
      * @return <tt>true</tt> if the connect operation is finished successfully.
      */
     boolean isConnected();
-
-    /**
-     * @return {@code true} if the connect operation has been canceled by {@link #cancel()} method.
-     */
-    boolean isCanceled();
 
     /**
      * Sets the newly connected session and notifies all threads waiting for this future. This method is invoked by SSHD
@@ -55,16 +43,4 @@ public interface IoConnectFuture extends SshFuture<IoConnectFuture> {
      */
     void setSession(IoSession session);
 
-    /**
-     * Sets the exception caught due to connection failure and notifies all threads waiting for this future. This method
-     * is invoked by SSHD internally. Please do not call this method directly.
-     *
-     * @param exception The caught {@link Throwable}
-     */
-    void setException(Throwable exception);
-
-    /**
-     * Cancels the connection attempt and notifies all threads waiting for this future.
-     */
-    void cancel();
 }

--- a/sshd-common/src/main/java/org/apache/sshd/common/util/closeable/Builder.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/util/closeable/Builder.java
@@ -52,22 +52,19 @@ public final class Builder implements ObjectBuilder<Closeable> {
         });
     }
 
-    @SuppressWarnings("rawtypes")
-    public <T extends SshFuture> Builder when(SshFuture<T> future) {
+    public <T extends SshFuture<T>> Builder when(SshFuture<T> future) {
         if (future != null) {
             when(future.getId(), Collections.singleton(future));
         }
         return this;
     }
 
-    @SuppressWarnings("rawtypes")
     @SafeVarargs
-    public final <T extends SshFuture> Builder when(SshFuture<T>... futures) {
+    public final <T extends SshFuture<T>> Builder when(SshFuture<T>... futures) {
         return when(getClass().getSimpleName(), Arrays.asList(futures));
     }
 
-    @SuppressWarnings("rawtypes")
-    public <T extends SshFuture> Builder when(Object id, Iterable<? extends SshFuture<T>> futures) {
+    public <T extends SshFuture<T>> Builder when(Object id, Iterable<? extends SshFuture<T>> futures) {
         return close(new FuturesCloseable<>(id, lock, futures));
     }
 

--- a/sshd-common/src/main/java/org/apache/sshd/common/util/closeable/FuturesCloseable.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/util/closeable/FuturesCloseable.java
@@ -30,7 +30,7 @@ import org.apache.sshd.common.future.SshFutureListener;
  * @param  <T> Type of future
  * @author     <a href="mailto:dev@mina.apache.org">Apache MINA SSHD Project</a>
  */
-public class FuturesCloseable<T extends SshFuture> extends SimpleCloseable {
+public class FuturesCloseable<T extends SshFuture<T>> extends SimpleCloseable {
 
     private final Iterable<? extends SshFuture<T>> futures;
 
@@ -42,9 +42,9 @@ public class FuturesCloseable<T extends SshFuture> extends SimpleCloseable {
     @Override
     protected void doClose(boolean immediately) {
         if (immediately) {
-            for (SshFuture<?> f : futures) {
+            for (SshFuture<T> f : futures) {
                 if (f instanceof DefaultSshFuture) {
-                    ((DefaultSshFuture<?>) f).setValue(new SshException("Closed"));
+                    ((DefaultSshFuture<T>) f).setValue(new SshException("Closed"));
                 }
             }
             future.setClosed();

--- a/sshd-contrib/src/main/java/org/apache/sshd/contrib/common/io/EndlessWriteFuture.java
+++ b/sshd-contrib/src/main/java/org/apache/sshd/contrib/common/io/EndlessWriteFuture.java
@@ -21,6 +21,7 @@ package org.apache.sshd.contrib.common.io;
 
 import java.io.IOException;
 
+import org.apache.sshd.common.future.CancelOption;
 import org.apache.sshd.common.future.SshFutureListener;
 import org.apache.sshd.common.io.IoWriteFuture;
 
@@ -37,7 +38,7 @@ public class EndlessWriteFuture implements IoWriteFuture {
     }
 
     @Override
-    public IoWriteFuture verify(long timeoutMillis) throws IOException {
+    public IoWriteFuture verify(long timeoutMillis, CancelOption... options) throws IOException {
         await(timeoutMillis);
         return null;
     }
@@ -53,7 +54,7 @@ public class EndlessWriteFuture implements IoWriteFuture {
     }
 
     @Override
-    public boolean awaitUninterruptibly(long timeoutMillis) {
+    public boolean awaitUninterruptibly(long timeoutMillis, CancelOption... options) {
         try {
             Thread.sleep(timeoutMillis);
         } catch (InterruptedException e) {
@@ -64,7 +65,7 @@ public class EndlessWriteFuture implements IoWriteFuture {
     }
 
     @Override
-    public boolean await(long timeoutMillis) throws IOException {
+    public boolean await(long timeoutMillis, CancelOption... options) throws IOException {
         return awaitUninterruptibly(timeoutMillis);
     }
 

--- a/sshd-core/src/main/java/org/apache/sshd/client/auth/AbstractUserAuth.java
+++ b/sshd-core/src/main/java/org/apache/sshd/client/auth/AbstractUserAuth.java
@@ -33,6 +33,7 @@ public abstract class AbstractUserAuth extends AbstractLoggingBean implements Us
     private final String name;
     private ClientSession clientSession;
     private String service;
+    private boolean cancellable;
 
     protected AbstractUserAuth(String name) {
         this.name = ValidateUtils.checkNotNullAndNotEmpty(name, "No name");
@@ -55,6 +56,20 @@ public abstract class AbstractUserAuth extends AbstractLoggingBean implements Us
 
     public String getService() {
         return service;
+    }
+
+    @Override
+    public boolean isCancellable() {
+        return cancellable;
+    }
+
+    /**
+     * Sets whether the authentication protocol is currently cancellable.
+     *
+     * @param cancellable {@code true} if the protocol may be canceled in its current state; {@code false} if not
+     */
+    protected void setCancellable(boolean cancellable) {
+        this.cancellable = cancellable;
     }
 
     @Override

--- a/sshd-core/src/main/java/org/apache/sshd/client/auth/UserAuth.java
+++ b/sshd-core/src/main/java/org/apache/sshd/client/auth/UserAuth.java
@@ -78,6 +78,15 @@ public interface UserAuth extends ClientSessionHolder, UserAuthInstance<ClientSe
     }
 
     /**
+     * Tells whether the authentication protocol is cancellable currently.
+     *
+     * @return {@code true} if the protocol can be canceled at its current state; {@code false} if not.
+     */
+    default boolean isCancellable() {
+        return false;
+    }
+
+    /**
      * Called to release any allocated resources
      */
     void destroy();

--- a/sshd-core/src/main/java/org/apache/sshd/client/auth/pubkey/UserAuthPublicKey.java
+++ b/sshd-core/src/main/java/org/apache/sshd/client/auth/pubkey/UserAuthPublicKey.java
@@ -86,6 +86,7 @@ public class UserAuthPublicKey extends AbstractUserAuth implements SignatureFact
     public UserAuthPublicKey(List<NamedFactory<Signature>> factories) {
         super(NAME);
         this.factories = factories; // OK if null/empty
+        setCancellable(true);
     }
 
     @Override
@@ -251,6 +252,7 @@ public class UserAuthPublicKey extends AbstractUserAuth implements SignatureFact
         if (doHostBoundAuth) {
             buffer.putPublicKey(session.getServerKey());
         }
+        setCancellable(true);
         session.writePacket(buffer);
         return true;
     }
@@ -413,7 +415,7 @@ public class UserAuthPublicKey extends AbstractUserAuth implements SignatureFact
         if (reporter != null) {
             reporter.signalSignatureAttempt(session, service, keyPair, algo, sig);
         }
-
+        setCancellable(false);
         session.writePacket(buffer);
         return true;
     }

--- a/sshd-core/src/main/java/org/apache/sshd/client/channel/AbstractClientChannel.java
+++ b/sshd-core/src/main/java/org/apache/sshd/client/channel/AbstractClientChannel.java
@@ -382,7 +382,13 @@ public abstract class AbstractClientChannel extends AbstractChannel implements C
 
             signalChannelOpenSuccess();
             this.opened.set(true);
-            this.openFuture.setOpened();
+            OpenFuture opened = this.openFuture;
+            opened.setOpened();
+            if (opened.isCanceled()) {
+                close(false).addListener(f -> {
+                    opened.getCancellation().setCanceled();
+                });
+            }
         } catch (Throwable t) {
             Throwable e = ExceptionUtils.peelException(t);
             changeEvent = e.getClass().getName();

--- a/sshd-core/src/main/java/org/apache/sshd/client/future/AuthFuture.java
+++ b/sshd-core/src/main/java/org/apache/sshd/client/future/AuthFuture.java
@@ -18,6 +18,7 @@
  */
 package org.apache.sshd.client.future;
 
+import org.apache.sshd.common.future.Cancellable;
 import org.apache.sshd.common.future.SshFuture;
 import org.apache.sshd.common.future.VerifiableFuture;
 
@@ -26,14 +27,7 @@ import org.apache.sshd.common.future.VerifiableFuture;
  *
  * @author <a href="mailto:dev@mina.apache.org">Apache MINA SSHD Project</a>
  */
-public interface AuthFuture extends SshFuture<AuthFuture>, VerifiableFuture<AuthFuture> {
-    /**
-     * Returns the cause of the authentication failure.
-     *
-     * @return {@code null} if the authentication operation is not finished yet, or if the connection attempt is
-     *         successful (use {@link #isDone()} to distinguish between the two).
-     */
-    Throwable getException();
+public interface AuthFuture extends SshFuture<AuthFuture>, VerifiableFuture<AuthFuture>, Cancellable {
 
     /**
      * @return <code>true</code> if the authentication operation is finished successfully. <B>Note:</B> calling this
@@ -50,11 +44,6 @@ public interface AuthFuture extends SshFuture<AuthFuture>, VerifiableFuture<Auth
     boolean isFailure();
 
     /**
-     * @return {@code true} if the connect operation has been canceled by {@link #cancel()} method.
-     */
-    boolean isCanceled();
-
-    /**
      * Notifies that the session has been authenticated. This method is invoked by SSHD internally. Please do not call
      * this method directly.
      *
@@ -63,15 +52,27 @@ public interface AuthFuture extends SshFuture<AuthFuture>, VerifiableFuture<Auth
     void setAuthed(boolean authed);
 
     /**
-     * Sets the exception caught due to connection failure and notifies all threads waiting for this future. This method
-     * is invoked by SSHD internally. Please do not call this method directly.
+     * Enables or disables cancellation of this {@link AuthFuture}.
+     * <p>
+     * This is a framework method; do not call directly.
+     * </p>
      *
-     * @param exception The caught {@link Throwable}
+     * @param cancellable whether this future is currently cancellable
      */
-    void setException(Throwable exception);
+    void setCancellable(boolean cancellable);
 
     /**
-     * Cancels the authentication attempt and notifies all threads waiting for this future.
+     * Tells whether {@link #cancel()} was called on this {@link AuthFuture}.
+     * <p>
+     * This is different from {@link #isCanceled()}. Cancelling an on-going authentication may not be possible;
+     * {@link #cancel()} is only a <em>request</em> to cancel the authentication. That request may not be honored and
+     * the {@link org.apache.sshd.common.future.CancelFuture CancelFuture} may actually be
+     * {@link org.apache.sshd.common.future.CancelFuture#isCanceled() isCanceled()} {@code == false}.
+     * {@link AuthFuture}.{@link isCanceled()} is then {@code false}, too.
+     * </p>
+     *
+     * @return {@code true} if {@link #cancel()} was called, {@code false} otherwise
      */
-    void cancel();
+    boolean wasCanceled();
+
 }

--- a/sshd-core/src/main/java/org/apache/sshd/client/future/ConnectFuture.java
+++ b/sshd-core/src/main/java/org/apache/sshd/client/future/ConnectFuture.java
@@ -20,6 +20,7 @@ package org.apache.sshd.client.future;
 
 import org.apache.sshd.client.session.ClientSession;
 import org.apache.sshd.client.session.ClientSessionHolder;
+import org.apache.sshd.common.future.Cancellable;
 import org.apache.sshd.common.future.SshFuture;
 import org.apache.sshd.common.future.VerifiableFuture;
 import org.apache.sshd.common.session.SessionHolder;
@@ -33,7 +34,7 @@ public interface ConnectFuture
         extends SshFuture<ConnectFuture>,
         VerifiableFuture<ConnectFuture>,
         SessionHolder<ClientSession>,
-        ClientSessionHolder {
+        ClientSessionHolder, Cancellable {
 
     @Override
     default ClientSession getClientSession() {
@@ -46,11 +47,6 @@ public interface ConnectFuture
     boolean isConnected();
 
     /**
-     * @return {@code true} if the connect operation has been canceled by {@link #cancel()} method.
-     */
-    boolean isCanceled();
-
-    /**
      * Sets the newly connected session and notifies all threads waiting for this future. This method is invoked by SSHD
      * internally. Please do not call this method directly.
      *
@@ -58,24 +54,4 @@ public interface ConnectFuture
      */
     void setSession(ClientSession session);
 
-    /**
-     * Returns the cause of the connection failure.
-     *
-     * @return {@code null} if the connect operation is not finished yet, or if the connection attempt is successful
-     *         (use {@link #isDone()} to distinguish between the two)
-     */
-    Throwable getException();
-
-    /**
-     * Sets the exception caught due to connection failure and notifies all threads waiting for this future. This method
-     * is invoked by SSHD internally. Please do not call this method directly.
-     *
-     * @param exception The caught {@link Throwable}
-     */
-    void setException(Throwable exception);
-
-    /**
-     * Cancels the connection attempt and notifies all threads waiting for this future.
-     */
-    void cancel();
 }

--- a/sshd-core/src/main/java/org/apache/sshd/client/future/DefaultOpenFuture.java
+++ b/sshd-core/src/main/java/org/apache/sshd/client/future/DefaultOpenFuture.java
@@ -19,24 +19,24 @@
 package org.apache.sshd.client.future;
 
 import java.io.IOException;
-import java.util.Objects;
 
 import org.apache.sshd.common.SshException;
-import org.apache.sshd.common.future.DefaultVerifiableSshFuture;
+import org.apache.sshd.common.future.CancelOption;
+import org.apache.sshd.common.future.DefaultCancellableSshFuture;
 
 /**
  * A default implementation of {@link OpenFuture}.
  *
  * @author <a href="mailto:dev@mina.apache.org">Apache MINA SSHD Project</a>
  */
-public class DefaultOpenFuture extends DefaultVerifiableSshFuture<OpenFuture> implements OpenFuture {
+public class DefaultOpenFuture extends DefaultCancellableSshFuture<OpenFuture> implements OpenFuture {
     public DefaultOpenFuture(Object id, Object lock) {
         super(id, lock);
     }
 
     @Override
-    public OpenFuture verify(long timeoutMillis) throws IOException {
-        Boolean result = verifyResult(Boolean.class, timeoutMillis);
+    public OpenFuture verify(long timeoutMillis, CancelOption... options) throws IOException {
+        Boolean result = verifyResult(Boolean.class, timeoutMillis, options);
         if (!result) {
             throw formatExceptionMessage(
                     SshException::new,
@@ -48,16 +48,6 @@ public class DefaultOpenFuture extends DefaultVerifiableSshFuture<OpenFuture> im
     }
 
     @Override
-    public Throwable getException() {
-        Object v = getValue();
-        if (v instanceof Throwable) {
-            return (Throwable) v;
-        } else {
-            return null;
-        }
-    }
-
-    @Override
     public boolean isOpened() {
         Object value = getValue();
         return (value instanceof Boolean) && (Boolean) value;
@@ -66,11 +56,5 @@ public class DefaultOpenFuture extends DefaultVerifiableSshFuture<OpenFuture> im
     @Override
     public void setOpened() {
         setValue(Boolean.TRUE);
-    }
-
-    @Override
-    public void setException(Throwable exception) {
-        Objects.requireNonNull(exception, "No exception provided");
-        setValue(exception);
     }
 }

--- a/sshd-core/src/main/java/org/apache/sshd/common/channel/ChannelAsyncInputStream.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/channel/ChannelAsyncInputStream.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.util.Objects;
 
 import org.apache.sshd.common.RuntimeSshException;
+import org.apache.sshd.common.future.CancelOption;
 import org.apache.sshd.common.future.CloseFuture;
 import org.apache.sshd.common.future.DefaultVerifiableSshFuture;
 import org.apache.sshd.common.io.IoInputStream;
@@ -167,9 +168,9 @@ public class ChannelAsyncInputStream extends AbstractCloseable implements IoInpu
         }
 
         @Override
-        public IoReadFuture verify(long timeoutMillis) throws IOException {
+        public IoReadFuture verify(long timeoutMillis, CancelOption... options) throws IOException {
             long startTime = System.nanoTime();
-            Number result = verifyResult(Number.class, timeoutMillis);
+            Number result = verifyResult(Number.class, timeoutMillis, options);
             long endTime = System.nanoTime();
             if (log.isDebugEnabled()) {
                 log.debug("Read {} bytes after {} nanos", result, endTime - startTime);

--- a/sshd-core/src/main/java/org/apache/sshd/core/CoreModuleProperties.java
+++ b/sshd-core/src/main/java/org/apache/sshd/core/CoreModuleProperties.java
@@ -316,6 +316,40 @@ public final class CoreModuleProperties {
             = Property.duration("idle-timeout", Duration.ofMinutes(10));
 
     /**
+     * Key used to retrieve the value of the socket connect time-out.
+     * <p>
+     * Connection time-outs are generally handled in Apache MINA SSHD at the application level via
+     * {@link org.apache.sshd.client.future.ConnectFuture}.{@link org.apache.sshd.common.future.VerifiableFuture#verify(Duration, org.apache.sshd.common.future.CancelOption...)
+     * verify()}. However, the underlying I/O library may have its own connection time-out. By setting this property on
+     * an {@link org.apache.sshd.client.SshClient} or {@link org.apache.sshd.server.SshServer}, users can explicitly set
+     * this I/O connection time-out to any value. If the duration is zero or negative, or the property is not set on the
+     * client or server, the default of the I/O library used is in effect. These defaults are:
+     * </p>
+     * <table>
+     * <tr>
+     * <th>I/O back-end</th>
+     * <th>Default connection time-out</th>
+     * </tr>
+     * <tr>
+     * <td>NIO2</td>
+     * <td>infinite</td>
+     * </tr>
+     * <tr>
+     * <td>MINA</td>
+     * <td>1 minute</td>
+     * </tr>
+     * <tr>
+     * <td>Netty</td>
+     * <td>30 seconds</td>
+     * </tr>
+     * </table>
+     * <p>
+     * The default value of this property is 1 minute.
+     * </p>
+     */
+    public static final Property<Duration> IO_CONNECT_TIMEOUT = Property.duration("io-connect-timeout", Duration.ofMinutes(1));
+
+    /**
      * Key used to retrieve the value of the socket read timeout for NIO2 session implementation - in milliseconds.
      */
     public static final Property<Duration> NIO2_READ_TIMEOUT

--- a/sshd-core/src/main/java/org/apache/sshd/server/forward/TcpipServerChannel.java
+++ b/sshd-core/src/main/java/org/apache/sshd/server/forward/TcpipServerChannel.java
@@ -254,8 +254,14 @@ public class TcpipServerChannel extends AbstractServerChannel implements Forward
         try {
             signalChannelOpenSuccess();
             f.setOpened();
-            // Now that we have sent the SSH_MSG_CHANNEL_OPEN_CONFIRMATION we may read from the port.
-            session.resumeRead();
+            if (f.isCanceled()) {
+                close(false).addListener(cf -> {
+                    f.getCancellation().setCanceled();
+                });
+            } else {
+                // Now that we have sent the SSH_MSG_CHANNEL_OPEN_CONFIRMATION we may read from the port.
+                session.resumeRead();
+            }
         } catch (Throwable t) {
             Throwable e = ExceptionUtils.peelException(t);
             changeEvent = e.getClass().getSimpleName();

--- a/sshd-mina/src/main/java/org/apache/sshd/mina/MinaService.java
+++ b/sshd-mina/src/main/java/org/apache/sshd/mina/MinaService.java
@@ -25,6 +25,8 @@ import java.util.Objects;
 
 import org.apache.mina.core.RuntimeIoException;
 import org.apache.mina.core.buffer.IoBuffer;
+import org.apache.mina.core.filterchain.DefaultIoFilterChain;
+import org.apache.mina.core.future.ConnectFuture;
 import org.apache.mina.core.service.IoHandler;
 import org.apache.mina.core.service.IoProcessor;
 import org.apache.mina.core.service.IoService;
@@ -106,7 +108,13 @@ public abstract class MinaService extends AbstractCloseable
 
     @Override
     public void sessionOpened(IoSession session) throws Exception {
-        // Empty handler
+        ConnectFuture future = (ConnectFuture) session.removeAttribute(DefaultIoFilterChain.SESSION_CREATED_FUTURE);
+        if (future != null) {
+            future.setSession(session);
+            if (future.getSession() != session) {
+                session.closeNow();
+            }
+        }
     }
 
     @Override


### PR DESCRIPTION
Implement cancellation of futures such that cancelling a user-visible future also cancels the underlying internal operation. Since cancellations can be asynchronous, introduce the concept of a `CancelFuture` that can be used to wait until a cancellation has indeed been effected.

Augment `Future.verify()` with additional optional `CancelOption` parameters so that client code can specify whether a time-out should cancel the future and its underlying operation. In particular, `DefaultConnectFuture.verify()` now by default does cancel the connection attempt on a time-out. This avoids leaking a socket if the low-level connection attempt succeeds after the high-level time-out has expired.

Add a property to control a possibly connection time-out that might exist at the I/O library level.

Add tests for connection time-outs and for cancelling a connection attempt, and verify that either no sessions are created, or if so, that they are being closed or already have been closed.