### PR TITLE
sftp readdir: determine file type from longname

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,6 +33,7 @@
 ## Bug Fixes
 
 * [GH-455](https://github.com/apache/mina-sshd/issues/455) Fix `BaseCipher`: make sure all bytes are processed
+* [GH-489](https://github.com/apache/mina-sshd/issues/489) SFTP v3 client: better file type determination
 
 ## New Features
 

--- a/sshd-common/src/main/java/org/apache/sshd/common/util/io/DirectoryScanner.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/util/io/DirectoryScanner.java
@@ -132,6 +132,8 @@ public class DirectoryScanner extends PathScanningMatcher {
      */
     protected Path basedir;
 
+    private boolean filesOnly = true;
+
     public DirectoryScanner() {
         super();
     }
@@ -147,6 +149,25 @@ public class DirectoryScanner extends PathScanningMatcher {
     public DirectoryScanner(Path dir, Collection<String> includes) {
         setBasedir(dir);
         setIncludes(includes);
+    }
+
+    /**
+     * Tells whether the scanner is set to return only files (the default).
+     *
+     * @return {@code true} if items that are not regular files or subdirectories shall be omitted; {@code false}
+     *         otherwise
+     */
+    public boolean isFilesOnly() {
+        return filesOnly;
+    }
+
+    /**
+     * Sets whether the scanner shall return only regular files and subdirectories.
+     *
+     * @param filesOnly whether to skip all items that are not regular files
+     */
+    public void setFilesOnly(boolean filesOnly) {
+        this.filesOnly = filesOnly;
     }
 
     /**
@@ -230,7 +251,7 @@ public class DirectoryScanner extends PathScanningMatcher {
                     } else if (couldHoldIncluded(name)) {
                         scandir(rootDir, p, filesList);
                     }
-                } else if (Files.isRegularFile(p)) {
+                } else if (!filesOnly || Files.isRegularFile(p)) {
                     if (isIncluded(name)) {
                         filesList.add(p);
                     }

--- a/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/fs/SftpClientDirectoryScanner.java
+++ b/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/fs/SftpClientDirectoryScanner.java
@@ -42,7 +42,10 @@ import org.apache.sshd.sftp.client.SftpClient.DirEntry;
  * @author <a href="mailto:dev@mina.apache.org">Apache MINA SSHD Project</a>
  */
 public class SftpClientDirectoryScanner extends PathScanningMatcher {
+
     protected String basedir;
+
+    private boolean filesOnly = true;
 
     public SftpClientDirectoryScanner() {
         this(true);
@@ -66,6 +69,25 @@ public class SftpClientDirectoryScanner extends PathScanningMatcher {
 
         setBasedir(dir);
         setIncludes(includes);
+    }
+
+    /**
+     * Tells whether the scanner is set to return only files and links (the default).
+     *
+     * @return {@code true} if items that are not regular files or subdirectories shall be omitted; {@code false}
+     *         otherwise
+     */
+    public boolean isFilesOnly() {
+        return filesOnly;
+    }
+
+    /**
+     * Sets whether the scanner shall return only regular files, links, and subdirectories.
+     *
+     * @param filesOnly whether to skip all items that are not regular files, links, or subdirectories
+     */
+    public void setFilesOnly(boolean filesOnly) {
+        this.filesOnly = filesOnly;
     }
 
     public String getBasedir() {
@@ -171,7 +193,7 @@ public class SftpClientDirectoryScanner extends PathScanningMatcher {
                 } else if (couldHoldIncluded(name)) {
                     scandir(client, createRelativePath(rootDir, name), createRelativePath(parent, name), filesList);
                 }
-            } else if (attrs.isRegularFile()) {
+            } else if (!filesOnly || attrs.isRegularFile() || attrs.isSymbolicLink()) {
                 if (isIncluded(name)) {
                     filesList.add(new ScanDirEntry(createRelativePath(rootDir, name), createRelativePath(parent, name), de));
                 }

--- a/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/impl/AbstractSftpClient.java
+++ b/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/impl/AbstractSftpClient.java
@@ -378,7 +378,7 @@ public abstract class AbstractSftpClient
                     longName = getReferencedName(cmd, buffer, nameIndex.getAndIncrement());
                 }
 
-                Attributes attrs = readAttributes(cmd, buffer, nameIndex);
+                Attributes attrs = SftpHelper.complete(readAttributes(cmd, buffer, nameIndex), longName);
                 Boolean indicator = SftpHelper.getEndOfListIndicatorValue(buffer, version);
                 // TODO decide what to do if not-null and not TRUE
                 if (log.isTraceEnabled()) {
@@ -898,12 +898,11 @@ public abstract class AbstractSftpClient
                         longName = getReferencedName(cmd, buffer, nameIndex.getAndIncrement());
                     }
 
-                    Attributes attrs = readAttributes(cmd, buffer, nameIndex);
+                    Attributes attrs = SftpHelper.complete(readAttributes(cmd, buffer, nameIndex), longName);
                     if (traceEnabled) {
                         log.trace("checkDirResponse({})[id={}][{}/{}] ({})[{}]: {}", channel, response.getId(), index, count,
                                 name, longName, attrs);
                     }
-
                     entries.add(new DirEntry(name, longName, attrs));
                 }
 

--- a/sshd-sftp/src/test/java/org/apache/sshd/sftp/common/SftpHelperTest.java
+++ b/sshd-sftp/src/test/java/org/apache/sshd/sftp/common/SftpHelperTest.java
@@ -1,0 +1,165 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sshd.sftp.common;
+
+import org.apache.sshd.sftp.client.SftpClient.Attributes;
+import org.apache.sshd.util.test.JUnitTestSupport;
+import org.apache.sshd.util.test.NoIoTestCase;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runners.MethodSorters;
+
+/**
+ * @author <a href="mailto:dev@mina.apache.org">Apache MINA SSHD Project</a>
+ */
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+@Category({ NoIoTestCase.class })
+public class SftpHelperTest extends JUnitTestSupport {
+
+    public SftpHelperTest() {
+        super();
+    }
+
+    @Test
+    public void testPermissionsToFile() {
+        assertEquals(SftpConstants.SSH_FILEXFER_TYPE_SOCKET, SftpHelper.permissionsToFileType(SftpConstants.S_IFSOCK));
+    }
+
+    @Test
+    public void testCompleteAttributesNoLongName() {
+        Attributes attrs = new Attributes();
+        attrs.setType(SftpConstants.SSH_FILEXFER_TYPE_UNKNOWN);
+        attrs.setPermissions(0x1B6);
+        attrs = SftpHelper.complete(attrs, null);
+        assertEquals(SftpConstants.SSH_FILEXFER_TYPE_UNKNOWN, attrs.getType());
+        assertEquals(0x1B6, attrs.getPermissions());
+    }
+
+    @Test
+    public void testCompleteAttributesLongName() {
+        Attributes attrs = new Attributes();
+        attrs.setType(SftpConstants.SSH_FILEXFER_TYPE_UNKNOWN);
+        attrs.setPermissions(0x1B6);
+        attrs = SftpHelper.complete(attrs, "-rw-rw-rw-   1     root     root     1944 Apr 24 14:58 demo.csv");
+        assertEquals(SftpConstants.SSH_FILEXFER_TYPE_REGULAR, attrs.getType());
+        assertEquals(0x1B6 | SftpConstants.S_IFREG, attrs.getPermissions());
+    }
+
+    @Test
+    public void testCompleteAttributesLongNameDir() {
+        Attributes attrs = new Attributes();
+        attrs.setType(SftpConstants.SSH_FILEXFER_TYPE_UNKNOWN);
+        attrs.setPermissions(0x1FF);
+        attrs = SftpHelper.complete(attrs, "drwxrwxrwx   1     root     root     1944 Apr 24 14:58 demo.csv");
+        assertEquals(SftpConstants.SSH_FILEXFER_TYPE_DIRECTORY, attrs.getType());
+        assertEquals(0x1FF | SftpConstants.S_IFDIR, attrs.getPermissions());
+    }
+
+    @Test
+    public void testCompleteAttributesLongNameT() {
+        Attributes attrs = new Attributes();
+        attrs.setType(SftpConstants.SSH_FILEXFER_TYPE_UNKNOWN);
+        attrs.setPermissions(0x1FD);
+        attrs = SftpHelper.complete(attrs, "drwxrwxrwT   1     root     root     1944 Apr 24 14:58 demo.csv");
+        assertEquals(SftpConstants.SSH_FILEXFER_TYPE_DIRECTORY, attrs.getType());
+        assertEquals(0x1FD | SftpConstants.S_IFDIR, attrs.getPermissions());
+    }
+
+    @Test
+    public void testCompleteAttributesLongNameS() {
+        Attributes attrs = new Attributes();
+        attrs.setType(SftpConstants.SSH_FILEXFER_TYPE_UNKNOWN);
+        attrs.setPermissions(0x1BD);
+        attrs = SftpHelper.complete(attrs, "-rw-rwSrw-   1     root     root     1944 Apr 24 14:58 demo.csv");
+        assertEquals(SftpConstants.SSH_FILEXFER_TYPE_REGULAR, attrs.getType());
+        assertEquals(0x1BD | SftpConstants.S_IFREG, attrs.getPermissions());
+    }
+
+    @Test
+    public void testCompleteAttributesLongNameLink() {
+        Attributes attrs = new Attributes();
+        attrs.setType(SftpConstants.SSH_FILEXFER_TYPE_UNKNOWN);
+        attrs.setPermissions(0x1FF);
+        attrs = SftpHelper.complete(attrs, "lrwxrwxrwx   1     root     root     1944 Apr 24 14:58 demo.csv");
+        assertEquals(SftpConstants.SSH_FILEXFER_TYPE_SYMLINK, attrs.getType());
+        assertEquals(0x1FF | SftpConstants.S_IFLNK, attrs.getPermissions());
+    }
+
+    @Test
+    public void testCompleteAttributesSolarWindsLongName() {
+        Attributes attrs = new Attributes();
+        attrs.setType(SftpConstants.SSH_FILEXFER_TYPE_UNKNOWN);
+        attrs.setPermissions(0x1B6);
+        attrs = SftpHelper.complete(attrs, "-rw-rw-rw   1     root     root     1944 Apr 24 14:58 demo.csv");
+        assertEquals(SftpConstants.SSH_FILEXFER_TYPE_REGULAR, attrs.getType());
+        assertEquals(0x1B6 | SftpConstants.S_IFREG, attrs.getPermissions());
+    }
+
+    @Test
+    public void testCompleteAttributesWinLongName() {
+        Attributes attrs = new Attributes();
+        attrs.setType(SftpConstants.SSH_FILEXFER_TYPE_UNKNOWN);
+        attrs.setPermissions(0x1B6);
+        attrs = SftpHelper.complete(attrs, "-rw-******   1     root     root     1944 Apr 24 14:58 demo.csv");
+        assertEquals(SftpConstants.SSH_FILEXFER_TYPE_REGULAR, attrs.getType());
+        assertEquals(0x1B6 | SftpConstants.S_IFREG, attrs.getPermissions());
+    }
+
+    @Test
+    public void testCompleteAttributesOsxLongName() {
+        Attributes attrs = new Attributes();
+        attrs.setType(SftpConstants.SSH_FILEXFER_TYPE_UNKNOWN);
+        attrs.setPermissions(0x1B6);
+        attrs = SftpHelper.complete(attrs, "-rw-rw-rw-@   1     root     root     1944 Apr 24 14:58 demo.csv");
+        assertEquals(SftpConstants.SSH_FILEXFER_TYPE_REGULAR, attrs.getType());
+        assertEquals(0x1B6 | SftpConstants.S_IFREG, attrs.getPermissions());
+    }
+
+    @Test
+    public void testCompleteAttributesUnknownLongName() {
+        Attributes attrs = new Attributes();
+        attrs.setType(SftpConstants.SSH_FILEXFER_TYPE_UNKNOWN);
+        attrs.setPermissions(0x1B6);
+        attrs = SftpHelper.complete(attrs, "-demo.csv 1944 2024-04-24'T'14:58:01");
+        assertEquals(SftpConstants.SSH_FILEXFER_TYPE_UNKNOWN, attrs.getType());
+        assertEquals(0x1B6, attrs.getPermissions());
+    }
+
+    @Test
+    public void testCompleteAttributesBrokenLongName() {
+        Attributes attrs = new Attributes();
+        attrs.setType(SftpConstants.SSH_FILEXFER_TYPE_UNKNOWN);
+        attrs.setPermissions(0x1B6);
+        attrs = SftpHelper.complete(attrs, "rw-rw-rw-   1     root     root     1944 Apr 24 14:58 demo.csv");
+        assertEquals(SftpConstants.SSH_FILEXFER_TYPE_UNKNOWN, attrs.getType());
+        assertEquals(0x1B6, attrs.getPermissions());
+    }
+
+    @Test
+    public void testCompleteAttributesBrokenLongName2() {
+        Attributes attrs = new Attributes();
+        attrs.setType(SftpConstants.SSH_FILEXFER_TYPE_UNKNOWN);
+        attrs.setPermissions(0x1B6);
+        attrs = SftpHelper.complete(attrs, "Qrw-rw-rw-   1     root     root     1944 Apr 24 14:58 demo.csv");
+        assertEquals(SftpConstants.SSH_FILEXFER_TYPE_UNKNOWN, attrs.getType());
+        assertEquals(0x1B6, attrs.getPermissions());
+    }
+}


### PR DESCRIPTION
Some SFTP v3 servers do not include the file type flags in the permissions field of an SSH_FXP_NAME record. It this case use the "longname" field to extract this information, if possible.

Also give the SftpClientDirectoryScanner and the DirectoryScanner a flag to make them return not only regular files but also links and other items. (DirectoryScanner already returned links to regular files; SftpClientDirectoryScanner did not.)

Fixes #489.