### PR TITLE
Read openssl ed25519 PEM with traditional encryption

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -137,6 +137,11 @@ appropriate for the precise use case.
   (RFC 5958, EncryptedPrivateKeyInfo) has been added. Such PEM files start with
   "-----BEGIN ENCRYPTED PRIVATE KEY-----". Reading and decrypting keys from such
   files requires Bouncy Castle to be present.
+* Support reading SSH keys from PEM files starting with "-----BEGIN ED25519 PRIVATE KEY-----".
+  Some OpenSSL versions could produce such files when the user specified
+  "traditional" PEM output. (Encrypted keys written using RFC 1421 encryption.)
+  Modern OpenSSL refuses to create such PEM files; it always uses PKCS#8
+  (RFC 5958) style PEM files for EdDSA keys.
 * `CoreModuleProperties.PASSWORD_PROMPTS` is now also used for password
   authentication. Previous versions used it only for keyboard-interactive
   authentication. The semantics has been clarified to be the equivalent

--- a/sshd-common/src/main/java/org/apache/sshd/common/config/keys/loader/pem/PKCS8PEMResourceKeyPairParser.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/config/keys/loader/pem/PKCS8PEMResourceKeyPairParser.java
@@ -62,11 +62,11 @@ public class PKCS8PEMResourceKeyPairParser extends AbstractPEMResourceKeyPairPar
 
     public static final String BEGIN_MARKER = "BEGIN PRIVATE KEY";
     public static final String BEGIN_ENCRYPTED_MARKER = "BEGIN ENCRYPTED PRIVATE KEY";
-    public static final List<String> BEGINNERS = GenericUtils.asList(BEGIN_MARKER, BEGIN_ENCRYPTED_MARKER);
+    public static final List<String> BEGINNERS = GenericUtils.unmodifiableList(BEGIN_MARKER, BEGIN_ENCRYPTED_MARKER);
 
     public static final String END_MARKER = "END PRIVATE KEY";
     public static final String END_ENCRYPTED_MARKER = "END ENCRYPTED PRIVATE KEY";
-    public static final List<String> ENDERS = GenericUtils.asList(END_MARKER, END_ENCRYPTED_MARKER);
+    public static final List<String> ENDERS = GenericUtils.unmodifiableList(END_MARKER, END_ENCRYPTED_MARKER);
 
     public static final String PKCS8_FORMAT = "PKCS#8";
 
@@ -99,7 +99,7 @@ public class PKCS8PEMResourceKeyPairParser extends AbstractPEMResourceKeyPairPar
         if (passwordProvider == null) {
             throw new CredentialException("Missing password provider for encrypted resource=" + resourceKey);
         }
-        // This requires Bouncy Castle due to various bug regarding PBES2 in various Java versions.
+        // This requires Bouncy Castle due to various bugs regarding PBES2 in various Java versions.
         //
         // See https://stackoverflow.com/questions/66286457/load-an-encrypted-pcks8-pem-private-key-in-java
         Decryptor decryptor = SecurityUtils.getBouncycastleEncryptedPrivateKeyInfoDecryptor();

--- a/sshd-common/src/main/java/org/apache/sshd/common/util/security/eddsa/Ed25519PEMResourceKeyParser.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/util/security/eddsa/Ed25519PEMResourceKeyParser.java
@@ -53,12 +53,19 @@ import org.apache.sshd.common.util.security.SecurityUtils;
  * @author <a href="mailto:dev@mina.apache.org">Apache MINA SSHD Project</a>
  */
 public class Ed25519PEMResourceKeyParser extends AbstractPEMResourceKeyPairParser {
-    // TODO find out how the markers really look like for now provide something
+
+    // From an early draft of RFC 8410 (https://datatracker.ietf.org/doc/html/draft-ietf-curdle-pkix-eddsa-00).
+    // The final RFC 8410 dropped the "EDDSA" and moved to PKCS#8 using just "BEGIN PRIVATE KEY".
     public static final String BEGIN_MARKER = "BEGIN EDDSA PRIVATE KEY";
-    public static final List<String> BEGINNERS = Collections.unmodifiableList(Collections.singletonList(BEGIN_MARKER));
+
+    // Some (older) OpenSSL versions used this if "traditional" (RFC 1421) PEM format was chosen:
+    public static final String BEGIN_ED25519_MARKER = "BEGIN ED25519 PRIVATE KEY";
+
+    public static final List<String> BEGINNERS = GenericUtils.unmodifiableList(BEGIN_MARKER, BEGIN_ED25519_MARKER);
 
     public static final String END_MARKER = "END EDDSA PRIVATE KEY";
-    public static final List<String> ENDERS = Collections.unmodifiableList(Collections.singletonList(END_MARKER));
+    public static final String END_ED25519_MARKER = "END ED25519 PRIVATE KEY";
+    public static final List<String> ENDERS = GenericUtils.unmodifiableList(END_MARKER, END_ED25519_MARKER);
 
     /**
      * @see <A HREF="https://tools.ietf.org/html/rfc8410#section-3">RFC8412 section 3</A>


### PR DESCRIPTION
Older OpenSSL could encode ed25519 private keys as PEM with traditional RFC 1421/1423 encryption (using "Proc-Type" and "DEK-Info" headers) and used the label "ED25519 PRIVATE KEY" in such PEM files.