### PR TITLE
Remove unwanted reverse lookup

### DIFF
--- a/sshd-common/src/main/java/org/apache/sshd/common/util/net/SshdSocketAddress.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/util/net/SshdSocketAddress.java
@@ -399,7 +399,7 @@ public class SshdSocketAddress extends SocketAddress {
             return (SshdSocketAddress) addr;
         } else if (addr instanceof InetSocketAddress) {
             InetSocketAddress isockAddress = (InetSocketAddress) addr;
-            return new SshdSocketAddress(isockAddress.getHostName(), isockAddress.getPort());
+            return new SshdSocketAddress(isockAddress.getHostString(), isockAddress.getPort());
         } else {
             throw new UnsupportedOperationException("Cannot convert " + addr.getClass().getSimpleName()
                                                     + "=" + addr + " to " + SshdSocketAddress.class.getSimpleName());


### PR DESCRIPTION
If you currently connect to an host ip string, the known_hosts lookup is done with the reverse dns entry.
`getHostString` keeps the IP.