### PR TITLE
GH-398: SftpInputStreamAsync: fix EOF for read length zero

### DIFF
--- a/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/impl/SftpInputStreamAsync.java
+++ b/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/impl/SftpInputStreamAsync.java
@@ -136,7 +136,7 @@ public class SftpInputStreamAsync extends InputStreamWithChannel implements Sftp
             int l = buf.available();
             buf.getRawBytes(b, offset.getAndAdd(l), l);
         });
-        if (res == 0 && eofIndicator) {
+        if (res == 0 && eofIndicator && hasNoData()) {
             res = -1;
         }
         return res;


### PR DESCRIPTION
Only return EOF once the EOF indicator is set *and* there is no more buffered data.

Fixes #398.