### PR TITLE
[SSHD-1237] Handle keep-alive channel requests

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -42,6 +42,9 @@
 * [PR-476](https://github.com/apache/mina-sshd/pull/476) Fix Android detection
 * [PR-486](https://github.com/apache/mina-sshd/pull/486) Add missing `equals` and `hashCode` to U2F key classes
 
+
+* [SSHD-1237](https://issues.apache.org/jira/browse/SSHD-1237) Handle keep-alive _channel_ requests
+
 ## New Features
 
 ## Behavioral changes and enhancements

--- a/sshd-core/src/main/java/org/apache/sshd/common/channel/AbstractChannel.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/channel/AbstractChannel.java
@@ -358,6 +358,12 @@ public abstract class AbstractChannel extends AbstractInnerCloseable implements 
      */
     protected RequestHandler.Result handleInternalRequest(String req, boolean wantReply, Buffer buffer)
             throws IOException {
+        if (req.startsWith("keepalive@") || req.startsWith("keep-alive@")) {
+            if (log.isDebugEnabled()) {
+                log.debug("handleInternalRequest({})[want-reply={}] received keep-alive: {}", this, wantReply, req);
+            }
+            return RequestHandler.Result.ReplySuccess;
+        }
         if (log.isDebugEnabled()) {
             log.debug("handleInternalRequest({})[want-reply={}] unknown type: {}", this, wantReply, req);
         }


### PR DESCRIPTION
OpenSSH server sends keep-alive requests as channel requests if a channel is open. Handle these channel requests in the "last-resort" channel request handler.