### PR TITLE
Synchronize not thread safe java.security.KeyPairGenerator.generateKe…

### DIFF
--- a/sshd-core/src/main/java/org/apache/sshd/common/kex/MontgomeryCurve.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/kex/MontgomeryCurve.java
@@ -153,7 +153,9 @@ public enum MontgomeryCurve implements KeySizeIndicator, OptionalFeature {
     }
 
     public KeyPair generateKeyPair() {
-        return keyPairGenerator.generateKeyPair();
+        synchronized (this) {
+            return keyPairGenerator.generateKeyPair();
+        }
     }
 
     public byte[] encode(PublicKey key) throws InvalidKeyException {


### PR DESCRIPTION
…yPair() method call.

The keyPairGenerator object is a bouncycastle implementation of the java.security.KeyPairGenerator class. The generateKeyPair method in class org.bouncycastle.jcajce.provider.asymmetric.edec.KeyPairGeneratorSpi is not thread safe, so calling the generateKeyPair method must be synchronized, otherwise calling this method by multiple threads will often cause a NullPointerException due to a race conditions.

Consider the following scenario: two threads simultaneously reach the generateKeyPair() method in class org.bouncycastle.jcajce.provider.asymmetric.edec.KeyPairGeneratorSpi. Thread one performs the if (!initialised) check. The "initialised" variable is false. Therefore, the setupGenerator(algorithm) method is executed. In the setupGenerator method, the "initialised" variable is assigned true at the very beginning. And at this moment, execution of the thread one is suspended and execution of the thread two continues. Thread two evaluates the "initialised" variable. The variable is true therefore thread two executes the further command AsymmetricCipherKeyPair kp = generator.generateKeyPair(); the generator is not yet correctly initialized. Thread two continues its execution and eventually throws a NullPointerException, which is the result of the generator not being initialized correctly because the setupGenerator method was not executed to completion even though the initialised variable was already set to true. The callstack looks like this:
Caused by: java.lang.NullPointerException
at org.bouncycastle.math.ec.rfc7748.X25519.generatePrivateKey(X25519.java:54) at org.bouncycastle.crypto.params.X25519PrivateKeyParameters.<init>(X25519PrivateKeyParameters.java:24) at org.bouncycastle.crypto.generators.X25519KeyPairGenerator.generateKeyPair(X25519KeyPairGenerator.java:23) at org.bouncycastle.jcajce.provider.asymmetric.edec.KeyPairGeneratorSpi.generateKeyPair(KeyPairGeneratorSpi.java:193) at java.base/java.security.KeyPairGenerator$Delegate.generateKeyPair(KeyPairGenerator.java:722) at org.apache.sshd.common.kex.MontgomeryCurve.generateKeyPair(MontgomeryCurve.java:156) The org.bouncycastle.math.ec.rfc7748.X25519.generatePrivateKey(SecureRandom random, byte[] k) method executes the random.nextBytes(k) instruction. In this case, the "random" argument is null, since the setupGenerator(algorithm) method was not completed yet. The result is a NullPointerException.