### PR TITLE
GH-325: SFTP: fix deleting remote symbolic links

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -35,6 +35,7 @@
 * [GH-298](https://github.com/apache/mina-sshd/issues/298) Server side heartbeat not working.
 * [GH-300](https://github.com/apache/mina-sshd/issues/300) Read the channel id in `SSH_MSG_CHANNEL_OPEN_CONFIRMATION` as unsigned int.
 * [GH-313](https://github.com/apache/mina-sshd/issues/313) Log exceptions in the SFTP subsystem before sending a failure status reply.
+* [GH-325](https://github.com/apache/mina-sshd/issues/325) SftpFileSystemProvider: fix deletions of symlinks through Files.delete().
 
 
 * [SSHD-1295](https://issues.apache.org/jira/browse/SSHD-1295) Fix cancellation of futures and add options to cancel futures on time-outs.


### PR DESCRIPTION
Files.delete() is specified *not* to follow symbolic links. The implementation in SftpFileSystemProvider checked for write access and file existence via a method that does resolve symbolic links. This lead to general inconsistency and various kinds of failures.

Fix this by making sure that the code does not resolve symbolic links in Files.delete().

Fixes #325.