### PR TITLE
GH-407: Override FilterOutputStream.write(byte[], int, int)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,6 +33,7 @@
 * [GH-388](https://github.com/apache/mina-sshd/issues/388) `ScpClient`: support issuing commands to a server that uses a non-UTF-8 locale.
 * [GH-398](https://github.com/apache/mina-sshd/issues/398) `SftpInputStreamAsync`: fix reporting EOF on zero-length reads.
 * [GH-403](https://github.com/apache/mina-sshd/issues/403) Work-around a bug in WS_FTP <= 12.9 SFTP clients.
+* [GH-407](https://github.com/apache/mina-sshd/issues/407) (Regression in 2.10.0) SFTP performance fix: override `FilterOutputStream.write(byte[], int, int)`.
 
 * [SSHD-1259](https://issues.apache.org/jira/browse/SSHD-1259) Consider all applicable host keys from the known_hosts files.
 * [SSHD-1310](https://issues.apache.org/jira/browse/SSHD-1310) `SftpFileSystem`: do not close user session.

--- a/sshd-common/src/main/java/org/apache/sshd/common/util/io/der/DERWriter.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/util/io/der/DERWriter.java
@@ -135,6 +135,11 @@ public class DERWriter extends FilterOutputStream {
         write(data, 0, len);
     }
 
+    @Override
+    public void write(byte[] b, int off, int len) throws IOException {
+        out.write(b, off, len);
+    }
+
     public void writeLength(int len) throws IOException {
         ValidateUtils.checkTrue(len >= 0, "Invalid length: %d", len);
 

--- a/sshd-common/src/main/java/org/apache/sshd/common/util/io/output/NoCloseOutputStream.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/util/io/output/NoCloseOutputStream.java
@@ -37,6 +37,11 @@ public class NoCloseOutputStream extends FilterOutputStream {
         // ignored
     }
 
+    @Override
+    public void write(byte[] b, int off, int len) throws IOException {
+        out.write(b, off, len);
+    }
+
     public static OutputStream resolveOutputStream(OutputStream output, boolean okToClose) {
         if ((output == null) || okToClose) {
             return output;

--- a/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/fs/SftpFileSystemProvider.java
+++ b/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/fs/SftpFileSystemProvider.java
@@ -658,6 +658,11 @@ public class SftpFileSystemProvider extends FileSystemProvider {
                     client.close();
                 }
             }
+
+            @Override
+            public void write(byte[] b, int off, int len) throws IOException {
+                out.write(b, off, len);
+            }
         };
     }
 


### PR DESCRIPTION
The default implementation calls write(int) for every byte, which may be very inefficient. Override it in the few cases where we use a FilterOutputStream to pass through the operation to the underlying OutputStream, which is also responsible for any index and length validations.

Fixes #407.