### PR TITLE
Add missing U2F {ed25519,ecdsa}-sk public key equality methods

### DIFF
--- a/sshd-common/src/main/java/org/apache/sshd/common/config/keys/u2f/SkED25519PublicKey.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/config/keys/u2f/SkED25519PublicKey.java
@@ -18,6 +18,7 @@
  */
 package org.apache.sshd.common.config.keys.u2f;
 
+import java.util.Objects;
 import net.i2p.crypto.eddsa.EdDSAPublicKey;
 
 public class SkED25519PublicKey implements SecurityKeyPublicKey<EdDSAPublicKey> {
@@ -73,5 +74,28 @@ public class SkED25519PublicKey implements SecurityKeyPublicKey<EdDSAPublicKey> 
                + ", noTouchRequired=" + isNoTouchRequired()
                + ", delegatePublicKey=" + getDelegatePublicKey()
                + "]";
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(appName, noTouchRequired, delegatePublicKey);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        if (this == obj) {
+            return true;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+
+        SkED25519PublicKey other = (SkED25519PublicKey) obj;
+        return Objects.equals(this.appName, other.appName)
+            && this.noTouchRequired == other.noTouchRequired
+            && Objects.equals(this.delegatePublicKey, other.delegatePublicKey);
     }
 }

--- a/sshd-common/src/main/java/org/apache/sshd/common/config/keys/u2f/SkEcdsaPublicKey.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/config/keys/u2f/SkEcdsaPublicKey.java
@@ -18,6 +18,7 @@
  */
 package org.apache.sshd.common.config.keys.u2f;
 
+import java.util.Objects;
 import java.security.interfaces.ECPublicKey;
 
 public class SkEcdsaPublicKey implements SecurityKeyPublicKey<ECPublicKey> {
@@ -73,5 +74,28 @@ public class SkEcdsaPublicKey implements SecurityKeyPublicKey<ECPublicKey> {
                + ", noTouchRequired=" + isNoTouchRequired()
                + ", delegatePublicKey=" + getDelegatePublicKey()
                + "]";
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(appName, noTouchRequired, delegatePublicKey);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        if (this == obj) {
+            return true;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+
+        SkEcdsaPublicKey other = (SkEcdsaPublicKey) obj;
+        return Objects.equals(this.appName, other.appName)
+            && this.noTouchRequired == other.noTouchRequired
+            && Objects.equals(this.delegatePublicKey, other.delegatePublicKey);
     }
 }


### PR DESCRIPTION
This fixes a bug where Gerrit Code Review (3.8.2, at least) does not properly admit U2F based SSH keys, and they get rejected mysteriously on authentication.