### PR TITLE
GH-410: Ensure EOF gets sent before CLOSE when Channel closes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,6 +34,7 @@
 * [GH-398](https://github.com/apache/mina-sshd/issues/398) `SftpInputStreamAsync`: fix reporting EOF on zero-length reads.
 * [GH-403](https://github.com/apache/mina-sshd/issues/403) Work-around a bug in WS_FTP <= 12.9 SFTP clients.
 * [GH-407](https://github.com/apache/mina-sshd/issues/407) (Regression in 2.10.0) SFTP performance fix: override `FilterOutputStream.write(byte[], int, int)`.
+* [GH-410](https://github.com/apache/mina-sshd/issues/410) Fix a race condition to ensure `SSH_MSG_CHANNEL_EOF` is always sent before `SSH_MSG_CHANNEL_CLOSE`.
 
 * [SSHD-1259](https://issues.apache.org/jira/browse/SSHD-1259) Consider all applicable host keys from the known_hosts files.
 * [SSHD-1310](https://issues.apache.org/jira/browse/SSHD-1310) `SftpFileSystem`: do not close user session.


### PR DESCRIPTION
When a channel using a ChannelAsyncOutputStream, do not only wait until all pending data has been written but also wait for the EOF having been sent before proceeding with closing the channel.

For channels using a synchronous ChannelOutputStream, no local fix was found. Instead give the channel access to the IoWriteFuture for sending the EOF packet, and if one was sent, ensure that closing the channel proceeds only after the EOF has been sent.

Otherwise there may be a race between sending that EOF and sending the CLOSE, and sometimes the EOF might be sent after the CLOSE.

Fixes: #410 