### PR TITLE
GH-414: Correct error handling in KeyExchangeMessageHandler

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -35,6 +35,7 @@
 * [GH-403](https://github.com/apache/mina-sshd/issues/403) Work-around a bug in WS_FTP <= 12.9 SFTP clients.
 * [GH-407](https://github.com/apache/mina-sshd/issues/407) (Regression in 2.10.0) SFTP performance fix: override `FilterOutputStream.write(byte[], int, int)`.
 * [GH-410](https://github.com/apache/mina-sshd/issues/410) Fix a race condition to ensure `SSH_MSG_CHANNEL_EOF` is always sent before `SSH_MSG_CHANNEL_CLOSE`.
+* [GH-414](https://github.com/apache/mina-sshd/issues/414) Fix error handling while flushing queued packets at end of KEX.
 
 * [SSHD-1259](https://issues.apache.org/jira/browse/SSHD-1259) Consider all applicable host keys from the known_hosts files.
 * [SSHD-1310](https://issues.apache.org/jira/browse/SSHD-1310) `SftpFileSystem`: do not close user session.

--- a/sshd-sftp/src/test/java/org/apache/sshd/sftp/server/SftpServerTest.java
+++ b/sshd-sftp/src/test/java/org/apache/sshd/sftp/server/SftpServerTest.java
@@ -22,7 +22,6 @@ import java.io.BufferedInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.lang.reflect.Field;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
@@ -30,6 +29,8 @@ import java.nio.file.Path;
 import java.util.Collections;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.sshd.client.SshClient;
 import org.apache.sshd.client.session.ClientSession;
@@ -37,7 +38,6 @@ import org.apache.sshd.common.file.virtualfs.VirtualFileSystemFactory;
 import org.apache.sshd.common.util.io.IoUtils;
 import org.apache.sshd.server.SshServer;
 import org.apache.sshd.server.session.ServerSession;
-import org.apache.sshd.sftp.client.SftpClient;
 import org.apache.sshd.sftp.client.SftpClientFactory;
 import org.apache.sshd.sftp.client.fs.SftpFileSystem;
 import org.apache.sshd.sftp.client.fs.SftpPath;
@@ -60,7 +60,7 @@ public class SftpServerTest extends BaseTestSupport {
 
     private SshClient client;
 
-    private int numberOfSubsystems;
+    private AtomicInteger numberOfSubsystems = new AtomicInteger();
 
     private CountDownLatch serverHasNoSftpSubsystem;
 
@@ -76,13 +76,12 @@ public class SftpServerTest extends BaseTestSupport {
         factory.addSftpEventListener(new SftpEventListener() {
             @Override
             public void initialized(ServerSession session, int version) throws IOException {
-                numberOfSubsystems++;
+                numberOfSubsystems.incrementAndGet();
             }
 
             @Override
             public void destroying(ServerSession session) throws IOException {
-                numberOfSubsystems--;
-                if (numberOfSubsystems == 0) {
+                if (numberOfSubsystems.decrementAndGet() == 0) {
                     serverHasNoSftpSubsystem.countDown();
                 }
             }
@@ -100,7 +99,7 @@ public class SftpServerTest extends BaseTestSupport {
     @After
     public void shutdown() throws Exception {
         if (client != null) {
-            // client.stop();
+            client.stop();
         }
         if (server != null) {
             server.stop(true);
@@ -108,20 +107,21 @@ public class SftpServerTest extends BaseTestSupport {
     }
 
     private String download(Path remote) throws Exception {
-        String[] actual = { null };
+        AtomicReference<String> actual = new AtomicReference<>();
         Thread worker = new Thread(() -> {
             try (ByteArrayOutputStream downloaded = new ByteArrayOutputStream()) {
                 try (InputStream input = new BufferedInputStream(Files.newInputStream(remote))) {
                     IoUtils.copy(input, downloaded);
                 }
-                actual[0] = downloaded.toString(StandardCharsets.UTF_8.name());
+                actual.set(downloaded.toString(StandardCharsets.UTF_8.name()));
             } catch (IOException e) {
-                actual[0] = e.toString();
+                actual.set(e.toString());
             }
         });
         worker.start();
         worker.join(TimeUnit.SECONDS.toMillis(3));
-        return actual[0];
+        assertFalse("Thread should have terminated", worker.isAlive());
+        return actual.get();
     }
 
     @Test
@@ -149,11 +149,11 @@ public class SftpServerTest extends BaseTestSupport {
                 assertEquals("Mismatched content", expected, actual);
                 // Yes, we had three threads, but no concurrency at all. There should be only a single server-side
                 // SftpSubsystem.
-                assertEquals("Unexpected number of SftpSubsystems", 1, numberOfSubsystems);
+                assertEquals("Unexpected number of SftpSubsystems", 1, numberOfSubsystems.get());
             }
             assertTrue("Session should still be open", session.isOpen());
             assertTrue("Server did not close SftpSubsystem", serverHasNoSftpSubsystem.await(3, TimeUnit.SECONDS));
-            assertEquals("SftpSubsystem count should be zero", 0, numberOfSubsystems);
+            assertEquals("SftpSubsystem count should be zero", 0, numberOfSubsystems.get());
         }
     }
 
@@ -172,7 +172,7 @@ public class SftpServerTest extends BaseTestSupport {
             try (SftpFileSystem fs = SftpClientFactory.instance().createSftpFileSystem(session)) {
                 Path remote = fs.getPath(fileName);
                 assertTrue("Should be an SftpPath", remote instanceof SftpPath);
-                String[] actual1 = { null };
+                AtomicReference<String> actual1 = new AtomicReference<>();
                 CountDownLatch secondThreadIsReady = new CountDownLatch(1);
                 Thread worker1 = new Thread(() -> {
                     try (ByteArrayOutputStream downloaded = new ByteArrayOutputStream()) {
@@ -189,13 +189,13 @@ public class SftpServerTest extends BaseTestSupport {
                                 downloaded.write(b);
                             }
                         }
-                        actual1[0] = downloaded.toString(StandardCharsets.UTF_8.name());
+                        actual1.set(downloaded.toString(StandardCharsets.UTF_8.name()));
                     } catch (Exception e) {
-                        actual1[0] = e.toString();
+                        actual1.set(e.toString());
                     }
                 });
-                String[] actual2 = { null };
-                int[] numberOfChannels = { -1 };
+                AtomicReference<String> actual2 = new AtomicReference<>();
+                AtomicInteger numberOfChannels = new AtomicInteger();
                 Thread worker2 = new Thread(() -> {
                     try (ByteArrayOutputStream downloaded = new ByteArrayOutputStream()) {
                         try (InputStream input = Files.newInputStream(remote)) {
@@ -203,7 +203,7 @@ public class SftpServerTest extends BaseTestSupport {
                             for (boolean first = true;; first = false) {
                                 int b = input.read();
                                 if (first) {
-                                    numberOfChannels[0] = numberOfSubsystems;
+                                    numberOfChannels.set(numberOfSubsystems.get());
                                     secondThreadIsReady.countDown();
                                 }
                                 if (b < 0) {
@@ -212,31 +212,29 @@ public class SftpServerTest extends BaseTestSupport {
                                 downloaded.write(b);
                             }
                         }
-                        actual2[0] = downloaded.toString(StandardCharsets.UTF_8.name());
+                        actual2.set(downloaded.toString(StandardCharsets.UTF_8.name()));
                     } catch (Exception e) {
-                        actual2[0] = e.toString();
+                        actual2.set(e.toString());
                     }
                 });
                 worker1.start();
                 worker2.start();
                 worker1.join(TimeUnit.SECONDS.toMillis(3));
                 worker2.join(TimeUnit.SECONDS.toMillis(3));
-                assertEquals("Mismatched content", expected, actual1[0]);
-                assertEquals("Mismatched content", expected, actual2[0]);
-                assertEquals("Unexpected number of SftpSubsystems", 2, numberOfChannels[0]);
+                assertFalse("Worker 1 should have finished", worker1.isAlive());
+                assertFalse("Worker 2 should have finished", worker2.isAlive());
+                assertEquals("Mismatched content", expected, actual1.get());
+                assertEquals("Mismatched content", expected, actual2.get());
+                assertEquals("Unexpected number of SftpSubsystems", 2, numberOfChannels.get());
             }
             assertTrue("Session should still be open", session.isOpen());
             assertTrue("Server did not close SftpSubsystem", serverHasNoSftpSubsystem.await(3, TimeUnit.SECONDS));
-            assertEquals("SftpSubsystem count", 0, numberOfSubsystems);
+            assertEquals("SftpSubsystem count", 0, numberOfSubsystems.get());
         }
     }
 
     @Test
     public void testHandOffStream() throws Exception {
-        // This test shows that it is not possible to correctly handle these ThreadLocals. There are cases where
-        // perfectly valid code creates the wrapper in one thread but closes it in another. In this case, closing the
-        // wrapper cannot remove the ThreadLocal: it'll try to do so on a different thread, where either there is no
-        // ThreadLocal, or (perhaps even worse) there might be one containing a different wrapper.
         Path targetPath = detectTargetFolder();
         Path parentPath = targetPath.getParent();
         Path lclSftp = CommonTestSupportUtils.resolve(targetPath, SftpConstants.SFTP_SUBSYSTEM_NAME, getClass().getSimpleName(),
@@ -251,53 +249,27 @@ public class SftpServerTest extends BaseTestSupport {
                 Path remote = fs.getPath(fileName);
                 assertTrue("Should be an SftpPath", remote instanceof SftpPath);
                 InputStream is = Files.newInputStream(remote);
-                String[] actual = { null };
+                AtomicReference<String> actual = new AtomicReference<>();
                 Thread worker = new Thread(() -> {
                     try (ByteArrayOutputStream downloaded = new ByteArrayOutputStream()) {
                         try (InputStream input = new BufferedInputStream(is)) {
                             IoUtils.copy(input, downloaded);
                         }
-                        actual[0] = downloaded.toString(StandardCharsets.UTF_8.name());
+                        actual.set(downloaded.toString(StandardCharsets.UTF_8.name()));
                     } catch (IOException e) {
-                        actual[0] = e.toString();
+                        actual.set(e.toString());
                     }
                 });
                 worker.start();
                 worker.join(TimeUnit.SECONDS.toMillis(3));
-                assertEquals("Mismatched content", expected, actual[0]);
-                // It's rather hard to test ThreadLocals because even just calling get() will create it the thread's
-                // ThreadLocalMap. I don't want to do reflection on JDK classes, so the best we can do is check that we
-                // have a null value. There's no way to check that the ThreadLocalMap has no entry at all for any
-                // wrapper.
-                //
-                // The test succeeds if either SftpFileSystem does not have the ThreadLocal, or its value is null.
-                // It should be null because is was closed. In reality it isn't with the SftpFileSystem implementation
-                // of Apache MINA 2.10.0, or even with the state at commit 18f4346a0.
-                try {
-                    Field f = fs.getClass().getDeclaredField("wrappers");
-                    f.setAccessible(true);
-                    ThreadLocal<?> item = (ThreadLocal<?>) f.get(fs);
-                    Object content = item.get();
-                    if (content instanceof SftpClient) {
-                        // We expect null. But if we have an SftpClient here, it should at least be closed because the
-                        // input stream 'is' was closed. Which is, of course, also bad. The ThreadLocal should never
-                        // contain a closed SftpClient. But such is the nature of this memory leak.
-                        assertFalse(((SftpClient) content).isOpen());
-                    }
-                    assertNull("ThreadLocal", content);
-                } catch (NoSuchFieldException e) {
-                    // It's OK
-                }
+                assertFalse("Worker should have terminated", worker.isAlive());
+                assertEquals("Mismatched content", expected, actual.get());
             }
         }
     }
 
     @Test
     public void testDirectoryStream() throws Exception {
-        // This test shows that it is not possible to correctly handle these ThreadLocals. There are cases where
-        // perfectly valid code creates the wrapper in one thread but closes it in another. In this case, closing the
-        // wrapper cannot remove the ThreadLocal: it'll try to do so on a different thread, where either there is no
-        // ThreadLocal, or (perhaps even worse) there might be one containing a different wrapper.
         Path targetPath = detectTargetFolder();
         Path parentPath = targetPath.getParent();
         Path lclSftp = CommonTestSupportUtils.resolve(targetPath, SftpConstants.SFTP_SUBSYSTEM_NAME, getClass().getSimpleName(),
@@ -315,21 +287,13 @@ public class SftpServerTest extends BaseTestSupport {
                 int numberOfFiles = 0;
                 try (DirectoryStream<Path> dir = Files.newDirectoryStream(remote)) {
                     // Pretend we did something with the directory listing.
-                    for (@SuppressWarnings("unused")
-                    Path p : dir) {
-                        numberOfFiles++;
+                    for (Path p : dir) {
+                        if (p != null) {
+                            numberOfFiles++;
+                        }
                     }
                 }
                 assertEquals("Unexpected number of files", 1, numberOfFiles); // We don't get . and ..
-                try {
-                    Field f = fs.getClass().getDeclaredField("wrappers");
-                    f.setAccessible(true);
-                    ThreadLocal<?> item = (ThreadLocal<?>) f.get(fs);
-                    Object content = item.get();
-                    assertNull("ThreadLocal", content);
-                } catch (NoSuchFieldException e) {
-                    // It's OK
-                }
             }
         }
     }


### PR DESCRIPTION
During KEX we may queue up higher-level packets. When KEX ends, we flush this queue, writing all these queued packets. When writing a queued packet fails, previous code handled the failure wrongly, leading to an inconsistent state that could cause an endless loop in writeOrEnqueue.

Fix this by making sure that (a) kexFlushed is true also in this case, and (b) by fulfilling the kexFlushedFuture and closing the session outside of the critical region.

Because kexFlushed = true now also on failure, drain the queue and set up all the queued futures such that they will be fulfilled with the exception.

Additionally, do the same if the session closes while we're still flushing queued packets.

Fixes #414.