### PR TITLE
Create Nio2Session using Nio2ServiceFactory

### DIFF
--- a/sshd-core/src/main/java/org/apache/sshd/common/io/nio2/Nio2Acceptor.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/io/nio2/Nio2Acceptor.java
@@ -50,11 +50,13 @@ import org.apache.sshd.core.CoreModuleProperties;
  */
 public class Nio2Acceptor extends Nio2Service implements IoAcceptor {
     protected final Map<SocketAddress, AsynchronousServerSocketChannel> channels = new ConcurrentHashMap<>();
+    private final Nio2ServiceFactory nio2ServiceFactory;
     private int backlog;
 
-    public Nio2Acceptor(PropertyResolver propertyResolver, IoHandler handler, AsynchronousChannelGroup group,
+    public Nio2Acceptor(Nio2ServiceFactory nio2ServiceFactory, PropertyResolver propertyResolver, IoHandler handler, AsynchronousChannelGroup group,
                         ExecutorService resumeTasks) {
         super(propertyResolver, handler, group, resumeTasks);
+        this.nio2ServiceFactory = nio2ServiceFactory;
         backlog = CoreModuleProperties.SOCKET_BACKLOG.getRequired(propertyResolver);
     }
 
@@ -354,7 +356,7 @@ public class Nio2Acceptor extends Nio2Service implements IoAcceptor {
             if (log.isTraceEnabled()) {
                 log.trace("createNio2Session({}) address={}", acceptor, address);
             }
-            return new Nio2Session(acceptor, propertyResolver, handler, channel, address);
+            return nio2ServiceFactory.createSession(acceptor, handler, channel, address);
         }
 
         @Override

--- a/sshd-core/src/main/java/org/apache/sshd/common/io/nio2/Nio2Connector.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/io/nio2/Nio2Connector.java
@@ -49,9 +49,12 @@ import org.apache.sshd.core.CoreModuleProperties;
  * @author <a href="mailto:dev@mina.apache.org">Apache MINA SSHD Project</a>
  */
 public class Nio2Connector extends Nio2Service implements IoConnector {
-    public Nio2Connector(PropertyResolver propertyResolver, IoHandler handler, AsynchronousChannelGroup group,
+    private final Nio2ServiceFactory nio2ServiceFactory;
+
+    public Nio2Connector(Nio2ServiceFactory nio2ServiceFactory, PropertyResolver propertyResolver, IoHandler handler, AsynchronousChannelGroup group,
                          ExecutorService resumeTasks) {
         super(propertyResolver, handler, group, resumeTasks);
+        this.nio2ServiceFactory = nio2ServiceFactory;
     }
 
     @Override
@@ -276,7 +279,6 @@ public class Nio2Connector extends Nio2Service implements IoConnector {
     protected Nio2Session createSession(
             PropertyResolver propertyResolver, IoHandler handler, AsynchronousSocketChannel socket)
             throws Throwable {
-        return new Nio2Session(this, propertyResolver, handler, socket, null);
+        return nio2ServiceFactory.createSession(this, handler, socket, null);
     }
-
 }

--- a/sshd-core/src/main/java/org/apache/sshd/common/io/nio2/Nio2ServiceFactory.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/io/nio2/Nio2ServiceFactory.java
@@ -19,7 +19,9 @@
 package org.apache.sshd.common.io.nio2;
 
 import java.io.IOException;
+import java.net.SocketAddress;
 import java.nio.channels.AsynchronousChannelGroup;
+import java.nio.channels.AsynchronousSocketChannel;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.sshd.common.FactoryManager;
@@ -56,12 +58,18 @@ public class Nio2ServiceFactory extends AbstractIoServiceFactory {
 
     @Override
     public IoConnector createConnector(IoHandler handler) {
-        return autowireCreatedService(new Nio2Connector(getFactoryManager(), handler, group, resuming));
+        return autowireCreatedService(new Nio2Connector(this, getFactoryManager(), handler, group, resuming));
     }
 
     @Override
     public IoAcceptor createAcceptor(IoHandler handler) {
-        return autowireCreatedService(new Nio2Acceptor(getFactoryManager(), handler, group, resuming));
+        return autowireCreatedService(new Nio2Acceptor(this, getFactoryManager(), handler, group, resuming));
+    }
+
+    public Nio2Session createSession(
+            Nio2Service service, IoHandler handler, AsynchronousSocketChannel socket, SocketAddress address)
+            throws Throwable {
+        return new Nio2Session(service, getFactoryManager(), handler, socket, address);
     }
 
     @Override


### PR DESCRIPTION
This allows client code to override and extend the Nio2Session class. Current implementation creates createWriteCycleCompletionHandler which executes OS callback and completes the future on another thread. The overridden implementation may wrap the callbacks with custom code and set up, for example, the logging MDC