### PR TITLE
GH-420: avoid spurious exceptions on closing forwarded channel

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -37,6 +37,7 @@
 * [GH-407](https://github.com/apache/mina-sshd/issues/407) (Regression in 2.10.0) SFTP performance fix: override `FilterOutputStream.write(byte[], int, int)`.
 * [GH-410](https://github.com/apache/mina-sshd/issues/410) Fix a race condition to ensure `SSH_MSG_CHANNEL_EOF` is always sent before `SSH_MSG_CHANNEL_CLOSE`.
 * [GH-414](https://github.com/apache/mina-sshd/issues/414) Fix error handling while flushing queued packets at end of KEX.
+* [GH-420](https://github.com/apache/mina-sshd/issues/420) Fix wrong log level on closing an `Nio2Session`.
 
 * [SSHD-789](https://issues.apache.org/jira/browse/SSHD-789) Fix detection of Android O/S from system properties.
 * [SSHD-1259](https://issues.apache.org/jira/browse/SSHD-1259) Consider all applicable host keys from the known_hosts files.

--- a/sshd-core/src/main/java/org/apache/sshd/common/io/nio2/Nio2Session.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/io/nio2/Nio2Session.java
@@ -224,9 +224,11 @@ public class Nio2Session extends AbstractCloseable implements IoSession {
                 .run(closeId, () -> {
                     try {
                         AsynchronousSocketChannel socket = getSocket();
-                        socket.shutdownOutput();
+                        if (socket.isOpen()) {
+                            socket.shutdownOutput();
+                        }
                     } catch (IOException e) {
-                        info("doCloseGracefully({}) {} while shutting down output: {}",
+                        log.trace("doCloseGracefully({}) {} while shutting down output: {}",
                                 this, e.getClass().getSimpleName(), e.getMessage(), e);
                     }
                 }).build()


### PR DESCRIPTION
Fix `Nio2Session.doCloseGracefully()`: before calling `AsynchronousSocketChannel.shutdownOutput()`, check that the socket is still open, and if we get an `IOException` all the same, log it with TRACE level. See also comments in `doShutdownOutputStream()`.

Fixes #420.