### PR TITLE
READ (only) default mode in SftpFileSystemProvider.newFileChannel()

### DIFF
--- a/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/fs/SftpFileSystemProvider.java
+++ b/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/fs/SftpFileSystemProvider.java
@@ -506,7 +506,7 @@ public class SftpFileSystemProvider extends FileSystemProvider {
             throws IOException {
         Collection<OpenMode> modes = OpenMode.fromOpenOptions(options);
         if (modes.isEmpty()) {
-            modes = EnumSet.of(OpenMode.Read, OpenMode.Write);
+            modes = EnumSet.of(OpenMode.Read);
         }
         // TODO: process file attributes
         SftpPath p = toSftpPath(path);

--- a/sshd-sftp/src/test/java/org/apache/sshd/sftp/client/fs/AbstractSftpFilesSystemSupport.java
+++ b/sshd-sftp/src/test/java/org/apache/sshd/sftp/client/fs/AbstractSftpFilesSystemSupport.java
@@ -33,6 +33,7 @@ import java.nio.file.LinkOption;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.AclEntry;
 import java.nio.file.attribute.AclFileAttributeView;
 import java.util.Collections;
@@ -189,11 +190,11 @@ public abstract class AbstractSftpFilesSystemSupport extends AbstractSftpClientT
     }
 
     protected static void testFileChannelLock(Path file) throws IOException {
-        try (FileChannel channel = FileChannel.open(file)) {
+        try (FileChannel channel = FileChannel.open(file, StandardOpenOption.WRITE)) {
             try (FileLock lock = channel.lock()) {
                 outputDebugMessage("Lock %s: %s", file, lock);
 
-                try (FileChannel channel2 = FileChannel.open(file)) {
+                try (FileChannel channel2 = FileChannel.open(file, StandardOpenOption.WRITE)) {
                     try (FileLock lock2 = channel2.lock()) {
                         fail("Unexpected success in re-locking " + file + ": " + lock2);
                     } catch (OverlappingFileLockException e) {


### PR DESCRIPTION
According to [upstream javadoc](https://docs.oracle.com/javase/8/docs/api/java/nio/channels/FileChannel.html#open-java.nio.file.Path-java.util.Set-java.nio.file.attribute.FileAttribute...-), the default mode is READ (only) when there is no mode specified:

> The [READ](https://docs.oracle.com/javase/8/docs/api/java/nio/file/StandardOpenOption.html#READ) and [WRITE](https://docs.oracle.com/javase/8/docs/api/java/nio/file/StandardOpenOption.html#WRITE) options determine if the file should be opened for reading and/or writing. If neither option (or the [APPEND](https://docs.oracle.com/javase/8/docs/api/java/nio/file/StandardOpenOption.html#APPEND) option) is contained in the array then the file is opened for reading

SftpFileSystemProvider used `READ, WRITE` which leads to `Permission denied` errors when trying to access read-only files (see [this Stackoverflow thread](https://stackoverflow.com/questions/49235417/sshd-get-content-of-readonly-file)).

This MR suggests to use a standard-complaint setting; however, this might cause regressions...