### PR TITLE
Fix SFTP file handles

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,6 +32,7 @@
 * [GH-384](https://github.com/apache/mina-sshd/issues/384) Use correct lock modes for SFTP `FileChannel.lock()`.
 * [GH-388](https://github.com/apache/mina-sshd/issues/388) `ScpClient`: support issuing commands to a server that uses a non-UTF-8 locale.
 * [GH-398](https://github.com/apache/mina-sshd/issues/398) `SftpInputStreamAsync`: fix reporting EOF on zero-length reads.
+* [GH-403](https://github.com/apache/mina-sshd/issues/403) Work-around a bug in WS_FTP <= 12.9 SFTP clients.
 
 * [SSHD-1259](https://issues.apache.org/jira/browse/SSHD-1259) Consider all applicable host keys from the known_hosts files.
 * [SSHD-1310](https://issues.apache.org/jira/browse/SSHD-1310) `SftpFileSystem`: do not close user session.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -56,6 +56,12 @@ handle size was thus 32 bytes.
 
 This has been fixed in this version.
 
+Additionally, the default setting for the size of file handles has been changed
+from 16 to 4 bytes. OpenSSH also uses 4-byte SFTP file handles. Using the same
+size not only means that there is a little more space left in SSH packets for
+actual data transfer. It also completely avoids the WS_FTP bug mentioned in
+[GH-403](https://github.com/apache/mina-sshd/issues/403).
+
 ## Potential compatibility issues
 
 ### Server-side SFTP file handle encoding

--- a/sshd-core/src/main/java/org/apache/sshd/common/channel/exception/SshChannelInvalidPacketException.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/channel/exception/SshChannelInvalidPacketException.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sshd.common.channel.exception;
+
+/**
+ * @author <a href="mailto:dev@mina.apache.org">Apache MINA SSHD Project</a>
+ */
+public class SshChannelInvalidPacketException extends SshChannelException {
+
+    private static final long serialVersionUID = -4567136397319835717L;
+
+    public SshChannelInvalidPacketException(long channelId, String message) {
+        this(channelId, message, null);
+    }
+
+    public SshChannelInvalidPacketException(long channelId, Throwable cause) {
+        this(channelId, cause.getMessage(), cause);
+    }
+
+    public SshChannelInvalidPacketException(long channelId, String message, Throwable cause) {
+        super(channelId, message, cause);
+    }
+}

--- a/sshd-sftp/src/main/java/org/apache/sshd/sftp/SftpModuleProperties.java
+++ b/sshd-sftp/src/main/java/org/apache/sshd/sftp/SftpModuleProperties.java
@@ -203,7 +203,7 @@ public final class SftpModuleProperties {
 
     /**
      * Properties key for the maximum of available open handles per session. By default we impose virtually no limit and
-     * relay on the O/S.
+     * rely on the O/S.
      */
     public static final Property<Integer> MAX_OPEN_HANDLES_PER_SESSION
             = Property.integer("max-open-handles-per-session", Integer.MAX_VALUE - 1);

--- a/sshd-sftp/src/main/java/org/apache/sshd/sftp/SftpModuleProperties.java
+++ b/sshd-sftp/src/main/java/org/apache/sshd/sftp/SftpModuleProperties.java
@@ -208,8 +208,8 @@ public final class SftpModuleProperties {
     public static final Property<Integer> MAX_OPEN_HANDLES_PER_SESSION
             = Property.integer("max-open-handles-per-session", Integer.MAX_VALUE - 1);
 
-    public static final int MIN_FILE_HANDLE_SIZE = 4; // ~uint32
-    public static final int DEFAULT_FILE_HANDLE_SIZE = 16;
+    public static final int MIN_FILE_HANDLE_SIZE = Integer.BYTES; // ~uint32
+    public static final int DEFAULT_FILE_HANDLE_SIZE = MIN_FILE_HANDLE_SIZE;
     public static final int MAX_FILE_HANDLE_SIZE = 64; // ~sha512
 
     /**

--- a/sshd-sftp/src/test/java/org/apache/sshd/sftp/server/HandleTest.java
+++ b/sshd-sftp/src/test/java/org/apache/sshd/sftp/server/HandleTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sshd.sftp.server;
+
+import java.nio.charset.StandardCharsets;
+
+import org.apache.sshd.common.util.buffer.Buffer;
+import org.apache.sshd.common.util.buffer.BufferUtils;
+import org.apache.sshd.common.util.buffer.ByteArrayBuffer;
+import org.apache.sshd.util.test.NoIoTestCase;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import static org.junit.Assert.assertEquals;
+
+@Category({ NoIoTestCase.class })
+public class HandleTest {
+
+    public HandleTest() {
+        super();
+    }
+
+    private void roundtrip(long x) {
+        byte[] buf = new byte[Integer.BYTES];
+        BufferUtils.putUInt(x, buf);
+        String s = new String(buf, StandardCharsets.ISO_8859_1);
+        int h = s.hashCode();
+        Buffer buffer = new ByteArrayBuffer();
+        buffer.putString(s, StandardCharsets.ISO_8859_1);
+        String t = buffer.getString(StandardCharsets.ISO_8859_1);
+        assertEquals("Hash for " + x + " different", h, t.hashCode());
+        assertEquals("String for " + x + " different", s, t);
+        byte[] b = t.getBytes(StandardCharsets.ISO_8859_1);
+        long j = BufferUtils.getUInt(b);
+        assertEquals("Values different", x, j);
+    }
+
+    @Test
+    public void testIntegerStringRoundtrip() {
+        final int limit = 100_000;
+        for (long i = 0; i <= limit; i++) {
+            roundtrip(i);
+        }
+        for (long i = Integer.MAX_VALUE; i >= Integer.MAX_VALUE - limit; i--) {
+            roundtrip(i);
+        }
+        roundtrip(0x01020304);
+        roundtrip(0x77ccdd01);
+    }
+}


### PR DESCRIPTION
* Work-around for the WS_FTP bug
* Ensure file handle size is indeed the configured number of bytes
* Change default to 4 bytes, and use a different way to generate 4-byte handles