### PR TITLE
Follow first-match semantics specified for ssh config file

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,7 @@
 
 * [GH-268](https://github.com/apache/mina-sshd/issues/268) (Regression in 2.9.0) Heartbeat should throw an exception if no reply arrives within the timeout.
 * [GH-275](https://github.com/apache/mina-sshd/issues/275) SFTP: be more lenient when reading `SSH_FXP_STATUS` replies.
+* [GH-281](https://github.com/apache/mina-sshd/issues/281) Use OpenSSH first-match semantics for processing HostConfigEntries.
 * [GH-282](https://github.com/apache/mina-sshd/issues/282) Correct setting file permissions on newly written host key files on Windows.
 * [GH-283](https://github.com/apache/mina-sshd/issues/283) Fix handling of `CoreModuleProperties.PASSWORD_PROMPTS`.
 * [GH-285](https://github.com/apache/mina-sshd/issues/285) Fix compilation failure on Java 19.
@@ -36,7 +37,7 @@
 * [GH-300](https://github.com/apache/mina-sshd/issues/300) Read the channel id in `SSH_MSG_CHANNEL_OPEN_CONFIRMATION` as unsigned int.
 * [GH-313](https://github.com/apache/mina-sshd/issues/313) Log exceptions in the SFTP subsystem before sending a failure status reply.
 * [GH-322](https://github.com/apache/mina-sshd/issues/322) Add basic Android O/S awareness.
-* [GH-325](https://github.com/apache/mina-sshd/issues/325) SftpFileSystemProvider: fix deletions of symlinks through Files.delete().
+* [GH-325](https://github.com/apache/mina-sshd/issues/325) SftpFileSystemProvider: fix deletions of symlinks through `Files.delete()`.
 
 
 * [SSHD-1295](https://issues.apache.org/jira/browse/SSHD-1295) Fix cancellation of futures and add options to cancel futures on time-outs.

--- a/sshd-common/src/main/java/org/apache/sshd/client/config/hosts/HostPatternsHolder.java
+++ b/sshd-common/src/main/java/org/apache/sshd/client/config/hosts/HostPatternsHolder.java
@@ -117,57 +117,6 @@ public abstract class HostPatternsHolder {
         return true;
     }
 
-    /**
-     * Locates all the matching entries for a give host name / address
-     *
-     * @param  host    The host name / address - ignored if {@code null}/empty
-     * @param  entries The {@link HostConfigEntry}-ies to scan - ignored if {@code null}/empty
-     * @return         A {@link List} of all the matching entries
-     * @see            #isHostMatch(String, int)
-     */
-    public static List<HostConfigEntry> findMatchingEntries(String host, HostConfigEntry... entries) {
-        // TODO in Java-8 use Stream(s) + predicate
-        if (GenericUtils.isEmpty(host) || GenericUtils.isEmpty(entries)) {
-            return Collections.emptyList();
-        } else {
-            return findMatchingEntries(host, Arrays.asList(entries));
-        }
-    }
-
-    /**
-     * Locates all the matching entries for a give host name / address
-     *
-     * @param  host    The host name / address - ignored if {@code null}/empty
-     * @param  entries The {@link HostConfigEntry}-ies to scan - ignored if {@code null}/empty
-     * @return         A {@link List} of all the matching entries
-     * @see            #isHostMatch(String, int)
-     */
-    public static List<HostConfigEntry> findMatchingEntries(String host, Collection<? extends HostConfigEntry> entries) {
-        // TODO in Java-8 use Stream(s) + predicate
-        if (GenericUtils.isEmpty(host) || GenericUtils.isEmpty(entries)) {
-            return Collections.emptyList();
-        }
-
-        List<HostConfigEntry> matches = null;
-        for (HostConfigEntry entry : entries) {
-            if (!entry.isHostMatch(host, 0 /* any port */)) {
-                continue; // debug breakpoint
-            }
-
-            if (matches == null) {
-                matches = new ArrayList<>(entries.size()); // in case ALL of them match
-            }
-
-            matches.add(entry);
-        }
-
-        if (matches == null) {
-            return Collections.emptyList();
-        } else {
-            return matches;
-        }
-    }
-
     public static boolean isHostMatch(String host, int port, Collection<HostPatternValue> patterns) {
         if (GenericUtils.isEmpty(patterns)) {
             return false;
@@ -208,8 +157,8 @@ public abstract class HostPatternsHolder {
     }
 
     /**
-     * @param  port1 1st port value - if non-positive the assumed to be {@link SshConstants#DEFAULT_PORT DEFAULT_PORT}
-     * @param  port2 2nd port value - if non-positive the assumed to be {@link SshConstants#DEFAULT_PORT DEFAULT_PORT}
+     * @param  port1 1st port value - if non-positive then assumed to be {@link SshConstants#DEFAULT_PORT DEFAULT_PORT}
+     * @param  port2 2nd port value - if non-positive then assumed to be {@link SshConstants#DEFAULT_PORT DEFAULT_PORT}
      * @return       {@code true} if ports are effectively equal
      */
     public static boolean isPortMatch(int port1, int port2) {

--- a/sshd-common/src/test/java/org/apache/sshd/client/config/hosts/ConfigFileHostEntryResolverTest.java
+++ b/sshd-common/src/test/java/org/apache/sshd/client/config/hosts/ConfigFileHostEntryResolverTest.java
@@ -72,29 +72,29 @@ public class ConfigFileHostEntryResolverTest extends JUnitTestSupport {
         testConfigFileReload("Wildcard", path, reloadCount,
                 Arrays.asList(
                         new HostConfigEntry(
-                                HostPatternsHolder.ALL_HOSTS_PATTERN,
-                                getClass().getSimpleName(),
-                                1234,
-                                getClass().getSimpleName()),
-                        new HostConfigEntry(
                                 expected.getHost() + Character.toString(HostPatternsHolder.WILDCARD_PATTERN),
                                 expected.getHost(),
                                 expected.getPort(),
-                                expected.getUsername())),
-                resolver, expected, expected);
-        testConfigFileReload("Specific", path, reloadCount,
-                Arrays.asList(
+                                expected.getUsername()),
                         new HostConfigEntry(
                                 HostPatternsHolder.ALL_HOSTS_PATTERN,
                                 getClass().getSimpleName(),
                                 1234,
-                                getClass().getSimpleName()),
+                                getClass().getSimpleName())),
+                resolver, expected, expected);
+        testConfigFileReload("Specific", path, reloadCount,
+                Arrays.asList(
                         new HostConfigEntry(
                                 getClass().getSimpleName() + Character.toString(HostPatternsHolder.WILDCARD_PATTERN),
                                 getClass().getSimpleName(),
                                 1234,
                                 getClass().getSimpleName()),
-                        expected),
+                        expected,
+                        new HostConfigEntry(
+                                HostPatternsHolder.ALL_HOSTS_PATTERN,
+                                getClass().getSimpleName(),
+                                1234,
+                                getClass().getSimpleName())),
                 resolver, expected, expected);
     }
 

--- a/sshd-core/src/test/java/org/apache/sshd/client/config/hosts/HostConfigEntryResolverTest.java
+++ b/sshd-core/src/test/java/org/apache/sshd/client/config/hosts/HostConfigEntryResolverTest.java
@@ -121,9 +121,9 @@ public class HostConfigEntryResolverTest extends BaseTestSupport {
         client.start();
 
         try (ClientSession session = client.connect(
-                negativeEntry.getUsername(),
+                null,
                 negativeEntry.getHostName(),
-                negativeEntry.getPort()).verify(CONNECT_TIMEOUT).getSession()) {
+                0).verify(CONNECT_TIMEOUT).getSession()) {
             session.addPasswordIdentity(getCurrentTestName());
             session.auth().verify(AUTH_TIMEOUT);
             assertEffectiveRemoteAddress(session, positiveEntry);


### PR DESCRIPTION
This change tries to bring config file processing more in line with the semantics indicated in the ssh man page. The most significant changes are that each attribute is drawn from the first matching entry in file order. There are also defaults supplied that are in line with the behavior of the ssh command line tool. In particular, the local user name is used for any host where none is specified, and port 22 is used whenever port is not specified. Even though one might imagine these obvious defaults were in effect before, there were paths through the code where they did not get set.

This change modifies some of the test cases:
testResolvePort, testResolveUsername -- Removed because these functions no longer exist.
testFindBestMatch -- Removed because that's not how config files are supposed to be handled.
testConfigFileReload -- Original test was based on the incorrect notion that a latter entry in config could override an earlier one. I moved the catch-all entry to the end to approximate the correct semantics. Note that there may be relevant test cases where the global attributes are involved, but this particular test doesn't fit in that category.
testReadGlobalHostsConfigEntries -- Original test was written with the assumption that entries are collated at the time they are read from file. In the new approach, they are collated on demand. (This is necessary because only when a host query is made do we know which entries apply.) The test is rewritten to verify that entries have only the attributes specified in the file. The new version of the test is somewhat pointless, but it seemed better than deleting altogether.

Note that testNegatedHostEntriesResolution is failing on my system. Debug tracing shows that it is doing the right thing (not using the negated entry). I believe the problem is due to corporate firewall configuration.

The HostConfigEntry class could be further improved by storing everything in the properties collection and funneling all the accessors to it, rather than having separate class members for special properties like port and username. This may be the subject of a future PR.

Fixes #281.