### PR TITLE
Adapt OSGi metadata of sshd.osgi to work with slf4j-api 1 and 2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,7 @@
         <groovy.version>3.0.11</groovy.version>
         <bouncycastle.version>1.70</bouncycastle.version>
         <slf4j.version>1.7.32</slf4j.version>
+        <slf4j.upper.bound>3</slf4j.upper.bound>
         <logback.version>1.2.11</logback.version>
         <spring.version>5.3.20</spring.version>
             <!-- NOTE: upgrading to 6.x requires Java 11 -->
@@ -1464,7 +1465,11 @@
                         </goals>
                         <configuration>
                             <instructions>
-                                <Import-Package>org.apache.sshd*;version="[$(version;==;${sshd.osgi.version.clean}),$(version;=+;${sshd.osgi.version.clean}))",*</Import-Package>
+                                <Import-Package><![CDATA[
+                                  org.apache.sshd*;version="[$(version;==;${sshd.osgi.version.clean}),$(version;=+;${sshd.osgi.version.clean}))",
+                                  org.slf4j*;version="${range;[==,${slf4j.upper.bound})}",
+                                  *
+                                  ]]></Import-Package>
                                 <Export-Package>*;-noimport:=true</Export-Package>
                             </instructions>
                             <noWarningProjectTypes>pom</noWarningProjectTypes>


### PR DESCRIPTION
SSHD-Mina seems to be compatible with slf4j 1.7.x and 2.0.x. At least my local build (`mvn clean verify`) succeed without errors. I only had to disable the license check for slf4j.api.
Please let me know if my assumption about compatibility in regards of slf4j-2 is wrong.

This PR adjusts the OSGi `Import-Package` entries in the MANIFEST.MF to make sshd-mina work with both versions of the slf4j.api bundle in an OSGi runtime.