### PR TITLE
GH-461: Fix heartbeats with wantReply=true

### DIFF
--- a/sshd-common/src/main/java/org/apache/sshd/common/future/HasException.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/future/HasException.java
@@ -16,16 +16,20 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.sshd.common.io;
+package org.apache.sshd.common.future;
 
-import org.apache.sshd.common.future.HasException;
-import org.apache.sshd.common.future.SshFuture;
-import org.apache.sshd.common.future.VerifiableFuture;
+/**
+ * Something that may have a failure exception.
+ *
+ * @author <a href="mailto:dev@mina.apache.org">Apache MINA SSHD Project</a>
+ */
+public interface HasException {
 
-public interface IoWriteFuture extends HasException, SshFuture<IoWriteFuture>, VerifiableFuture<IoWriteFuture> {
     /**
-     * @return <tt>true</tt> if the write operation is finished successfully.
+     * Returns the cause of the failure.
+     *
+     * @return the {@link Throwable} of the failure, or {@code null} if not failed (yet).
      */
-    boolean isWritten();
+    Throwable getException();
 
 }

--- a/sshd-common/src/main/java/org/apache/sshd/common/future/WithException.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/future/WithException.java
@@ -23,14 +23,7 @@ package org.apache.sshd.common.future;
  *
  * @author <a href="mailto:dev@mina.apache.org">Apache MINA SSHD Project</a>
  */
-public interface WithException {
-
-    /**
-     * Returns the cause of the failure.
-     *
-     * @return the {@link Throwable} of the failure, or {@code null} if not failed (yet).
-     */
-    Throwable getException();
+public interface WithException extends HasException {
 
     /**
      * Sets the exception that caused the operation to fail.

--- a/sshd-core/src/main/java/org/apache/sshd/common/future/GlobalRequestFuture.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/future/GlobalRequestFuture.java
@@ -30,7 +30,7 @@ import org.apache.sshd.common.util.buffer.Buffer;
  * @see org.apache.sshd.common.session.Session#request(Buffer, String, ReplyHandler)
  */
 public class GlobalRequestFuture extends DefaultSshFuture<GlobalRequestFuture>
-        implements SshFutureListener<IoWriteFuture> {
+        implements HasException, SshFutureListener<IoWriteFuture> {
 
     /**
      * A {@code ReplyHandler} is invoked asynchronously when the reply for a request with {@code want-reply = true} is
@@ -137,6 +137,7 @@ public class GlobalRequestFuture extends DefaultSshFuture<GlobalRequestFuture>
      *
      * @return a failure reason, or {@code null} if there isn't one or if the request did not fail
      */
+    @Override
     public Throwable getException() {
         Object value = getValue();
         if (value instanceof Throwable) {

--- a/sshd-core/src/main/java/org/apache/sshd/common/session/helpers/AbstractConnectionService.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/session/helpers/AbstractConnectionService.java
@@ -53,6 +53,7 @@ import org.apache.sshd.common.forward.Forwarder;
 import org.apache.sshd.common.forward.ForwarderFactory;
 import org.apache.sshd.common.forward.PortForwardingEventListener;
 import org.apache.sshd.common.forward.PortForwardingEventListenerManager;
+import org.apache.sshd.common.future.HasException;
 import org.apache.sshd.common.io.AbstractIoWriteFuture;
 import org.apache.sshd.common.io.IoWriteFuture;
 import org.apache.sshd.common.kex.KexState;
@@ -263,7 +264,7 @@ public abstract class AbstractConnectionService
         }
     }
 
-    protected void futureDone(IoWriteFuture future) {
+    protected void futureDone(HasException future) {
         Throwable t = future.getException();
         if (t != null) {
             Session session = getSession();

--- a/sshd-core/src/main/java/org/apache/sshd/core/CoreModuleProperties.java
+++ b/sshd-core/src/main/java/org/apache/sshd/core/CoreModuleProperties.java
@@ -162,9 +162,22 @@ public final class CoreModuleProperties {
     /**
      * Key used to indicate that the heartbeat request is also expecting a reply - time in <U>milliseconds</U> to wait
      * for the reply. If non-positive then no reply is expected (nor requested).
+     *
+     * @deprecated since 2.13.0, use {@link #HEARTBEAT_NO_REPLY_MAX} instead
      */
+    @Deprecated
     public static final Property<Duration> HEARTBEAT_REPLY_WAIT
             = Property.durationSec("heartbeat-reply-wait", Duration.ofMinutes(5));
+
+    /**
+     * Key to set the maximum number of heartbeat messages to send without having received a reply. If &gt; 0, heartbeat
+     * messages are sent with a flag that requires the peer to reply. The session will be killed if
+     * {@code HEARTBEAT_NO_REPLY_MAX} heartbeats have been sent without having received a reply. If &lt;= 0, heartbeat
+     * messages will be sent, but no reply is requested or expected, and the client will not kill the session.
+     *
+     * @since 2.13.0
+     */
+    public static final Property<Integer> HEARTBEAT_NO_REPLY_MAX = Property.integer("heartbeat-no-reply-max", 0);
 
     /**
      * Whether to ignore invalid identities files when pre-initializing the client session

--- a/sshd-core/src/test/java/org/apache/sshd/KeepAliveTest.java
+++ b/sshd-core/src/test/java/org/apache/sshd/KeepAliveTest.java
@@ -110,7 +110,7 @@ public class KeepAliveTest extends BaseTestSupport {
         // Restore default value
         CoreModuleProperties.IDLE_TIMEOUT.remove(sshd);
         CoreModuleProperties.HEARTBEAT_INTERVAL.remove(client);
-        CoreModuleProperties.HEARTBEAT_REPLY_WAIT.remove(client);
+        CoreModuleProperties.HEARTBEAT_NO_REPLY_MAX.remove(client);
     }
 
     @Test
@@ -198,7 +198,7 @@ public class KeepAliveTest extends BaseTestSupport {
                             }
                         }));
         CoreModuleProperties.HEARTBEAT_INTERVAL.set(client, HEARTBEAT);
-        CoreModuleProperties.HEARTBEAT_REPLY_WAIT.set(client, Duration.ofSeconds(5L));
+        CoreModuleProperties.HEARTBEAT_NO_REPLY_MAX.set(client, 1);
         try (ClientSession session = client.connect(getCurrentTestName(), TEST_LOCALHOST, port)
                 .verify(7L, TimeUnit.SECONDS)
                 .getSession()) {
@@ -229,8 +229,9 @@ public class KeepAliveTest extends BaseTestSupport {
                 return Result.Replied;
             }
         }));
-        CoreModuleProperties.HEARTBEAT_INTERVAL.set(client, HEARTBEAT);
-        CoreModuleProperties.HEARTBEAT_REPLY_WAIT.set(client, Duration.ofSeconds(1));
+        CoreModuleProperties.HEARTBEAT_INTERVAL.set(client, Duration.ofSeconds(1));
+        // CoreModuleProperties.HEARTBEAT_REPLY_WAIT.set(client, Duration.ofSeconds(1));
+        CoreModuleProperties.HEARTBEAT_NO_REPLY_MAX.set(client, 1);
         try (ClientSession session = client.connect(getCurrentTestName(), TEST_LOCALHOST, port).verify(CONNECT_TIMEOUT)
                 .getSession()) {
             session.addPasswordIdentity(getCurrentTestName());


### PR DESCRIPTION
Switch from a timeout model to the OpenSSH model: fail if there are more than a certain number of heartbeats for which no reply was received yet.

Fixes #461.