### PR TITLE
Switch uses of JSch library to the com.github.mwiede:jsch fork

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -504,14 +504,9 @@
             </dependency>
 
             <dependency>
-                <groupId>com.jcraft</groupId>
+                <groupId>com.github.mwiede</groupId>
                 <artifactId>jsch</artifactId>
-                <version>0.1.55</version>
-            </dependency>
-            <dependency>
-                <groupId>com.jcraft</groupId>
-                <artifactId>jzlib</artifactId>
-                <version>1.1.3</version>
+                <version>0.2.17</version>
             </dependency>
 
                 <!-- Transitive dependencies by various 3rd party packages -->

--- a/sshd-cli/pom.xml
+++ b/sshd-cli/pom.xml
@@ -92,13 +92,8 @@
         </dependency>
 
         <dependency>
-            <groupId>com.jcraft</groupId>
+            <groupId>com.github.mwiede</groupId>
             <artifactId>jsch</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.jcraft</groupId>
-            <artifactId>jzlib</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/sshd-core/pom.xml
+++ b/sshd-core/pom.xml
@@ -81,13 +81,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.jcraft</groupId>
+            <groupId>com.github.mwiede</groupId>
             <artifactId>jsch</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.jcraft</groupId>
-            <artifactId>jzlib</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -246,6 +241,8 @@
                                 <configuration>
                                     <reportsDirectory>${project.build.directory}/surefire-reports-jce</reportsDirectory>
                                     <systemProperties>
+                                        <!-- Enable using deprecated ssh-rsa signature keys with JSch 0.2.x -->
+                                        <jsch.server_host_key>ssh-ed25519,ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521,rsa-sha2-512,rsa-sha2-256,ssh-rsa</jsch.server_host_key>
                                         <org.apache.sshd.security.provider.BC.enabled>false</org.apache.sshd.security.provider.BC.enabled>
                                         <!-- deprecated -->
                                         <org.apache.sshd.registerBouncyCastle>false</org.apache.sshd.registerBouncyCastle>

--- a/sshd-core/src/test/java/org/apache/sshd/common/compression/CompressionTest.java
+++ b/sshd-core/src/test/java/org/apache/sshd/common/compression/CompressionTest.java
@@ -121,8 +121,8 @@ public class CompressionTest extends BaseTestSupport {
         String name = factory.getName();
         JSch.setConfig("compression.s2c", name);
         JSch.setConfig("compression.c2s", name);
-        JSch.setConfig("zlib", com.jcraft.jsch.jcraft.Compression.class.getName());
-        JSch.setConfig("zlib@openssh.com", com.jcraft.jsch.jcraft.Compression.class.getName());
+        JSch.setConfig("zlib", com.jcraft.jsch.jzlib.Compression.class.getName());
+        JSch.setConfig("zlib@openssh.com", com.jcraft.jsch.jzlib.Compression.class.getName());
     }
 
     @After

--- a/sshd-core/src/test/java/org/apache/sshd/server/auth/AsyncAuthInteractiveTest.java
+++ b/sshd-core/src/test/java/org/apache/sshd/server/auth/AsyncAuthInteractiveTest.java
@@ -82,13 +82,10 @@ public class AsyncAuthInteractiveTest extends AsyncAuthTestBase {
             session.connect();
         } catch (JSchException e) {
             String reason = e.getMessage();
-            switch (reason) {
-                case "Auth cancel":
-                case "Auth fail":
-                    return false;
-                default:
-                    throw e;
+            if (reason != null && (reason.startsWith("Auth cancel") || reason.startsWith("Auth fail"))) {
+                return false;
             }
+            throw e;
         }
 
         try {

--- a/sshd-core/src/test/java/org/apache/sshd/server/auth/AsyncAuthTest.java
+++ b/sshd-core/src/test/java/org/apache/sshd/server/auth/AsyncAuthTest.java
@@ -18,8 +18,6 @@
  */
 package org.apache.sshd.server.auth;
 
-import java.util.Objects;
-
 import com.jcraft.jsch.ChannelShell;
 import com.jcraft.jsch.JSch;
 import com.jcraft.jsch.JSchException;
@@ -86,7 +84,7 @@ public class AsyncAuthTest extends AsyncAuthTestBase {
             session.connect();
         } catch (JSchException e) {
             String reason = e.getMessage();
-            if (Objects.equals(reason, "Auth cancel")) {
+            if (reason != null && reason.startsWith("Auth cancel")) {
                 return false;
             } else {
                 throw e;

--- a/sshd-git/pom.xml
+++ b/sshd-git/pom.xml
@@ -117,7 +117,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.jcraft</groupId>
+            <groupId>com.github.mwiede</groupId>
             <artifactId>jsch</artifactId>
             <scope>test</scope>
         </dependency>

--- a/sshd-mina/pom.xml
+++ b/sshd-mina/pom.xml
@@ -75,13 +75,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.jcraft</groupId>
+            <groupId>com.github.mwiede</groupId>
             <artifactId>jsch</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.jcraft</groupId>
-            <artifactId>jzlib</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/sshd-netty/pom.xml
+++ b/sshd-netty/pom.xml
@@ -96,13 +96,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.jcraft</groupId>
+            <groupId>com.github.mwiede</groupId>
             <artifactId>jsch</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.jcraft</groupId>
-            <artifactId>jzlib</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/sshd-scp/pom.xml
+++ b/sshd-scp/pom.xml
@@ -56,18 +56,13 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.jcraft</groupId>
+            <groupId>com.github.mwiede</groupId>
             <artifactId>jsch</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>ch.ethz.ganymed</groupId>
             <artifactId>ganymed-ssh2</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.jcraft</groupId>
-            <artifactId>jzlib</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -105,6 +100,8 @@
                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
                     <reportsDirectory>${project.build.directory}/surefire-reports-nio2</reportsDirectory>
                     <systemProperties>
+                        <!-- Enable using deprecated ssh-rsa signature keys with JSch 0.2.x -->
+                        <jsch.server_host_key>ssh-ed25519,ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521,rsa-sha2-512,rsa-sha2-256,ssh-rsa</jsch.server_host_key>
                         <org.apache.sshd.common.io.IoServiceFactoryFactory>org.apache.sshd.common.io.nio2.Nio2ServiceFactoryFactory</org.apache.sshd.common.io.IoServiceFactoryFactory>
                     </systemProperties>
                 </configuration>

--- a/sshd-sftp/pom.xml
+++ b/sshd-sftp/pom.xml
@@ -56,13 +56,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.jcraft</groupId>
+            <groupId>com.github.mwiede</groupId>
             <artifactId>jsch</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.jcraft</groupId>
-            <artifactId>jzlib</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -112,6 +107,8 @@
                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
                     <reportsDirectory>${project.build.directory}/surefire-reports-nio2</reportsDirectory>
                     <systemProperties>
+                        <!-- Enable using deprecated ssh-rsa signature keys with JSch 0.2.x -->
+                        <jsch.server_host_key>ssh-ed25519,ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521,rsa-sha2-512,rsa-sha2-256,ssh-rsa</jsch.server_host_key>
                         <org.apache.sshd.common.io.IoServiceFactoryFactory>org.apache.sshd.common.io.nio2.Nio2ServiceFactoryFactory</org.apache.sshd.common.io.IoServiceFactoryFactory>
                     </systemProperties>
                 </configuration>

--- a/sshd-spring-sftp/pom.xml
+++ b/sshd-spring-sftp/pom.xml
@@ -75,13 +75,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.jcraft</groupId>
+            <groupId>com.github.mwiede</groupId>
             <artifactId>jsch</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.jcraft</groupId>
-            <artifactId>jzlib</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
The original Jcraft version of the JSch library has not seen updates in over a decade. The current fork with the most active maintenance is the com.github.mwiede:jsch library and it is largely compatible with the original but with secure defaults. It also absorbed the Jzlib implementation in its own code base and eliminated the need to have the extra dependencies.

As this is only a test dependency for this code base I feel adding this update is an improvement.