### PR TITLE
GH-468: Handle excess data in SFTP read requests

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -49,6 +49,14 @@
 
 ## Behavioral changes and enhancements
 
+* [GH-468](https://github.com/apache/mina-sshd/issues/468) SFTP: validate length of data received: must not be more than requested
+
+SFTP read operations now check the amount of data they get back. If it's more than
+requested an exception is thrown. SFTP servers must never return more data than the
+client requested, but it appears that there are some that do so. If property
+`SftpModuleProperties.TOLERATE_EXCESS_DATA` is set to `true`, a warning is logged and
+such excess data is silently discarded.
+
 ## Potential compatibility issues
 
 ## Major Code Re-factoring

--- a/sshd-sftp/src/main/java/org/apache/sshd/sftp/SftpModuleProperties.java
+++ b/sshd-sftp/src/main/java/org/apache/sshd/sftp/SftpModuleProperties.java
@@ -251,6 +251,14 @@ public final class SftpModuleProperties {
             = Property.integer("sftp-max-readdir-data-size", 16 * 1024);
 
     /**
+     * Apparently some SFTP servers may return more data than requested in SFTP read requests. This is a violation of
+     * the SFTP protocol. If this flag is {@code true}, such excess data is ignored and a warning is logged. If the flag
+     * is {@code false} (the default), an exception is thrown. The flag can be set on an SSH session or on the
+     * {@link SftpClient#getClientChannel() client channel} of an {@link SftpClient}.
+     */
+    public static final Property<Boolean> TOLERATE_EXCESS_DATA = Property.bool("sftp-tolerate-excess-data", false);
+
+    /**
      * Force the use of a given sftp version
      */
     public static final Property<Integer> SFTP_VERSION

--- a/sshd-sftp/src/test/java/org/apache/sshd/sftp/client/SftpTest.java
+++ b/sshd-sftp/src/test/java/org/apache/sshd/sftp/client/SftpTest.java
@@ -387,6 +387,27 @@ public class SftpTest extends AbstractSftpClientTestSupport {
         }
     }
 
+    @Test
+    public void testEmptyFileDownload() throws Exception {
+        Assume.assumeTrue("Not sure appending to a file opened for reading works on Windows",
+                OsUtils.isUNIX() || OsUtils.isOSX());
+        Path targetPath = detectTargetFolder();
+        Path parentPath = targetPath.getParent();
+        Path lclSftp = CommonTestSupportUtils.resolve(targetPath, SftpConstants.SFTP_SUBSYSTEM_NAME, getClass().getSimpleName(),
+                getCurrentTestName());
+        Path testFile = assertHierarchyTargetFolderExists(lclSftp).resolve("file.bin");
+        byte[] expected = new byte[0];
+
+        Files.write(testFile, expected);
+
+        String file = CommonTestSupportUtils.resolveRelativeRemotePath(parentPath, testFile);
+        try (SftpClient sftp = createSingleSessionClient()) {
+            try (InputStream in = sftp.read(file)) {
+                assertEquals(-1, in.read());
+            }
+        }
+    }
+
     @Test // see extra fix for SSHD-538
     public void testNavigateBeyondRootFolder() throws Exception {
         Path rootLocation = Paths.get(OsUtils.isUNIX() ? "/" : "C:\\");


### PR DESCRIPTION
Some SFTP servers appear to return sometimes more data than requested. If that happened, it was possible that a downloaded file would be corrupted (size larger than expected, and some duplicated data inside the file).

By default, throw an exception if an SFTP server returns more data than requested. If property SftpModuleProperties.TOLERATE_EXCESS_DATA is set to true on the session or on the channel, discard such excess data and log a warning.

Avoid code duplication; unify SSH_FXP_READ response handling in AbstractSftpClient.