### PR TITLE
GH-429: Support GIT protocol-v2

### DIFF
--- a/sshd-git/src/main/java/org/apache/sshd/git/GitModuleProperties.java
+++ b/sshd-git/src/main/java/org/apache/sshd/git/GitModuleProperties.java
@@ -50,6 +50,13 @@ public final class GitModuleProperties {
     public static final Property<Duration> CHANNEL_OPEN_TIMEOUT
             = Property.duration("git-ssh-channel-open-timeout", Duration.ofSeconds(7L));
 
+    /**
+     * Property used to configure the SSHD {@link org.apache.sshd.common.FactoryManager} with the {@code GIT_PROTOCOL}
+     * environment variable. The default is not specified and therefore original (v0) protocol is used.
+     */
+    public static final Property<String> GIT_PROTOCOL_VERSION
+            = Property.string("git-ssh-protocol-version");
+
     private GitModuleProperties() {
         // private
     }

--- a/sshd-git/src/main/java/org/apache/sshd/git/pack/GitPackCommand.java
+++ b/sshd-git/src/main/java/org/apache/sshd/git/pack/GitPackCommand.java
@@ -20,6 +20,7 @@ package org.apache.sshd.git.pack;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.Collections;
 import java.util.List;
 
 import org.apache.sshd.common.util.GenericUtils;
@@ -29,6 +30,7 @@ import org.apache.sshd.git.AbstractGitCommand;
 import org.apache.sshd.git.GitLocationResolver;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.lib.RepositoryCache;
+import org.eclipse.jgit.transport.GitProtocolConstants;
 import org.eclipse.jgit.transport.ReceivePack;
 import org.eclipse.jgit.transport.RemoteConfig;
 import org.eclipse.jgit.transport.UploadPack;
@@ -77,7 +79,11 @@ public class GitPackCommand extends AbstractGitCommand {
             Repository db = key.open(true /* must exist */);
             String subCommand = args[0];
             if (RemoteConfig.DEFAULT_UPLOAD_PACK.equals(subCommand)) {
-                new UploadPack(db).upload(getInputStream(), getOutputStream(), getErrorStream());
+                UploadPack uploadPack = new UploadPack(db);
+                String protocol = this.getEnvironment().getEnv()
+                        .getOrDefault(GitProtocolConstants.PROTOCOL_ENVIRONMENT_VARIABLE, "version=0");
+                uploadPack.setExtraParameters(Collections.singleton(protocol));
+                uploadPack.upload(getInputStream(), getOutputStream(), getErrorStream());
             } else if (RemoteConfig.DEFAULT_RECEIVE_PACK.equals(subCommand)) {
                 new ReceivePack(db).receive(getInputStream(), getOutputStream(), getErrorStream());
             } else {

--- a/sshd-git/src/main/java/org/apache/sshd/git/pack/GitPackCommand.java
+++ b/sshd-git/src/main/java/org/apache/sshd/git/pack/GitPackCommand.java
@@ -80,9 +80,10 @@ public class GitPackCommand extends AbstractGitCommand {
             String subCommand = args[0];
             if (RemoteConfig.DEFAULT_UPLOAD_PACK.equals(subCommand)) {
                 UploadPack uploadPack = new UploadPack(db);
-                String protocol = this.getEnvironment().getEnv()
-                        .getOrDefault(GitProtocolConstants.PROTOCOL_ENVIRONMENT_VARIABLE, "version=0");
-                uploadPack.setExtraParameters(Collections.singleton(protocol));
+                String protocol = this.getEnvironment().getEnv().get(GitProtocolConstants.PROTOCOL_ENVIRONMENT_VARIABLE);
+                if (protocol != null) {
+                    uploadPack.setExtraParameters(Collections.singleton(protocol));
+                }
                 uploadPack.upload(getInputStream(), getOutputStream(), getErrorStream());
             } else if (RemoteConfig.DEFAULT_RECEIVE_PACK.equals(subCommand)) {
                 new ReceivePack(db).receive(getInputStream(), getOutputStream(), getErrorStream());

--- a/sshd-git/src/main/java/org/apache/sshd/git/pack/GitPackCommand.java
+++ b/sshd-git/src/main/java/org/apache/sshd/git/pack/GitPackCommand.java
@@ -81,7 +81,7 @@ public class GitPackCommand extends AbstractGitCommand {
             if (RemoteConfig.DEFAULT_UPLOAD_PACK.equals(subCommand)) {
                 UploadPack uploadPack = new UploadPack(db);
                 String protocol = this.getEnvironment().getEnv().get(GitProtocolConstants.PROTOCOL_ENVIRONMENT_VARIABLE);
-                if (protocol != null) {
+                if (GenericUtils.isNotBlank(protocol)) {
                     uploadPack.setExtraParameters(Collections.singleton(protocol));
                 }
                 uploadPack.upload(getInputStream(), getOutputStream(), getErrorStream());

--- a/sshd-git/src/main/java/org/apache/sshd/git/transport/GitSshdSession.java
+++ b/sshd-git/src/main/java/org/apache/sshd/git/transport/GitSshdSession.java
@@ -19,6 +19,8 @@
 package org.apache.sshd.git.transport;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
 
 import org.apache.sshd.client.SshClient;
 import org.apache.sshd.client.channel.ChannelExec;
@@ -30,12 +32,15 @@ import org.eclipse.jgit.transport.CredentialItem;
 import org.eclipse.jgit.transport.CredentialsProvider;
 import org.eclipse.jgit.transport.RemoteSession;
 import org.eclipse.jgit.transport.URIish;
+import static org.eclipse.jgit.transport.GitProtocolConstants.*;
 import org.eclipse.jgit.util.FS;
 
 /**
  * @author <a href="mailto:dev@mina.apache.org">Apache MINA SSHD Project</a>
  */
 public class GitSshdSession extends AbstractLoggingBean implements RemoteSession {
+
+    private static final Map version2Env = Collections.singletonMap(PROTOCOL_ENVIRONMENT_VARIABLE, VERSION_2_REQUEST);
 
     private final SshClient client;
     private final ClientSession session;
@@ -128,7 +133,7 @@ public class GitSshdSession extends AbstractLoggingBean implements RemoteSession
             log.trace("exec({}) session={}, timeout={} sec.", commandName, session, timeout);
         }
 
-        ChannelExec channel = session.createExecChannel(commandName);
+        ChannelExec channel = session.createExecChannel(commandName, null, version2Env);
         if (traceEnabled) {
             log.trace("exec({}) session={} - open channel", commandName, session);
         }

--- a/sshd-git/src/main/java/org/apache/sshd/git/transport/GitSshdSession.java
+++ b/sshd-git/src/main/java/org/apache/sshd/git/transport/GitSshdSession.java
@@ -134,7 +134,8 @@ public class GitSshdSession extends AbstractLoggingBean implements RemoteSession
 
         ChannelExec channel;
         Optional<String> protocolVer = GitModuleProperties.GIT_PROTOCOL_VERSION.get(session);
-        if (protocolVer.isPresent()) {
+        String protocol = protocolVer.orElse(null);
+        if (GenericUtils.isNotBlank(protocol)) {
             Map<String, String> env = Collections.singletonMap(
                     GitProtocolConstants.PROTOCOL_ENVIRONMENT_VARIABLE, protocolVer.get());
             channel = session.createExecChannel(commandName, null, env);

--- a/sshd-git/src/test/java/org/apache/sshd/git/pack/GitPackCommandTest.java
+++ b/sshd-git/src/test/java/org/apache/sshd/git/pack/GitPackCommandTest.java
@@ -24,8 +24,11 @@ import java.util.Collections;
 
 import com.jcraft.jsch.JSch;
 import org.apache.sshd.client.SshClient;
+import org.apache.sshd.common.PropertyResolver;
+import org.apache.sshd.common.PropertyResolverUtils;
 import org.apache.sshd.common.util.OsUtils;
 import org.apache.sshd.git.GitLocationResolver;
+import org.apache.sshd.git.GitModuleProperties;
 import org.apache.sshd.git.transport.GitSshdSessionFactory;
 import org.apache.sshd.server.SshServer;
 import org.apache.sshd.server.auth.password.AcceptAllPasswordAuthenticator;
@@ -36,6 +39,7 @@ import org.apache.sshd.util.test.JSchLogger;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.lib.Constants;
 import org.eclipse.jgit.transport.CredentialsProvider;
+import org.eclipse.jgit.transport.GitProtocolConstants;
 import org.eclipse.jgit.transport.SshSessionFactory;
 import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider;
 import org.junit.Assume;
@@ -108,6 +112,15 @@ public class GitPackCommandTest extends BaseTestSupport {
 
                     git.pull().setRebase(true).call();
                     assertTrue("Client not started after rebase", client.isStarted());
+
+                    PropertyResolver useProtocolV2 = PropertyResolverUtils
+                            .toPropertyResolver(
+                                    Collections.singletonMap(GitModuleProperties.GIT_PROTOCOL_VERSION.getName(),
+                                            GitProtocolConstants.VERSION_2_REQUEST));
+                    client.setParentPropertyResolver(useProtocolV2);
+                    git.fetch().call();
+                    assertTrue("Client not started after fetch using GIT_PROTOCOL='version=2' env. variable",
+                            client.isStarted());
                 } finally {
                     client.stop();
                 }


### PR DESCRIPTION
Support for protocol-v2. GIT_PROTOCOL environment variable is set to "version=2" in a session.

The UploadPack is modified to accept the variable.

https://github.com/apache/mina-sshd/issues/429