### PR TITLE
[SSHD-1327] ChannelAsyncOutputStream: remove write future when done

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,3 +24,6 @@
 
 # Planned for next version
 
+## Bug Fixes
+
+* [SSHD-1327](https://issues.apache.org/jira/browse/SSHD-1327) `ChannelAsyncOutputStream`: remove write future when done.


### PR DESCRIPTION
We keep the top-level future of the last initiated write to be able to delay closing the stream until it has been written. But once the write _has_ been done, there is no need to keep the future still referenced.

Use a listener on the future to set lastWrite to null if it still references the same future.