### PR TITLE
[SSHD-1310] SftpFileSystem: do not close user sessions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,4 +29,5 @@
 * [GH-370](https://github.com/apache/mina-sshd/issues/370) Also compare file keys in `ModifiableFileWatcher`.
 
 
+* [SSHD-1310](https://issues.apache.org/jira/browse/SSHD-1327) `SftpFileSystem`: do not close user session.
 * [SSHD-1327](https://issues.apache.org/jira/browse/SSHD-1327) `ChannelAsyncOutputStream`: remove write future when done.

--- a/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/fs/SftpFileSystemProvider.java
+++ b/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/fs/SftpFileSystemProvider.java
@@ -275,6 +275,8 @@ public class SftpFileSystemProvider extends FileSystemProvider {
 
                 initializer.authenticateClientSession(this, context, session);
 
+                session.setAttribute(SftpFileSystem.OWNED_SESSION, Boolean.TRUE);
+
                 fileSystem = initializer.createSftpFileSystem(
                         this, context, session, selector, errorHandler);
                 fileSystems.put(id, fileSystem);


### PR DESCRIPTION
A SftpFileSystem can be obtained in two ways:

1. Via FileSystems.newFileSystem()
2. Via SftpClientFactory.instance().createSftpFileSystem(ClientSession)

In the first case, the SftpFileSystemProvider automatically creates a ClientSession, and that session must be closed when the file system closes.

In the second case, user code already has a ClientSession and wants to run an SftpFileSystem within. In this case, the session _must not_ be closed when the file system closes.

Add a session attribute that can be set on a ClientSession to tell the SftpFileSystem whether it owns the ClientSession. The SftpFileSystem will close only owned sessions.

Also add a SessionListener to ensure the file system is closed when the session closes.

Bug: https://issues.apache.org/jira/browse/SSHD-1310