### PR TITLE
SftpFileSystem: keep a session until the filesystem is closed

### DIFF
--- a/docs/technical/sftp_filesystem.md
+++ b/docs/technical/sftp_filesystem.md
@@ -17,15 +17,16 @@ There are two ways to create an `SftpFileSystem`:
    off that session using `SftpClientFactory.instance().createSftpFileSystem()`.
    The file system remains valid until it is closed, or until the session is
    closed. When the file system is closed, the session will *not* be closed.
+   When the session closes, so will the file system.
    
 2. You can create an `SftpFileSystem` with a `sftp://` URI using the standard
    Java factory `java.nio.file.FileSystems.newFileSystem()`. This will automatically
    create an `SshClient` with default settings, and the file system will open
    an SSH session itself. This session has heartbeats enabled to keep it open
    for as long as the file system is open. The file system remains valid until
-   closed, at which point it will close the session it had created.
-
-In either case, the file system will be closed if the session closes.
+   closed, at which point it will close the session it had created. If the
+   session closes while the file system is not closed, the next operation on
+   such a file system will open a new session.
 
 # SSH Resource Management
 

--- a/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/fs/SftpFileSystemAutomatic.java
+++ b/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/fs/SftpFileSystemAutomatic.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sshd.sftp.client.fs;
+
+import java.io.IOException;
+
+import org.apache.sshd.client.session.ClientSession;
+import org.apache.sshd.common.util.io.functors.IOFunction;
+import org.apache.sshd.sftp.client.SftpClientFactory;
+import org.apache.sshd.sftp.client.SftpErrorDataHandler;
+import org.apache.sshd.sftp.client.SftpVersionSelector;
+
+/**
+ * An {@link SftpFileSystem} that uses a provider function for its {@link ClientSession} so that it can continue to
+ * function even if a session was closed. The provider is supposed to create a new session if the current one is not
+ * open.
+ *
+ * @author <a href="mailto:dev@mina.apache.org">Apache MINA SSHD Project</a>
+ */
+public class SftpFileSystemAutomatic extends SftpFileSystem {
+
+    private final IOFunction<Boolean, ClientSession> sessionProvider;
+
+    public SftpFileSystemAutomatic(SftpFileSystemProvider provider, String id,
+                                   IOFunction<Boolean, ClientSession> sessionProvider, SftpClientFactory factory,
+                                   SftpVersionSelector selector, SftpErrorDataHandler errorDataHandler)
+            throws IOException {
+        super(provider, id, factory, selector, errorDataHandler);
+        this.sessionProvider = sessionProvider;
+        init();
+    }
+
+    @Override
+    public ClientSession getClientSession() {
+        try {
+            return sessionProvider.apply(Boolean.FALSE);
+        } catch (IOException e) {
+            // Cannot occur
+            return null;
+        }
+    }
+
+    @Override
+    protected ClientSession sessionForSftpClient() throws IOException {
+        if (!isOpen()) {
+            throw new IOException("SftpFileSystem is closed" + this);
+        }
+        ClientSession result = sessionProvider.apply(Boolean.TRUE);
+        setClientSession(result);
+        return result;
+    }
+
+}


### PR DESCRIPTION
When an SftpFileSystem is obtained via FileSystems.newFileSystem(URI), the new file system is created with an implicit SshClient and a new implicit ClientSession. This session has a heartbeat set to keep it open for the lifetime of the file system, i.e., until the file system is closed.

But heartbeats do not guarantee that the session remains open. A server may decide all the same to close the session, for instance, if it is idle for too long. (Even despite heartbeat messages.)

So ensure that in such a case, the file system automatically tries to open a new session. Otherwise a client of such an SftpFileSystem must be prepared to deal with these cases at any time, which may be difficult or even impossible to do.