### PR TITLE
GH-370: Also compare file keys in ModifiableFileWatcher

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,4 +26,7 @@
 
 ## Bug Fixes
 
+* [GH-370](https://github.com/apache/mina-sshd/issues/370) Also compare file keys in `ModifiableFileWatcher`.
+
+
 * [SSHD-1327](https://issues.apache.org/jira/browse/SSHD-1327) `ChannelAsyncOutputStream`: remove write future when done.

--- a/sshd-common/src/main/java/org/apache/sshd/common/util/io/FileSnapshot.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/util/io/FileSnapshot.java
@@ -1,0 +1,198 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sshd.common.util.io;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.FileTime;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Objects;
+
+/**
+ * A snapshot of file metadata that can be used to determine whether a file has been modified since the last time it was
+ * read. Intended usage:
+ *
+ * <pre>
+ * FileSnapshot fileSnapshot = FileSnapshot.save(path);
+ * byte[] content = Files.readAllBytes(path);
+ * ...
+ * FileSnapshot newSnapshot = oldSnapshot.reload(path);
+ * if (newSnapshot == fileSnapshot) {
+ *   // File was not modified
+ * } else {
+ *   // File may have been modified
+ *   fileSnapshot = newSnapshot;
+ *   content = Files.readAllBytes(path);
+ * }
+ * </pre>
+ *
+ * <p>
+ * File modifications that occur quicker than the resolution of the system's "last modified" timestamp of a file cannot
+ * be detected reliably. This implementation assumes a worst-case filesystem timestamp resolution of 2 seconds (as it
+ * exists on FAT file systems). A snapshot taken within 2 seconds since the last modified time is considered "racily
+ * clean" only: the file will be considered potentially modified even if the metadata matches.
+ * </p>
+ *
+ * @author <a href="mailto:dev@mina.apache.org">Apache MINA SSHD Project</a>
+ */
+public class FileSnapshot {
+
+    /**
+     * A value indicating an unknown file size.
+     */
+    public static final long UNKNOWN_SIZE = -1L;
+
+    /**
+     * A {@link FileSnapshot} describing a non-existing file.
+     */
+    public static final FileSnapshot NO_FILE = new FileSnapshot(Instant.now(), null, UNKNOWN_SIZE, null);
+
+    // FAT has a truly crude timestamp resolution.
+    private static final Duration WORST_CASE_TIMESTAMP_RESOLUTION = Duration.ofMillis(2000);
+
+    // File metadata
+    private final FileTime lastModified;
+    private final long size;
+    private final Object fileKey;
+
+    // The time the snapshot was taken; needed to determine whether it might be "racily clean"
+    private final Instant snapTime;
+
+    /**
+     * Creates a new {@link FileSnapshot} instance.
+     *
+     * @param  snapTime     the {@link Instant} the snapshot was taken
+     * @param  lastModified the "last modified" {@link FileTime}
+     * @param  size         the file size
+     * @param  fileKey      the file key
+     * @return              the {@link FileSnapshot}, never {@code null}
+     */
+    protected FileSnapshot(Instant snapTime, FileTime lastModified, long size, Object fileKey) {
+        this.snapTime = Objects.requireNonNull(snapTime);
+        this.lastModified = lastModified;
+        this.size = size;
+        this.fileKey = fileKey;
+    }
+
+    /**
+     * Retrieves the "last modified" time as recorded in this {@link FileSnapshot}.
+     *
+     * @return the {@link FileTime}, may be {@code null}
+     */
+    protected FileTime getLastModified() {
+        return lastModified;
+    }
+
+    /**
+     * Retrieves the file size as recorded in this {@link FileSnapshot}.
+     *
+     * @return the size, {@link #UNKNOWN_SIZE} for a snapshot of a non-existing file
+     */
+    protected long getSize() {
+        return size;
+    }
+
+    /**
+     * Retrieves the file key as recorded in this {@link FileSnapshot}.
+     *
+     * @return the file key, may be {@code null}
+     */
+    protected Object getFileKey() {
+        return fileKey;
+    }
+
+    /**
+     * Retrieves the time this {@link FileSnapshot} was taken.
+     *
+     * @return the {@link Instant} the snapshot was taken, never {@code null}
+     */
+    protected Instant getTime() {
+        return snapTime;
+    }
+
+    /**
+     * Creates a new {@link FileSnapshot} for the given path.
+     *
+     * @param  file    to take the snapshot of
+     * @param  options {@link LinkOption}s to use
+     * @return         the {@link FileSnapshot}, never {@code null}
+     */
+    public static FileSnapshot save(Path file, LinkOption... options) throws IOException {
+        BasicFileAttributes attributes = null;
+        Instant now = Instant.now();
+        try {
+            attributes = Files.readAttributes(file, BasicFileAttributes.class, options);
+        } catch (NoSuchFileException e) {
+            return NO_FILE;
+        }
+        if (attributes == null) {
+            return NO_FILE;
+        }
+        return new FileSnapshot(now, attributes.lastModifiedTime(), attributes.size(), attributes.fileKey());
+    }
+
+    /**
+     * Reload the {@link FileSnapshot} for the given file.
+     *
+     * @param  file    to take the snapshot of
+     * @param  options {@link LinkOption}s to use
+     * @return         a {@link FileSnapshot}, never {@code null}; if {@code == this}, the file may be assumed
+     *                 unmodified
+     */
+    public FileSnapshot reload(Path file, LinkOption... options) throws IOException {
+        FileSnapshot newSnapshot = save(file, options);
+        if (newSnapshot.mayBeRacilyClean()) {
+            return newSnapshot;
+        }
+        return same(newSnapshot) && !mayBeRacilyClean() ? this : newSnapshot;
+    }
+
+    /**
+     * Determines whether this {@link FileSnapshot} was taken within the file timestamp resolution of the file system
+     * after the last modified time of the file.
+     *
+     * @return {@code true} if so, {@code false} otherwise
+     */
+    protected boolean mayBeRacilyClean() {
+        FileTime fTime = getLastModified();
+        return fTime != null && Duration.between(fTime.toInstant(), getTime()).compareTo(WORST_CASE_TIMESTAMP_RESOLUTION) <= 0;
+    }
+
+    /**
+     * Compares the snapshots' file metadata.
+     *
+     * @param  other {@link FileSnapshot} to compare to (should be for the same {@link Path})
+     * @return       {@code true} if the two snapshots have the same file metadata, {@code false} otherwise
+     */
+    public boolean same(FileSnapshot other) {
+        if (this == other) {
+            return true;
+        }
+        if (other == null) {
+            return false;
+        }
+        return Objects.equals(getFileKey(), other.getFileKey()) && Objects.equals(getLastModified(), other.getLastModified())
+                && getSize() == other.getSize();
+    }
+}

--- a/sshd-common/src/test/java/org/apache/sshd/client/config/hosts/ConfigFileHostEntryResolverTest.java
+++ b/sshd-common/src/test/java/org/apache/sshd/client/config/hosts/ConfigFileHostEntryResolverTest.java
@@ -22,6 +22,8 @@ package org.apache.sshd.client.config.hosts;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -111,6 +113,7 @@ public class ConfigFileHostEntryResolverTest extends JUnitTestSupport {
             }
         } else {
             HostConfigEntry.writeHostConfigEntries(path, entries, IoUtils.EMPTY_OPEN_OPTIONS);
+            Files.setLastModifiedTime(path, FileTime.from(Instant.now().minusSeconds(4)));
         }
 
         reloadCount.set(0);

--- a/sshd-common/src/test/java/org/apache/sshd/common/util/io/ModifiableFileWatcherTest.java
+++ b/sshd-common/src/test/java/org/apache/sshd/common/util/io/ModifiableFileWatcherTest.java
@@ -24,7 +24,10 @@ import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
 import java.nio.file.attribute.PosixFilePermission;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.Collection;
 import java.util.Date;
 import java.util.Map;
@@ -35,8 +38,10 @@ import org.apache.sshd.util.test.JUnitTestSupport;
 import org.apache.sshd.util.test.NoIoTestCase;
 import org.junit.Assume;
 import org.junit.FixMethodOrder;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.rules.TemporaryFolder;
 import org.junit.runners.MethodSorters;
 
 /**
@@ -45,6 +50,10 @@ import org.junit.runners.MethodSorters;
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 @Category({ NoIoTestCase.class })
 public class ModifiableFileWatcherTest extends JUnitTestSupport {
+
+    @Rule
+    public TemporaryFolder tmp = new TemporaryFolder();
+
     public ModifiableFileWatcherTest() {
         super();
     }
@@ -87,5 +96,129 @@ public class ModifiableFileWatcherTest extends JUnitTestSupport {
             assertNull("Unexpected Windows violation for file " + file + " permissions=" + perms,
                     ModifiableFileWatcher.validateStrictConfigFilePermissions(file));
         }
+    }
+
+    @Test
+    public void testSymlinkChain() throws Exception {
+        Assume.assumeFalse("Symlink test disabled on Windows", OsUtils.isWin32());
+        Path adam = tmp.getRoot().toPath().resolve("adam");
+        Path jeff = adam.getParent().resolve("jeff");
+        Path link = adam.getParent().resolve(adam.getFileName() + ".link");
+        Path link2 = adam.getParent().resolve("topLink");
+        Files.write(adam, "adam".getBytes(StandardCharsets.US_ASCII));
+        Files.write(jeff, "jeff".getBytes(StandardCharsets.US_ASCII));
+        // Change the last modified time to avoid problems with "racily clean" timestamps
+        Files.setLastModifiedTime(adam, FileTime.from(Instant.now().minusSeconds(4)));
+        Files.setLastModifiedTime(jeff, Files.getLastModifiedTime(adam));
+        Files.createSymbolicLink(link, adam);
+        Files.createSymbolicLink(link2, link);
+        ModifiableFileWatcher watcher = new ModifiableFileWatcher(link2);
+        assertTrue("Should need to reload", watcher.checkReloadRequired());
+        String data = new String(Files.readAllBytes(link2), StandardCharsets.US_ASCII);
+        assertEquals("adam", data);
+        watcher.updateReloadAttributes();
+        assertFalse("Should not need to reload", watcher.checkReloadRequired());
+        Files.delete(link);
+        Files.createSymbolicLink(link, jeff);
+        assertTrue("Should need to reload", watcher.checkReloadRequired());
+        data = new String(Files.readAllBytes(link2), StandardCharsets.US_ASCII);
+        assertEquals("jeff", data);
+    }
+
+    @Test
+    public void testFileModified() throws Exception {
+        Path adam = tmp.getRoot().toPath().resolve("adam");
+        Files.write(adam, "adam".getBytes(StandardCharsets.US_ASCII));
+        Files.setLastModifiedTime(adam, FileTime.from(Instant.now().minusSeconds(6)));
+        ModifiableFileWatcher watcher = new ModifiableFileWatcher(adam);
+        assertTrue("Should need to reload", watcher.checkReloadRequired());
+        String data = new String(Files.readAllBytes(adam), StandardCharsets.US_ASCII);
+        assertEquals("adam", data);
+        assertFalse("Should not need to reload", watcher.checkReloadRequired());
+        watcher.updateReloadAttributes();
+        assertFalse("Should not need to reload", watcher.checkReloadRequired());
+        Files.write(adam, "adam".getBytes(StandardCharsets.US_ASCII));
+        Files.setLastModifiedTime(adam, FileTime.from(Instant.now().minusSeconds(4)));
+        assertTrue("Should need to reload", watcher.checkReloadRequired());
+        watcher.updateReloadAttributes();
+        assertFalse("Should not need to reload", watcher.checkReloadRequired());
+    }
+
+    @Test
+    public void testFileDeleted() throws Exception {
+        Path adam = tmp.getRoot().toPath().resolve("adam");
+        Files.write(adam, "adam".getBytes(StandardCharsets.US_ASCII));
+        Files.setLastModifiedTime(adam, FileTime.from(Instant.now().minusSeconds(4)));
+        ModifiableFileWatcher watcher = new ModifiableFileWatcher(adam);
+        assertTrue("Should need to reload", watcher.checkReloadRequired());
+        String data = new String(Files.readAllBytes(adam), StandardCharsets.US_ASCII);
+        assertEquals("adam", data);
+        assertFalse("Should not need to reload", watcher.checkReloadRequired());
+        watcher.updateReloadAttributes();
+        assertFalse("Should not need to reload", watcher.checkReloadRequired());
+        Files.delete(adam);
+        assertTrue("Should need to reload", watcher.checkReloadRequired());
+        watcher.updateReloadAttributes();
+        assertFalse("Should not need to reload", watcher.checkReloadRequired());
+    }
+
+    @Test
+    public void testFileCreated() throws Exception {
+        Path adam = tmp.getRoot().toPath().resolve("adam");
+        ModifiableFileWatcher watcher = new ModifiableFileWatcher(adam);
+        assertTrue("Should need to reload", watcher.checkReloadRequired());
+        watcher.updateReloadAttributes();
+        Files.write(adam, "adam".getBytes(StandardCharsets.US_ASCII));
+        Files.setLastModifiedTime(adam, FileTime.from(Instant.now().minusSeconds(4)));
+        assertTrue("Should need to reload", watcher.checkReloadRequired());
+        String data = new String(Files.readAllBytes(adam), StandardCharsets.US_ASCII);
+        assertEquals("adam", data);
+        assertFalse("Should not need to reload", watcher.checkReloadRequired());
+        watcher.updateReloadAttributes();
+        assertFalse("Should not need to reload", watcher.checkReloadRequired());
+    }
+
+    @Test
+    public void testLoadDirectly() throws Exception {
+        Path adam = tmp.getRoot().toPath().resolve("adam");
+        Files.write(adam, "adam".getBytes(StandardCharsets.US_ASCII));
+        Files.setLastModifiedTime(adam, FileTime.from(Instant.now().minusSeconds(6)));
+        ModifiableFileWatcher watcher = new ModifiableFileWatcher(adam);
+        String data = new String(Files.readAllBytes(adam), StandardCharsets.US_ASCII);
+        assertEquals("adam", data);
+        // No call to checkReloadRequired() before.
+        watcher.updateReloadAttributes();
+        assertFalse("Should not need to reload", watcher.checkReloadRequired());
+        Files.write(adam, "adam".getBytes(StandardCharsets.US_ASCII));
+        Files.setLastModifiedTime(adam, FileTime.from(Instant.now().minusSeconds(4)));
+        assertTrue("Should need to reload", watcher.checkReloadRequired());
+    }
+
+    @Test
+    public void testRacyFile() throws Exception {
+        Path adam = tmp.getRoot().toPath().resolve("adam");
+        Files.write(adam, "adam".getBytes(StandardCharsets.US_ASCII));
+        Files.setLastModifiedTime(adam, FileTime.from(Instant.now()));
+        FileTime timestamp = Files.getLastModifiedTime(adam);
+        ModifiableFileWatcher watcher = new ModifiableFileWatcher(adam);
+        assertTrue("Should need to reload", watcher.checkReloadRequired());
+        String data = new String(Files.readAllBytes(adam), StandardCharsets.US_ASCII);
+        assertEquals("adam", data);
+        watcher.updateReloadAttributes();
+        Instant start = Instant.now();
+        Instant stop = null;
+        int n = 0;
+        while (Duration.between(start, Instant.now()).compareTo(Duration.ofSeconds(10)) <= 0) {
+            n++;
+            if (watcher.checkReloadRequired()) {
+                watcher.updateReloadAttributes();
+            } else {
+                stop = Instant.now();
+                break;
+            }
+        }
+        assertNotNull("Expected non-racy clean", stop);
+        assertTrue("Should have been racy initially", n > 1);
+        assertTrue("Non-racy too early", Duration.between(timestamp.toInstant(), stop).compareTo(Duration.ofSeconds(2)) >= 0);
     }
 }

--- a/sshd-core/src/test/java/org/apache/sshd/server/config/keys/AuthorizedKeysAuthenticatorTest.java
+++ b/sshd-core/src/test/java/org/apache/sshd/server/config/keys/AuthorizedKeysAuthenticatorTest.java
@@ -24,8 +24,10 @@ import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
 import java.security.GeneralSecurityException;
 import java.security.PublicKey;
+import java.time.Instant;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -85,6 +87,7 @@ public class AuthorizedKeysAuthenticatorTest extends AuthorizedKeysTestSupport {
                     w.append(l).append(IoUtils.EOL);
                 }
             }
+            Files.setLastModifiedTime(file, FileTime.from(Instant.now().minusSeconds(4)));
 
             List<AuthorizedKeyEntry> entries = AuthorizedKeyEntry.readAuthorizedKeys(file);
             assertEquals("Mismatched number of loaded entries", keyLines.size(), entries.size());


### PR DESCRIPTION
Additionally, handle the case of files being modified very quickly, such that the last modified timestamp doesn't change, even though the file was modified. If the modification did not change the file size, such metadata is "racily clean", meaning it indicates the file had not been modified when in fact it was.

This can occur because of the finite resolution of file timestamps. If the file timestamp has a granularity of 2 seconds (FAT), two file modifications within these two seconds that don't change the file size cannot be recognized.

Hence any file timestamp from the past 2 seconds (measured from the time it was read) is suspect, and the file must be considered potentially modified, and must be re-loaded.

This is not a problem unless one frequently writes files and then reads them again within two seconds. (Or if one reads the same file multiple times within two seconds.) In such cases, care should be taken to determine the actual resolution of file timestamps, which often is much better. But for the use cases in SSH the worst-case assumption of two seconds should be fine.

Fixes: #370