### PR TITLE
GH-427: Read initial ACK on channel open prior to direct stream upload & close streams prior to exit code handling 

### DIFF
--- a/sshd-scp/src/main/java/org/apache/sshd/scp/client/DefaultScpClient.java
+++ b/sshd-scp/src/main/java/org/apache/sshd/scp/client/DefaultScpClient.java
@@ -118,9 +118,10 @@ public class DefaultScpClient extends AbstractScpClient {
                 // NOTE: we use a mock file system since we expect no invocations for it
                 ScpHelper helper = new ScpHelper(session, invOut, invIn, new MockFileSystem(remote), opener, listener);
                 Path mockPath = new MockPath(remote);
-                helper.readAck(false);
-                helper.sendStream(new DefaultScpStreamResolver(name, mockPath, perms, time, size, local, cmd),
-                        options.contains(Option.PreserveAttributes), ScpHelper.DEFAULT_SEND_BUFFER_SIZE);
+                DefaultScpStreamResolver resolver = new DefaultScpStreamResolver(name, mockPath, perms, time, size, local, cmd);
+                helper.readAndValidateOperationAck(cmd, resolver);
+                helper.sendStream(resolver, options.contains(Option.PreserveAttributes),
+                        ScpHelper.DEFAULT_SEND_BUFFER_SIZE);
             }
             handleCommandExitStatus(cmd, channel);
         } finally {

--- a/sshd-scp/src/main/java/org/apache/sshd/scp/common/ScpHelper.java
+++ b/sshd-scp/src/main/java/org/apache/sshd/scp/common/ScpHelper.java
@@ -411,12 +411,8 @@ public class ScpHelper extends AbstractLoggingBean implements SessionHolder<Sess
     }
 
     public void send(Collection<String> paths, boolean recursive, boolean preserve, int bufferSize) throws IOException {
-        ScpAckInfo ackInfo = readAck(false);
         boolean debugEnabled = log.isDebugEnabled();
-        if (debugEnabled) {
-            log.debug("send({}) ACK={}", paths, ackInfo);
-        }
-        validateOperationReadyCode("send", "Paths", ackInfo);
+        readAndValidateOperationAck("send", "Paths");
 
         LinkOption[] options = IoUtils.getLinkOptions(true);
         for (String pattern : paths) {
@@ -464,11 +460,7 @@ public class ScpHelper extends AbstractLoggingBean implements SessionHolder<Sess
 
     public void sendPaths(Collection<? extends Path> paths, boolean recursive, boolean preserve, int bufferSize)
             throws IOException {
-        ScpAckInfo ackInfo = readAck(false);
-        if (log.isDebugEnabled()) {
-            log.debug("sendPaths({}) ACK={}", paths, ackInfo);
-        }
-        validateOperationReadyCode("sendPaths", "Paths", ackInfo);
+        readAndValidateOperationAck("sendPaths", "Paths");
 
         LinkOption[] options = IoUtils.getLinkOptions(true);
         for (Path file : paths) {
@@ -748,6 +740,15 @@ public class ScpHelper extends AbstractLoggingBean implements SessionHolder<Sess
 
     public ScpAckInfo readAck(boolean canEof) throws IOException {
         return ScpAckInfo.readAck(in, csIn, canEof);
+    }
+
+    public void readAndValidateOperationAck(String cmd, Object location) throws IOException {
+        ScpAckInfo ackInfo = readAck(false);
+        boolean debugEnabled = log.isDebugEnabled();
+        if (debugEnabled) {
+            log.debug("readAndValidateOperationAck({}) ACK={}", location, ackInfo);
+        }
+        validateOperationReadyCode(cmd, location, ackInfo);
     }
 
     @Override


### PR DESCRIPTION
Fixes GH-427.

- Ensures that the initial ACK sent upon creating the channel is processed prior to sending the payload stream.
- Channel  IO streams are first closed to trigger EOF prior to handling the exit code.
- `DefaultScpClient.upload(InputStream local, ...)` no longer hits exit status timeout (5 seconds by default) on each invocation.
- This can be observed by running `ScpTest.testStreamsUploadAndDownload`.