### PR TITLE
SftpFileSystem: Open Modes & FileChannel locks

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,6 +29,7 @@
 * [GH-370](https://github.com/apache/mina-sshd/issues/370) Also compare file keys in `ModifiableFileWatcher`.
 * [GH-371](https://github.com/apache/mina-sshd/issues/371) Fix channel pool in `SftpFileSystem`.
 * [GH-383](https://github.com/apache/mina-sshd/issues/383) Use correct default `OpenOption`s in `SftpFileSystemProvider.newFileChannel()`.
+* [GH-384](https://github.com/apache/mina-sshd/issues/384) Use correct lock modes for SFTP `FileChannel.lock()`.
 
 * [SSHD-1259](https://issues.apache.org/jira/browse/SSHD-1259) Consider all applicable host keys from the known_hosts files.
 * [SSHD-1310](https://issues.apache.org/jira/browse/SSHD-1310) `SftpFileSystem`: do not close user session.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,7 +28,7 @@
 
 * [GH-370](https://github.com/apache/mina-sshd/issues/370) Also compare file keys in `ModifiableFileWatcher`.
 * [GH-371](https://github.com/apache/mina-sshd/issues/371) Fix channel pool in `SftpFileSystem`.
-
+* [GH-383](https://github.com/apache/mina-sshd/issues/383) Use correct default `OpenOption`s in `SftpFileSystemProvider.newFileChannel()`.
 
 * [SSHD-1259](https://issues.apache.org/jira/browse/SSHD-1259) Consider all applicable host keys from the known_hosts files.
 * [SSHD-1310](https://issues.apache.org/jira/browse/SSHD-1310) `SftpFileSystem`: do not close user session.

--- a/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/SftpClient.java
+++ b/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/SftpClient.java
@@ -84,13 +84,13 @@ public interface SftpClient extends SubsystemClient {
          * Converts {@link StandardOpenOption}-s into {@link OpenMode}-s
          *
          * @param  options                  The original options - ignored if {@code null}/empty
-         * @return                          A {@link Set} of the equivalent modes
+         * @return                          A modifiable {@link Set} of the equivalent modes
          * @throws IllegalArgumentException If an unsupported option is requested
          * @see                             #SUPPORTED_OPTIONS
          */
         public static Set<OpenMode> fromOpenOptions(Collection<? extends OpenOption> options) {
             if (GenericUtils.isEmpty(options)) {
-                return Collections.emptySet();
+                return EnumSet.noneOf(OpenMode.class);
             }
 
             Set<OpenMode> modes = EnumSet.noneOf(OpenMode.class);

--- a/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/impl/AbstractSftpClient.java
+++ b/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/impl/AbstractSftpClient.java
@@ -1091,7 +1091,7 @@ public abstract class AbstractSftpClient
         Buffer buffer = new ByteArrayBuffer(linkPath.length() + targetPath.length() + Long.SIZE /* some extra fields */, false);
         if (version < SftpConstants.SFTP_V6) {
             if (!symbolic) {
-                throw new UnsupportedOperationException("Hard links are not supported in sftp v" + version);
+                throw new UnsupportedOperationException("Hard links are not supported in sftp v" + version + ", need SFTPv6");
             }
             buffer = putReferencedName(cmd, buffer, targetPath, 0);
             buffer = putReferencedName(cmd, buffer, linkPath, 1);
@@ -1110,7 +1110,10 @@ public abstract class AbstractSftpClient
                     "lock(" + handle + ")[offset=" + offset + ", length=" + length + ", mask=0x" + Integer.toHexString(mask)
                                   + "] client is closed");
         }
-
+        int version = getVersion();
+        if (version < SftpConstants.SFTP_V6) {
+            throw new UnsupportedOperationException("File locks are not supported in sftp v" + version + ", need SFTPv6");
+        }
         byte[] id = Objects.requireNonNull(handle, "No handle").getIdentifier();
         Buffer buffer = new ByteArrayBuffer(id.length + Long.SIZE /* a bit extra */, false);
         buffer.putBytes(id);
@@ -1128,6 +1131,10 @@ public abstract class AbstractSftpClient
     public void unlock(Handle handle, long offset, long length) throws IOException {
         if (!isOpen()) {
             throw new IOException("unlock" + handle + ")[offset=" + offset + ", length=" + length + "] client is closed");
+        }
+        int version = getVersion();
+        if (version < SftpConstants.SFTP_V6) {
+            throw new UnsupportedOperationException("File locks are not supported in sftp v" + version + ", need SFTPv6");
         }
 
         byte[] id = Objects.requireNonNull(handle, "No handle").getIdentifier();

--- a/sshd-sftp/src/main/java/org/apache/sshd/sftp/server/SftpSubsystem.java
+++ b/sshd-sftp/src/main/java/org/apache/sshd/sftp/server/SftpSubsystem.java
@@ -534,6 +534,10 @@ public class SftpSubsystem
 
     @Override
     protected void doBlock(int id, String handle, long offset, long length, int mask) throws IOException {
+        int vers = getVersion();
+        if (vers < SftpConstants.SFTP_V6) {
+            throw new UnsupportedOperationException("File locks are not supported in sftp v" + vers + ", need SFTPv6");
+        }
         Handle p = handles.get(handle);
         ServerSession session = getServerSession();
         if (log.isDebugEnabled()) {
@@ -555,6 +559,10 @@ public class SftpSubsystem
 
     @Override
     protected void doUnblock(int id, String handle, long offset, long length) throws IOException {
+        int vers = getVersion();
+        if (vers < SftpConstants.SFTP_V6) {
+            throw new UnsupportedOperationException("File locks are not supported in sftp v" + vers + ", need SFTPv6");
+        }
         Handle p = handles.get(handle);
         ServerSession session = getServerSession();
         if (log.isDebugEnabled()) {


### PR DESCRIPTION
Two commits:

* Tighten rules about `StandardOpenOption`s when creating file channels or input/output streams. Fixes #383.
* Use correct lock modes for `FileChannel.lock(...)`. Fixes #384.