### PR TITLE
change client start condition in sshd-spring-sftp

### DIFF
--- a/sshd-spring-sftp/src/main/java/org/apache/sshd/sftp/spring/integration/ApacheSshdSftpSessionFactory.java
+++ b/sshd-spring-sftp/src/main/java/org/apache/sshd/sftp/spring/integration/ApacheSshdSftpSessionFactory.java
@@ -306,7 +306,7 @@ public class ApacheSshdSftpSessionFactory
             setSshClient(client);
         }
 
-        if (!client.isOpen()) {
+        if (!client.isStarted()) {
             log.info("afterPropertiesSet() - starting client");
             client.start();
             log.info("afterPropertiesSet() - client started");


### PR DESCRIPTION
The condition for starting the sshclient should be whether the client is started, rather than whether it is opened，