### PR TITLE
Fix Android detection false negative

### DIFF
--- a/sshd-common/src/main/java/org/apache/sshd/common/util/OsUtils.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/util/OsUtils.java
@@ -224,7 +224,8 @@ public final class OsUtils {
             }
 
             for (String p : detectionProps) {
-                if (detector.test(p)) {
+                String detectionPropValue = System.getProperty(p);
+                if (detector.test(detectionPropValue)) {
                     flagHolder.set(Boolean.TRUE);
                     return true;
                 }


### PR DESCRIPTION
`p` is the property name like `java.vendor`, and this wasn't matching