### PR TITLE
GH-318: fix proxyJumps

### DIFF
--- a/sshd-core/src/main/java/org/apache/sshd/core/CoreModuleProperties.java
+++ b/sshd-core/src/main/java/org/apache/sshd/core/CoreModuleProperties.java
@@ -789,6 +789,17 @@ public final class CoreModuleProperties {
     public static final Property<String> X11_BIND_HOST
             = Property.string("x11-fwd-bind-host", SshdSocketAddress.LOCALHOST_IPV4);
 
+    /**
+     * Configuration value for the maximum number of proxy jumps to allow in an SSH connection; by default 10. If there
+     * are more proxy jumps for an SSH connection, chances are that the proxy chain has a loop.
+     */
+    public static final Property<Integer> MAX_PROXY_JUMPS = Property.validating(Property.integer("max-proxy-jumps", 10), p -> {
+        if (p != null) {
+            ValidateUtils.checkTrue(p.intValue() > 0, "Maximum number of proxy jumps allowed must be greater than zero, is %d",
+                    p);
+        }
+    });
+
     private CoreModuleProperties() {
         throw new UnsupportedOperationException("No instance");
     }


### PR DESCRIPTION
Previous code only parsed the proxy jumps of the initial HostConfigEntry. However, if the last entry in that list has a HostConfigEntry that again has proxy jumps, these additional proxies must be added to the list. And so on.

To guard against proxy cascades with loops we limit the total number of proxies to at most 10. The limit is configurable through property CoreModuleProperties.MAX_PROXY_JUMPS.

Fixes #318.