### PR TITLE
GH-371: Re-implement the channel pool of an SftpFileSystem

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,7 +27,27 @@
 ## Bug Fixes
 
 * [GH-370](https://github.com/apache/mina-sshd/issues/370) Also compare file keys in `ModifiableFileWatcher`.
+* [GH-371](https://github.com/apache/mina-sshd/issues/371) Fix channel pool in `SftpFileSystem`.
 
 
 * [SSHD-1310](https://issues.apache.org/jira/browse/SSHD-1310) `SftpFileSystem`: do not close user session.
 * [SSHD-1327](https://issues.apache.org/jira/browse/SSHD-1327) `ChannelAsyncOutputStream`: remove write future when done.
+
+## New Features
+
+* [GH-356](https://github.com/apache/mina-sshd/issues/356) Publish snapshot maven artifacts to the [Apache Snapshots](https://repository.apache.org/content/repositories/snapshots) maven repository.
+
+
+## Major Code Re-factoring
+
+As part of the fix for [GH-371](https://github.com/apache/mina-sshd/issues/371)
+the channel pool in `SftpFileSystem` was rewritten completely. Previous code also
+used `ThreadLocal`s to store `SftpClient`s, which could cause memory leaks.
+
+These `ThreadLocal`s have been removed, and the channel pool has been rewritten
+to function similar to a Java `ThreadPool`: the pool has a maximum size; it has
+an expiration duration after which an idle channel is removed and closed, and
+it has a "core size" of channels to keep even if they are idle. If a channel is
+closed for any reason it is evicted from the pool.
+
+Properties to configure these pool parameters have been added to `SftpModuleProperties`.

--- a/docs/sftp.md
+++ b/docs/sftp.md
@@ -307,6 +307,8 @@ does not allow colon (`:`) in either one in order to avoid parsing confusion. Se
 >> deprecated ... Applications may choose to ignore or reject such
 >> data when it is received as part of a reference...
 
+See also the technical notes on the [SftpFileSystem](./technical/sft_filesystem.md).
+
 #### Configuring the `SftpFileSystemProvider`
 
 When "mounting" a new file system one can provide extra configuration parameters using either the

--- a/docs/technical/sftp_filesystem.md
+++ b/docs/technical/sftp_filesystem.md
@@ -1,0 +1,124 @@
+# The `SftpFileSystem`
+
+Class `SftpFileSystem` is an implementation of `java.nio.file.FileSystem` and
+lets client code treat an SFTP server like any other file system. It is a
+*remote* file system, though, and that has some effects that clients have
+to aware of. Because operations are *remote* operations involving network
+requests and answers, the performance characteristics are different than
+most other file systems.
+
+# Creating an `SftpFileSystem`
+
+An `SftpFileSystem` needs an SSH session to be able to talk to the SFTP server.
+
+There are two ways to create an `SftpFileSystem`:
+
+1. If you already have an SSH `ClientSession`, you can create the file system
+   off that session using `SftpClientFactory.instance().createSftpFileSystem()`.
+   The file system remains valid until it is closed, or until the session is
+   closed. When the file system is closed, the session will *not* be closed.
+   
+2. You can create an `SftpFileSystem` with a `sftp://` URI using the standard
+   Java factory `java.nio.file.FileSystems.newFileSystem()`. This will automatically
+   create an `SshClient` with default settings, and the file system will open
+   an SSH session itself. This session has heartbeats enabled to keep it open
+   for as long as the file system is open. The file system remains valid until
+   closed, at which point it will close the session it had created.
+
+In either case, the file system will be closed if the session closes.
+
+# SSH Resource Management
+
+Most operations on an `SftpFileSystem`, or on streams returned, produce SFTP
+requests over the network, and wait for a reply to be received. This works
+internally by using `SftpClient` to talk to the SFTP server. An `SftpClient`
+is the client-side implementation of the SFTP protocol over an SSH channel
+(a `ChannelSession`).
+
+The SSH channel and the `SftpClient` are tightly coupled: the channel is
+opened when the `SftpClient`is initialized, and the channel is closed when
+the `SftpClient` is closed, and when the channel closes, so is the `SftpClient`.
+
+For `SftpFileSystem` it would be rather inefficient to use a new `SftpClient`
+for each new operation. That would create a new channel every time, and tear
+it down after the operation. But channels have a setup cost, and the SFTP
+protocol also has to initialized, both of which involve exchanging messages
+over the network. This is not efficient if one wants to perform multiple
+operations, such as transferring multiple files with `java.nio.file.Files.copy()`.
+
+## The Channel Pool
+
+The `SftpFileSystem` thus employs a *pool* of `SftpClient`s. This pool is
+initially empty. The first operation will create an `SftpClient`, initialize
+it, and then perform its operation. But then it will add the still open
+`SftpClient` to the pool for use by subsequent operations instead of closing
+it. The next operation can then simply grab this already initialized `SftpClient`
+with its open channel and perform its operation.
+
+The pool is limited by a maximum size of `SftpModuleProperties.POOL_SIZE` (by
+default 8). The pool can grow to this size if there are that many threads that
+perform operations on the `SftpFileSystem` concurrently.
+
+`SftpClient`s in the pool need to be closed at some point. Consider an application
+that has a burst of file transfers and uses 8 threads to perform them. Afterwards,
+the pool will contain 8 `SftpClient`s: that's 8 open SSH channels, each with an SFTP
+subsystem at the server's end. If the application then does only little, like
+transferring a few files sequentially over the next few hours, until the next burst
+(which may never come), then we don't want to keep all 8 channels open and consuming
+resources not only in the client but also on the server side.
+
+(This assumes that the whole SSH session remains open for that long, which can be
+accomplished by using heartbeats on the session.)
+
+The `SftpFileSystem` handles this by expiring inactive clients from the pool. If a
+client has been in the pool for `SftpModuleProperties.POOL_LIFE_TIME` (default is 10
+seconds), it is removed from the pool and closed. (If it was in the pool for that
+time, this means it was idle for that time: no operation was performed on it.) If
+no operation on the `SftpFileSystem` occurs at all for this time, it's possible that
+the pool is emptied, and the next operation has to create and initialize a new
+`SftpClient`and channel.
+
+If an application doesn't want this, it can define `SftpModuleProperties.POOL_CORE_SIZE`,
+which must be smaller than `POOL_SIZE`. By default, it is zero. If greater than zero,
+that many `SftpClient`s are kept in the pool (and that many channels are kept open)
+even if they are idle.
+
+It should be noted that the SFTP server may also decide to close channels whenever
+it wants. This will close the channel and the `SftpClient`on the client side. If it
+happens while a client-side operation is ongoing, the operation will fail with an
+exception; it it happens on an idle `SftpClient` in the pool, the `SftpClient` is
+simply removed from the pool.
+
+If the whole SSH session is closed, the `SftpFileSystem` is closed. When a
+`SftpFileSystem` is closed, all `SftpClient`s in the pool are closed, and no new
+clients will be added to the pool.
+
+## Choosing the Pool Size
+
+If there are more then `POOL_SIZE` threads using the same `SftpFileSystem`, it is
+possible that all `POOL_SIZE` clients are already in use when a thread tries to
+do a file system operation. In this case, a new `SftpClient` is created, which
+will be closed after the operation. This is a sign of the `POOL_SIZE` being too 
+small for the application, or that the application is badly designed. Using too
+many threads for remote file operations is not a good idea in SFTP: all traffic
+in the end goes over a single network connection anyway. Using a limited number
+of threads may bring some speedup compared to strictly sequential operations
+because the handling of the data received is offloaded to these threads, while
+the next message can already be sent or received. But copying 1000 files using
+1000 threads and SSH channels is nonsense; it's far better to handle that many
+files in batches with a smaller number of threads (maybe 8).
+
+In any case, `SftpModuleProperties.POOL_SIZE` should be large enough to accommodate
+the number of threads the client application is going to use for operations on
+the `SftpFileSystem`. If there are more threads, performance may degrade.
+
+Versions of Apache MINA sshd <= 2.10.0 tried to mitigate this performance drop
+for such "extra" threads by keeping the `SftpClient` in a `ThreadLocal`, so that
+such "extra" threads could re-use the `SftpClient`. This mechanism has been *removed*
+because it sometimes caused memory leaks. The mechanism was also flawed because
+there were use cases where it just could not work correctly.
+
+Design your application such that is uses a small maximum number of threads that
+perform operations on a `SftpFileSystem`instance. Set `SftpModuleProperties.POOL_SIZE`
+such that it is >= the maximum number of threads that operate concurrently on the
+file system. The default pool size is 8.

--- a/sshd-sftp/src/main/java/org/apache/sshd/sftp/SftpModuleProperties.java
+++ b/sshd-sftp/src/main/java/org/apache/sshd/sftp/SftpModuleProperties.java
@@ -60,10 +60,37 @@ public final class SftpModuleProperties {
             = Property.duration("sftp-channel-open-timeout", Duration.ofSeconds(15L));
 
     /**
-     * See {@link org.apache.sshd.sftp.client.fs.SftpFileSystem}.
+     * The maximum size of the channel pool used by an {@link org.apache.sshd.sftp.client.fs.SftpFileSystem}; by default
+     * 8. The value must be &gt; zero.
+     *
+     * @see org.apache.sshd.sftp.client.fs.SftpFileSystem
      */
     public static final Property<Integer> POOL_SIZE
             = Property.integer("sftp-fs-pool-size", 8);
+
+    /**
+     * A timeout after which idle channels in the pool of an {@link org.apache.sshd.sftp.client.fs.SftpFileSystem} are
+     * removed from the pool and closed; by default 10 seconds. If set to zero, channels in the pool will not expire and
+     * will be closed only then the file system is closed, or if the server closes them.
+     * <p>
+     * The duration should not be shorter than 1 millisecond. If it is, 1 millisecond will be assumed.
+     * </p>
+     *
+     * @see org.apache.sshd.sftp.client.fs.SftpFileSystem
+     */
+    public static final Property<Duration> POOL_LIFE_TIME
+            = Property.duration("sftp-fs-pool-life-time", Duration.ofSeconds(10));
+
+    /**
+     * If &gt;= 0, that many channels may be kept open in the channel pool of an
+     * {@link org.apache.sshd.sftp.client.fs.SftpFileSystem} even if they are idle; by default 1. If &gt;=
+     * {@link #POOL_SIZE}, channels will not expire and will be closed only then the file system is closed, or if the
+     * server closes them.
+     *
+     * @see org.apache.sshd.sftp.client.fs.SftpFileSystem
+     */
+    public static final Property<Integer> POOL_CORE_SIZE
+            = Property.integer("sftp-fs-pool-core-size", 1);
 
     /**
      * See {@link org.apache.sshd.sftp.client.fs.SftpFileSystemProvider}.

--- a/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/fs/SftpDirectoryStream.java
+++ b/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/fs/SftpDirectoryStream.java
@@ -34,6 +34,7 @@ import org.apache.sshd.sftp.client.SftpClientHolder;
  */
 public class SftpDirectoryStream implements SftpClientHolder, DirectoryStream<Path> {
     protected SftpPathIterator pathIterator;
+    protected boolean pathIteratorConsumed;
 
     private final SftpPath path;
     private final Filter<? super Path> filter;
@@ -93,17 +94,19 @@ public class SftpDirectoryStream implements SftpClientHolder, DirectoryStream<Pa
         /*
          * According to documentation this method can be called only once
          */
-        if (pathIterator == null) {
+        if (pathIteratorConsumed) {
             throw new IllegalStateException("Iterator has already been consumed");
         }
 
-        Iterator<Path> iter = pathIterator;
-        pathIterator = null;
-        return iter;
+        pathIteratorConsumed = true;
+        return pathIterator;
     }
 
     @Override
     public void close() throws IOException {
+        if (pathIterator != null) {
+            pathIterator.close();
+        }
         sftp.close();
     }
 }

--- a/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/fs/SftpPathIterator.java
+++ b/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/fs/SftpPathIterator.java
@@ -19,6 +19,7 @@
 
 package org.apache.sshd.sftp.client.fs;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.nio.file.DirectoryIteratorException;
 import java.nio.file.DirectoryStream;
@@ -37,7 +38,7 @@ import org.apache.sshd.sftp.client.impl.SftpPathImpl;
  * @author <a href="mailto:dev@mina.apache.org">Apache MINA SSHD Project</a>
  */
 public class SftpPathIterator implements Iterator<Path> {
-    protected final Iterator<? extends SftpClient.DirEntry> it;
+    protected Iterator<? extends SftpClient.DirEntry> it;
     protected boolean dotIgnored;
     protected boolean dotdotIgnored;
     protected SftpPath curEntry;
@@ -79,6 +80,14 @@ public class SftpPathIterator implements Iterator<Path> {
      */
     public final Filter<? super Path> getFilter() {
         return filter;
+    }
+
+    public final void close() throws IOException {
+        Iterator<? extends SftpClient.DirEntry> curr = it;
+        it = null;
+        if (curr instanceof Closeable) {
+            ((Closeable) curr).close();
+        }
     }
 
     @Override

--- a/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/impl/SftpIterableDirEntry.java
+++ b/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/impl/SftpIterableDirEntry.java
@@ -19,6 +19,7 @@
 package org.apache.sshd.sftp.client.impl;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.Objects;
 
 import org.apache.sshd.common.util.ValidateUtils;
@@ -63,7 +64,8 @@ public class SftpIterableDirEntry implements SftpClientHolder, Iterable<DirEntry
         try {
             return new SftpDirEntryIterator(getClient(), getPath());
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new UncheckedIOException(e);
         }
     }
+
 }

--- a/sshd-sftp/src/test/java/org/apache/sshd/sftp/server/SftpServerTest.java
+++ b/sshd-sftp/src/test/java/org/apache/sshd/sftp/server/SftpServerTest.java
@@ -1,0 +1,337 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sshd.sftp.server;
+
+import java.io.BufferedInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.sshd.client.SshClient;
+import org.apache.sshd.client.session.ClientSession;
+import org.apache.sshd.common.file.virtualfs.VirtualFileSystemFactory;
+import org.apache.sshd.common.util.io.IoUtils;
+import org.apache.sshd.server.SshServer;
+import org.apache.sshd.server.session.ServerSession;
+import org.apache.sshd.sftp.client.SftpClient;
+import org.apache.sshd.sftp.client.SftpClientFactory;
+import org.apache.sshd.sftp.client.fs.SftpFileSystem;
+import org.apache.sshd.sftp.client.fs.SftpPath;
+import org.apache.sshd.sftp.common.SftpConstants;
+import org.apache.sshd.util.test.BaseTestSupport;
+import org.apache.sshd.util.test.CommonTestSupportUtils;
+import org.apache.sshd.util.test.CoreTestSupportUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Multi-thread tests for {@link SftpFileSystem}.
+ *
+ * @author <a href="mailto:dev@mina.apache.org">Apache MINA SSHD Project</a>
+ */
+public class SftpServerTest extends BaseTestSupport {
+
+    private SshServer server;
+
+    private SshClient client;
+
+    private int numberOfSubsystems;
+
+    private CountDownLatch serverHasNoSftpSubsystem;
+
+    public SftpServerTest() {
+        super();
+    }
+
+    @Before
+    public void setup() throws Exception {
+        server = CoreTestSupportUtils.setupTestFullSupportServer(SftpServerTest.class);
+        serverHasNoSftpSubsystem = new CountDownLatch(1);
+        SftpSubsystemFactory factory = new SftpSubsystemFactory();
+        factory.addSftpEventListener(new SftpEventListener() {
+            @Override
+            public void initialized(ServerSession session, int version) throws IOException {
+                numberOfSubsystems++;
+            }
+
+            @Override
+            public void destroying(ServerSession session) throws IOException {
+                numberOfSubsystems--;
+                if (numberOfSubsystems == 0) {
+                    serverHasNoSftpSubsystem.countDown();
+                }
+            }
+
+        });
+        server.setSubsystemFactories(Collections.singletonList(factory));
+        Path targetPath = detectTargetFolder();
+        server.setFileSystemFactory(new VirtualFileSystemFactory(targetPath.getParent()));
+        server.start();
+
+        client = CoreTestSupportUtils.setupTestClient(SftpServerTest.class);
+        client.start();
+    }
+
+    @After
+    public void shutdown() throws Exception {
+        if (client != null) {
+            // client.stop();
+        }
+        if (server != null) {
+            server.stop(true);
+        }
+    }
+
+    private String download(Path remote) throws Exception {
+        String[] actual = { null };
+        Thread worker = new Thread(() -> {
+            try (ByteArrayOutputStream downloaded = new ByteArrayOutputStream()) {
+                try (InputStream input = new BufferedInputStream(Files.newInputStream(remote))) {
+                    IoUtils.copy(input, downloaded);
+                }
+                actual[0] = downloaded.toString(StandardCharsets.UTF_8.name());
+            } catch (IOException e) {
+                actual[0] = e.toString();
+            }
+        });
+        worker.start();
+        worker.join(TimeUnit.SECONDS.toMillis(3));
+        return actual[0];
+    }
+
+    @Test
+    public void testSequentialThreads() throws Exception {
+        Path targetPath = detectTargetFolder();
+        Path parentPath = targetPath.getParent();
+        Path lclSftp = CommonTestSupportUtils.resolve(targetPath, SftpConstants.SFTP_SUBSYSTEM_NAME, getClass().getSimpleName(),
+                getCurrentTestName());
+        Path testFile = assertHierarchyTargetFolderExists(lclSftp).resolve("file.txt");
+        Files.deleteIfExists(testFile);
+        String expected = getCurrentTestName();
+        Files.write(testFile, expected.getBytes(StandardCharsets.UTF_8));
+        String fileName = CommonTestSupportUtils.resolveRelativeRemotePath(parentPath, testFile);
+        try (ClientSession session = createAuthenticatedClientSession(client, server.getPort())) {
+            try (SftpFileSystem fs = SftpClientFactory.instance().createSftpFileSystem(session)) {
+                Path remote = fs.getPath(fileName);
+                assertTrue("Should be an SftpPath", remote instanceof SftpPath);
+                String actual = download(remote);
+                assertEquals("Mismatched content", expected, actual);
+                // And again
+                actual = download(remote);
+                assertEquals("Mismatched content", expected, actual);
+                // And again
+                actual = download(remote);
+                assertEquals("Mismatched content", expected, actual);
+                // Yes, we had three threads, but no concurrency at all. There should be only a single server-side
+                // SftpSubsystem.
+                assertEquals("Unexpected number of SftpSubsystems", 1, numberOfSubsystems);
+            }
+            assertTrue("Session should still be open", session.isOpen());
+            assertTrue("Server did not close SftpSubsystem", serverHasNoSftpSubsystem.await(3, TimeUnit.SECONDS));
+            assertEquals("SftpSubsystem count should be zero", 0, numberOfSubsystems);
+        }
+    }
+
+    @Test
+    public void testConcurrentThreads() throws Exception {
+        Path targetPath = detectTargetFolder();
+        Path parentPath = targetPath.getParent();
+        Path lclSftp = CommonTestSupportUtils.resolve(targetPath, SftpConstants.SFTP_SUBSYSTEM_NAME, getClass().getSimpleName(),
+                getCurrentTestName());
+        Path testFile = assertHierarchyTargetFolderExists(lclSftp).resolve("file.txt");
+        Files.deleteIfExists(testFile);
+        String expected = getCurrentTestName();
+        Files.write(testFile, expected.getBytes(StandardCharsets.UTF_8));
+        String fileName = CommonTestSupportUtils.resolveRelativeRemotePath(parentPath, testFile);
+        try (ClientSession session = createAuthenticatedClientSession(client, server.getPort())) {
+            try (SftpFileSystem fs = SftpClientFactory.instance().createSftpFileSystem(session)) {
+                Path remote = fs.getPath(fileName);
+                assertTrue("Should be an SftpPath", remote instanceof SftpPath);
+                String[] actual1 = { null };
+                CountDownLatch secondThreadIsReady = new CountDownLatch(1);
+                Thread worker1 = new Thread(() -> {
+                    try (ByteArrayOutputStream downloaded = new ByteArrayOutputStream()) {
+                        try (InputStream input = Files.newInputStream(remote)) {
+                            // This is of course a stupid way to copy something, but for this test we need a loop.
+                            for (boolean first = true;; first = false) {
+                                int b = input.read();
+                                if (first) {
+                                    secondThreadIsReady.await();
+                                }
+                                if (b < 0) {
+                                    break;
+                                }
+                                downloaded.write(b);
+                            }
+                        }
+                        actual1[0] = downloaded.toString(StandardCharsets.UTF_8.name());
+                    } catch (Exception e) {
+                        actual1[0] = e.toString();
+                    }
+                });
+                String[] actual2 = { null };
+                int[] numberOfChannels = { -1 };
+                Thread worker2 = new Thread(() -> {
+                    try (ByteArrayOutputStream downloaded = new ByteArrayOutputStream()) {
+                        try (InputStream input = Files.newInputStream(remote)) {
+                            // This is of course a stupid way to copy something, but for this test we need a loop.
+                            for (boolean first = true;; first = false) {
+                                int b = input.read();
+                                if (first) {
+                                    numberOfChannels[0] = numberOfSubsystems;
+                                    secondThreadIsReady.countDown();
+                                }
+                                if (b < 0) {
+                                    break;
+                                }
+                                downloaded.write(b);
+                            }
+                        }
+                        actual2[0] = downloaded.toString(StandardCharsets.UTF_8.name());
+                    } catch (Exception e) {
+                        actual2[0] = e.toString();
+                    }
+                });
+                worker1.start();
+                worker2.start();
+                worker1.join(TimeUnit.SECONDS.toMillis(3));
+                worker2.join(TimeUnit.SECONDS.toMillis(3));
+                assertEquals("Mismatched content", expected, actual1[0]);
+                assertEquals("Mismatched content", expected, actual2[0]);
+                assertEquals("Unexpected number of SftpSubsystems", 2, numberOfChannels[0]);
+            }
+            assertTrue("Session should still be open", session.isOpen());
+            assertTrue("Server did not close SftpSubsystem", serverHasNoSftpSubsystem.await(3, TimeUnit.SECONDS));
+            assertEquals("SftpSubsystem count", 0, numberOfSubsystems);
+        }
+    }
+
+    @Test
+    public void testHandOffStream() throws Exception {
+        // This test shows that it is not possible to correctly handle these ThreadLocals. There are cases where
+        // perfectly valid code creates the wrapper in one thread but closes it in another. In this case, closing the
+        // wrapper cannot remove the ThreadLocal: it'll try to do so on a different thread, where either there is no
+        // ThreadLocal, or (perhaps even worse) there might be one containing a different wrapper.
+        Path targetPath = detectTargetFolder();
+        Path parentPath = targetPath.getParent();
+        Path lclSftp = CommonTestSupportUtils.resolve(targetPath, SftpConstants.SFTP_SUBSYSTEM_NAME, getClass().getSimpleName(),
+                getCurrentTestName());
+        Path testFile = assertHierarchyTargetFolderExists(lclSftp).resolve("file.txt");
+        Files.deleteIfExists(testFile);
+        String expected = getCurrentTestName();
+        Files.write(testFile, expected.getBytes(StandardCharsets.UTF_8));
+        String fileName = CommonTestSupportUtils.resolveRelativeRemotePath(parentPath, testFile);
+        try (ClientSession session = createAuthenticatedClientSession(client, server.getPort())) {
+            try (SftpFileSystem fs = SftpClientFactory.instance().createSftpFileSystem(session)) {
+                Path remote = fs.getPath(fileName);
+                assertTrue("Should be an SftpPath", remote instanceof SftpPath);
+                InputStream is = Files.newInputStream(remote);
+                String[] actual = { null };
+                Thread worker = new Thread(() -> {
+                    try (ByteArrayOutputStream downloaded = new ByteArrayOutputStream()) {
+                        try (InputStream input = new BufferedInputStream(is)) {
+                            IoUtils.copy(input, downloaded);
+                        }
+                        actual[0] = downloaded.toString(StandardCharsets.UTF_8.name());
+                    } catch (IOException e) {
+                        actual[0] = e.toString();
+                    }
+                });
+                worker.start();
+                worker.join(TimeUnit.SECONDS.toMillis(3));
+                assertEquals("Mismatched content", expected, actual[0]);
+                // It's rather hard to test ThreadLocals because even just calling get() will create it the thread's
+                // ThreadLocalMap. I don't want to do reflection on JDK classes, so the best we can do is check that we
+                // have a null value. There's no way to check that the ThreadLocalMap has no entry at all for any
+                // wrapper.
+                //
+                // The test succeeds if either SftpFileSystem does not have the ThreadLocal, or its value is null.
+                // It should be null because is was closed. In reality it isn't with the SftpFileSystem implementation
+                // of Apache MINA 2.10.0, or even with the state at commit 18f4346a0.
+                try {
+                    Field f = fs.getClass().getDeclaredField("wrappers");
+                    f.setAccessible(true);
+                    ThreadLocal<?> item = (ThreadLocal<?>) f.get(fs);
+                    Object content = item.get();
+                    if (content instanceof SftpClient) {
+                        // We expect null. But if we have an SftpClient here, it should at least be closed because the
+                        // input stream 'is' was closed. Which is, of course, also bad. The ThreadLocal should never
+                        // contain a closed SftpClient. But such is the nature of this memory leak.
+                        assertFalse(((SftpClient) content).isOpen());
+                    }
+                    assertNull("ThreadLocal", content);
+                } catch (NoSuchFieldException e) {
+                    // It's OK
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testDirectoryStream() throws Exception {
+        // This test shows that it is not possible to correctly handle these ThreadLocals. There are cases where
+        // perfectly valid code creates the wrapper in one thread but closes it in another. In this case, closing the
+        // wrapper cannot remove the ThreadLocal: it'll try to do so on a different thread, where either there is no
+        // ThreadLocal, or (perhaps even worse) there might be one containing a different wrapper.
+        Path targetPath = detectTargetFolder();
+        Path parentPath = targetPath.getParent();
+        Path lclSftp = CommonTestSupportUtils.resolve(targetPath, SftpConstants.SFTP_SUBSYSTEM_NAME, getClass().getSimpleName(),
+                getCurrentTestName());
+        CommonTestSupportUtils.deleteRecursive(lclSftp);
+        Path testFile = assertHierarchyTargetFolderExists(lclSftp).resolve("file.txt");
+        Files.deleteIfExists(testFile);
+        String expected = getCurrentTestName();
+        Files.write(testFile, expected.getBytes(StandardCharsets.UTF_8));
+        String dirName = CommonTestSupportUtils.resolveRelativeRemotePath(parentPath, lclSftp);
+        try (ClientSession session = createAuthenticatedClientSession(client, server.getPort())) {
+            try (SftpFileSystem fs = SftpClientFactory.instance().createSftpFileSystem(session)) {
+                Path remote = fs.getPath(dirName);
+                assertTrue("Should be an SftpPath", remote instanceof SftpPath);
+                int numberOfFiles = 0;
+                try (DirectoryStream<Path> dir = Files.newDirectoryStream(remote)) {
+                    // Pretend we did something with the directory listing.
+                    for (@SuppressWarnings("unused")
+                    Path p : dir) {
+                        numberOfFiles++;
+                    }
+                }
+                assertEquals("Unexpected number of files", 1, numberOfFiles); // We don't get . and ..
+                try {
+                    Field f = fs.getClass().getDeclaredField("wrappers");
+                    f.setAccessible(true);
+                    ThreadLocal<?> item = (ThreadLocal<?>) f.get(fs);
+                    Object content = item.get();
+                    assertNull("ThreadLocal", content);
+                } catch (NoSuchFieldException e) {
+                    // It's OK
+                }
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
The previous implementation always put unused SftpClients back into the pool, but SftpClients in the pool were never closed (unless the whole SSH session was closed).

Let this pool work more like a Java thread pool: besides a maximum size, give it a minimum "core" size, and a maximum life time for idle channels in the pool, and remove them from the pool and close them when they expire. By default, the maximum pool size is 8, the core size 1, and the idle life time 10 seconds.

Also drain the pool when the file system closes, and close all channels.

Remove the ThreadLocal. This mechanism was questionable anyway; it was the source of multiple earlier bug reports and there are some scenarios that it just cannot handle correctly. This change will mean that an application using more threads on an SftpFileSystem instance than the pool size may see poor SFTP performance on the extra threads. In this case, the pool size should be increased, or the application redesigned.

Add some technical documentation on all this.

Ensure in SftpFileSystem.readDir(String) that the SftpClient on the SftpIterableDirEntry is the wrapper. We don't want to close the underlying pooled channel. Ditto for InputStream and OutputStream returned from read or write: those also must use the wrapper to react properly when the wrapper is closed.

Ensure the behavior of an SftpDirectoryStream is correct when the stream is closed. According to the javadoc on DirectoryStream, the iterator may continue to produce already cached entries, but then may exhaust early.

Fixes #371.