### PR TITLE
Remove obsolete o.e.m2e:lifecycle-mapping pseudo plugin configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -283,129 +283,6 @@
                 </plugins>
             </build>
         </profile>
-
-        <profile>
-            <id>only-eclipse</id>
-            <activation>
-                <property>
-                    <name>m2e.version</name>
-                </property>
-            </activation>
-            <build>
-                <pluginManagement>
-                    <plugins>
-                        <!--This plugin's configuration is used to store Eclipse
-                            m2e settings only and overcome integration problems.
-                            It has no influence on the Maven build itself. -->
-                        <plugin>
-                            <groupId>org.eclipse.m2e</groupId>
-                            <artifactId>lifecycle-mapping</artifactId>
-                            <version>1.0.0</version>
-                            <configuration>
-                                <lifecycleMappingMetadata>
-                                    <pluginExecutions>
-                                        <pluginExecution>
-                                            <pluginExecutionFilter>
-                                                <groupId>org.apache.maven.plugins</groupId>
-                                                <artifactId>maven-dependency-plugin</artifactId>
-                                                <versionRange>[1.0,)</versionRange>
-                                                <goals>
-                                                    <goal>copy</goal>
-                                                    <goal>copy-dependencies</goal>
-                                                </goals>
-                                            </pluginExecutionFilter>
-                                            <action>
-                                                <execute />
-                                            </action>
-                                        </pluginExecution>
-                                        <pluginExecution>
-                                            <pluginExecutionFilter>
-                                                <groupId>org.codehaus.gmavenplus</groupId>
-                                                <artifactId>gmavenplus-plugin</artifactId>
-                                                <versionRange>[1.0,)</versionRange>
-                                                <goals>
-                                                    <goal>compile</goal>
-                                                    <goal>execute</goal>
-                                                    <goal>testCompile</goal>
-                                                </goals>
-                                            </pluginExecutionFilter>
-                                            <action>
-                                                <execute />
-                                            </action>
-                                        </pluginExecution>
-                                        <pluginExecution>
-                                            <pluginExecutionFilter>
-                                                <groupId>org.apache.rat</groupId>
-                                                <artifactId>apache-rat-plugin</artifactId>
-                                                <versionRange>[0.1,)</versionRange>
-                                                <goals>
-                                                    <goal>check</goal>
-                                                </goals>
-                                            </pluginExecutionFilter>
-                                            <action>
-                                                <execute />
-                                            </action>
-                                        </pluginExecution>
-                                        <pluginExecution>
-                                            <pluginExecutionFilter>
-                                                <groupId>org.apache.maven.plugins</groupId>
-                                                <artifactId>maven-checkstyle-plugin</artifactId>
-                                                <versionRange>[1.0,)</versionRange>
-                                                <goals>
-                                                    <goal>check</goal>
-                                                </goals>
-                                            </pluginExecutionFilter>
-                                            <action>
-                                                <ignore />
-                                            </action>
-                                        </pluginExecution>
-                                        <pluginExecution>
-                                            <pluginExecutionFilter>
-                                                <groupId>org.apache.maven.plugins</groupId>
-                                                <artifactId>maven-pmd-plugin</artifactId>
-                                                <versionRange>[3.9.0,)</versionRange>
-                                                <goals>
-                                                    <goal>check</goal>
-                                                </goals>
-                                            </pluginExecutionFilter>
-                                            <action>
-                                                <ignore />
-                                            </action>
-                                        </pluginExecution>
-                                        <pluginExecution>
-                                            <pluginExecutionFilter>
-                                                <groupId>org.apache.felix</groupId>
-                                                <artifactId>maven-bundle-plugin</artifactId>
-                                                <versionRange>[1.0,)</versionRange>
-                                                <goals>
-                                                    <goal>manifest</goal>
-                                                </goals>
-                                            </pluginExecutionFilter>
-                                            <action>
-                                                <execute />
-                                            </action>
-                                        </pluginExecution>
-                                        <pluginExecution>
-                                            <pluginExecutionFilter>
-                                                <groupId>org.apache.maven.plugins</groupId>
-                                                <artifactId>maven-antrun-plugin</artifactId>
-                                                <versionRange>[1.8,)</versionRange>
-                                                <goals>
-                                                    <goal>run</goal>
-                                                </goals>
-                                            </pluginExecutionFilter>
-                                            <action>
-                                                <execute />
-                                            </action>
-                                        </pluginExecution>
-                                    </pluginExecutions>
-                                </lifecycleMappingMetadata>
-                            </configuration>
-                        </plugin>
-                    </plugins>
-                </pluginManagement>
-            </build>
-        </profile>
     </profiles>
 
     <dependencyManagement>
@@ -1181,6 +1058,7 @@
                 </configuration>
                 <executions>
                     <execution>
+                        <?m2e ignore?>
                         <id>verify-style</id>
                         <!-- Note: phase must be AFTER detection of workspace root dir -->
                         <phase>process-sources</phase>
@@ -1202,6 +1080,7 @@
                </configuration>
                <executions>
                    <execution>
+                       <?m2e ignore?>
                        <id>pmd-checker</id>
                        <!-- Note: phase must be AFTER detection of workspace root dir -->
                        <phase>process-test-classes</phase>


### PR DESCRIPTION
Since Eclipse m2e 2.2.0 unknown mojos are executed by default: https://github.com/eclipse-m2e/m2e-core/blob/master/RELEASE_NOTES.md#mojos-without-a-mapping-are-now-executed-by-default-in-incremental-builds

Therefore the configuration of the pseudo plugin `org.eclipse.m2e:lifecycle-mapping` can be removed in conjunction with the `only-eclipse` profile.
For those mojo executions that have been ignored in said configuration, use m2e's processing instructions instead, which are less verbose and more focused. See
https://www.eclipse.org/m2e/documentation/release-notes-17.html#new-syntax-for-specifying-lifecycle-mapping-metadata