### PR TITLE
Performance optimizations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -40,6 +40,8 @@
 
 ## New Features
 
+* New utility methods `SftpClient.put(Path localFile, String remoteFileName)` and `SftpClient.put(InputStream in, String remoteFileName)` facilitate SFTP file uploading.
+
 ## Potential compatibility issues
 
 ## Major Code Re-factoring

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -38,11 +38,23 @@
 
 ## Bug Fixes
 
+* [GH-524](https://github.com/apache/mina-sshd/issues/524) Performance improvements
+
 ## New Features
 
 * New utility methods `SftpClient.put(Path localFile, String remoteFileName)` and `SftpClient.put(InputStream in, String remoteFileName)` facilitate SFTP file uploading.
 
 ## Potential compatibility issues
+
+There is a new `SecurityProviderRegistrar` that is registered by default
+if there is a `SunJCE` security provider and that uses the AES and
+HmacSHA* implementations from `SunJCE` even if Bouncy Castle is also
+registered. `SunJCE` has native implementation, whereas Bouncy Castle
+may not.
+
+The new registrar has the name "SunJCEWrapper" and can be configured
+like any other registrar. It can be disabled via the system property
+`org.apache.sshd.security.provider.SunJCEWrapper.enabled=false`.
 
 ## Major Code Re-factoring
 

--- a/sshd-common/src/main/java/org/apache/sshd/common/cipher/ChaCha20Cipher.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/cipher/ChaCha20Cipher.java
@@ -144,11 +144,11 @@ public class ChaCha20Cipher implements Cipher {
         private static final int NONCE_OFFSET = 14;
         private static final int NONCE_BYTES = 8;
         private static final int NONCE_INTS = NONCE_BYTES / Integer.BYTES;
-        private static final int[] ENGINE_STATE_HEADER
-                = unpackSigmaString("expand 32-byte k".getBytes(StandardCharsets.US_ASCII));
+        private static final int[] ENGINE_STATE_HEADER = unpackSigmaString(
+                "expand 32-byte k".getBytes(StandardCharsets.US_ASCII));
 
-        protected final int[] x = new int[BLOCK_INTS];
         protected final int[] engineState = new int[BLOCK_INTS];
+        protected final byte[] keyStream = new byte[BLOCK_BYTES];
         protected final byte[] nonce = new byte[NONCE_BYTES];
         protected long initialNonce;
 
@@ -181,19 +181,12 @@ public class ChaCha20Cipher implements Cipher {
         // one-shot usage
         protected void crypt(byte[] in, int offset, int length, byte[] out, int outOffset) {
             while (length > 0) {
-                System.arraycopy(engineState, 0, x, 0, BLOCK_INTS);
-                permute(x);
+                setKeyStream(engineState);
                 int want = Math.min(BLOCK_BYTES, length);
-                for (int i = 0, j = 0; i < want; i += Integer.BYTES, j++) {
-                    int keyStream = engineState[j] + x[j];
-                    int take = Math.min(Integer.BYTES, length);
-                    int input = unpackIntLE(in, offset, take);
-                    int output = keyStream ^ input;
-                    packIntLE(output, out, outOffset, take);
-                    offset += take;
-                    outOffset += take;
-                    length -= take;
+                for (int i = 0; i < want; i++) {
+                    out[outOffset++] = (byte) (in[offset++] ^ keyStream[i]);
                 }
+                length -= want;
                 int lo = ++engineState[COUNTER_OFFSET];
                 if (lo == 0) {
                     // overflow
@@ -210,56 +203,122 @@ public class ChaCha20Cipher implements Cipher {
             return block;
         }
 
-        protected static void permute(int[] state) {
+        protected void setKeyStream(int[] engine) {
+            int x0 = engine[0];
+            int x1 = engine[1];
+            int x2 = engine[2];
+            int x3 = engine[3];
+            int x4 = engine[4];
+            int x5 = engine[5];
+            int x6 = engine[6];
+            int x7 = engine[7];
+            int x8 = engine[8];
+            int x9 = engine[9];
+            int x10 = engine[10];
+            int x11 = engine[11];
+            int x12 = engine[12];
+            int x13 = engine[13];
+            int x14 = engine[14];
+            int x15 = engine[15];
+
             for (int i = 0; i < 10; i++) {
-                columnRound(state);
-                diagonalRound(state);
+                // Columns
+                // Quarter round 0, 4, 8, 12
+                x0 += x4;
+                x12 = Integer.rotateLeft(x12 ^ x0, 16);
+                x8 += x12;
+                x4 = Integer.rotateLeft(x4 ^ x8, 12);
+                x0 += x4;
+                x12 = Integer.rotateLeft(x12 ^ x0, 8);
+                x8 += x12;
+                x4 = Integer.rotateLeft(x4 ^ x8, 7);
+                // Quarter round 1, 5, 9, 13
+                x1 += x5;
+                x13 = Integer.rotateLeft(x13 ^ x1, 16);
+                x9 += x13;
+                x5 = Integer.rotateLeft(x5 ^ x9, 12);
+                x1 += x5;
+                x13 = Integer.rotateLeft(x13 ^ x1, 8);
+                x9 += x13;
+                x5 = Integer.rotateLeft(x5 ^ x9, 7);
+                // Quarter round 2, 6, 10, 14
+                x2 += x6;
+                x14 = Integer.rotateLeft(x14 ^ x2, 16);
+                x10 += x14;
+                x6 = Integer.rotateLeft(x6 ^ x10, 12);
+                x2 += x6;
+                x14 = Integer.rotateLeft(x14 ^ x2, 8);
+                x10 += x14;
+                x6 = Integer.rotateLeft(x6 ^ x10, 7);
+                // Quarter round 3, 7, 11, 15
+                x3 += x7;
+                x15 = Integer.rotateLeft(x15 ^ x3, 16);
+                x11 += x15;
+                x7 = Integer.rotateLeft(x7 ^ x11, 12);
+                x3 += x7;
+                x15 = Integer.rotateLeft(x15 ^ x3, 8);
+                x11 += x15;
+                x7 = Integer.rotateLeft(x7 ^ x11, 7);
+                // Diagonals
+                // Quarter round 0, 5, 10, 15
+                x0 += x5;
+                x15 = Integer.rotateLeft(x15 ^ x0, 16);
+                x10 += x15;
+                x5 = Integer.rotateLeft(x5 ^ x10, 12);
+                x0 += x5;
+                x15 = Integer.rotateLeft(x15 ^ x0, 8);
+                x10 += x15;
+                x5 = Integer.rotateLeft(x5 ^ x10, 7);
+                // Quarter round 1, 6, 11, 12
+                x1 += x6;
+                x12 = Integer.rotateLeft(x12 ^ x1, 16);
+                x11 += x12;
+                x6 = Integer.rotateLeft(x6 ^ x11, 12);
+                x1 += x6;
+                x12 = Integer.rotateLeft(x12 ^ x1, 8);
+                x11 += x12;
+                x6 = Integer.rotateLeft(x6 ^ x11, 7);
+                // Quarter round 2, 7, 8, 13
+                x2 += x7;
+                x13 = Integer.rotateLeft(x13 ^ x2, 16);
+                x8 += x13;
+                x7 = Integer.rotateLeft(x7 ^ x8, 12);
+                x2 += x7;
+                x13 = Integer.rotateLeft(x13 ^ x2, 8);
+                x8 += x13;
+                x7 = Integer.rotateLeft(x7 ^ x8, 7);
+                // Quarter round 3, 4, 9, 14
+                x3 += x4;
+                x14 = Integer.rotateLeft(x14 ^ x3, 16);
+                x9 += x14;
+                x4 = Integer.rotateLeft(x4 ^ x9, 12);
+                x3 += x4;
+                x14 = Integer.rotateLeft(x14 ^ x3, 8);
+                x9 += x14;
+                x4 = Integer.rotateLeft(x4 ^ x9, 7);
             }
-        }
 
-        protected static void columnRound(int[] state) {
-            quarterRound(state, 0, 4, 8, 12);
-            quarterRound(state, 1, 5, 9, 13);
-            quarterRound(state, 2, 6, 10, 14);
-            quarterRound(state, 3, 7, 11, 15);
-        }
-
-        protected static void diagonalRound(int[] state) {
-            quarterRound(state, 0, 5, 10, 15);
-            quarterRound(state, 1, 6, 11, 12);
-            quarterRound(state, 2, 7, 8, 13);
-            quarterRound(state, 3, 4, 9, 14);
-        }
-
-        protected static void quarterRound(int[] state, int a, int b, int c, int d) {
-            state[a] += state[b];
-            state[d] = Integer.rotateLeft(state[d] ^ state[a], 16);
-
-            state[c] += state[d];
-            state[b] = Integer.rotateLeft(state[b] ^ state[c], 12);
-
-            state[a] += state[b];
-            state[d] = Integer.rotateLeft(state[d] ^ state[a], 8);
-
-            state[c] += state[d];
-            state[b] = Integer.rotateLeft(state[b] ^ state[c], 7);
-        }
-
-        private static int unpackIntLE(byte[] buf, int off) {
-            return unpackIntLE(buf, off, Integer.BYTES);
-        }
-
-        private static int unpackIntLE(byte[] buf, int off, int len) {
-            int ret = 0;
-            for (int i = 0; i < len; i++) {
-                ret |= Byte.toUnsignedInt(buf[off + i]) << i * Byte.SIZE;
-            }
-            return ret;
+            Poly1305Mac.packIntLE(engine[0] + x0, keyStream, 0);
+            Poly1305Mac.packIntLE(engine[1] + x1, keyStream, 4);
+            Poly1305Mac.packIntLE(engine[2] + x2, keyStream, 8);
+            Poly1305Mac.packIntLE(engine[3] + x3, keyStream, 12);
+            Poly1305Mac.packIntLE(engine[4] + x4, keyStream, 16);
+            Poly1305Mac.packIntLE(engine[5] + x5, keyStream, 20);
+            Poly1305Mac.packIntLE(engine[6] + x6, keyStream, 24);
+            Poly1305Mac.packIntLE(engine[7] + x7, keyStream, 28);
+            Poly1305Mac.packIntLE(engine[8] + x8, keyStream, 32);
+            Poly1305Mac.packIntLE(engine[9] + x9, keyStream, 36);
+            Poly1305Mac.packIntLE(engine[10] + x10, keyStream, 40);
+            Poly1305Mac.packIntLE(engine[11] + x11, keyStream, 44);
+            Poly1305Mac.packIntLE(engine[12] + x12, keyStream, 48);
+            Poly1305Mac.packIntLE(engine[13] + x13, keyStream, 52);
+            Poly1305Mac.packIntLE(engine[14] + x14, keyStream, 56);
+            Poly1305Mac.packIntLE(engine[15] + x15, keyStream, 60);
         }
 
         private static void unpackIntsLE(byte[] buf, int off, int nrInts, int[] dst, int dstOff) {
             for (int i = 0; i < nrInts; i++) {
-                dst[dstOff++] = unpackIntLE(buf, off);
+                dst[dstOff++] = Poly1305Mac.unpackIntLE(buf, off);
                 off += Integer.BYTES;
             }
         }
@@ -270,10 +329,5 @@ public class ChaCha20Cipher implements Cipher {
             return values;
         }
 
-        private static void packIntLE(int value, byte[] dst, int off, int len) {
-            for (int i = 0; i < len; i++) {
-                dst[off + i] = (byte) (value >>> i * Byte.SIZE);
-            }
-        }
     }
 }

--- a/sshd-common/src/main/java/org/apache/sshd/common/util/buffer/BufferUtils.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/util/buffer/BufferUtils.java
@@ -392,6 +392,25 @@ public final class BufferUtils {
     }
 
     /**
+     * @param  buf A buffer holding a 32-bit signed integer in <B>big endian</B> format.
+     * @param  off The offset of the data in the buffer
+     * @param  len The available data length. <B>Note:</B> if more than 4 bytes are available, then only the
+     *             <U>first</U> 4 bytes in the buffer will be used (starting at the specified <tt>offset</tt>)
+     * @return     The integer value read
+     */
+    public static int getInt(byte[] buf, int off, int len) {
+        if (len < Integer.BYTES) {
+            throw new IllegalArgumentException("Not enough data for an INT: required=" + Integer.BYTES + ", available=" + len);
+        }
+
+        int i = (buf[off++] & 0xFF) << 24;
+        i |= (buf[off++] & 0xFF) << 16;
+        i |= (buf[off++] & 0xFF) << 8;
+        i |= buf[off] & 0xFF;
+        return i;
+    }
+
+    /**
      * @param  buf A buffer holding a 32-bit unsigned integer in <B>big endian</B> format. <B>Note:</B> if more than 4
      *             bytes are available, then only the <U>first</U> 4 bytes in the buffer will be used
      * @return     The result as a {@code long} whose 32 high-order bits are zero
@@ -409,15 +428,7 @@ public final class BufferUtils {
      * @return     The result as a {@code long} whose 32 high-order bits are zero
      */
     public static long getUInt(byte[] buf, int off, int len) {
-        if (len < Integer.BYTES) {
-            throw new IllegalArgumentException("Not enough data for a UINT: required=" + Integer.BYTES + ", available=" + len);
-        }
-
-        long l = (buf[off] << 24) & 0xff000000L;
-        l |= (buf[off + 1] << 16) & 0x00ff0000L;
-        l |= (buf[off + 2] << 8) & 0x0000ff00L;
-        l |= (buf[off + 3]) & 0x000000ffL;
-        return l;
+        return getInt(buf, off, len) & 0xFFFF_FFFFL;
     }
 
     public static long getLong(byte[] buf, int off, int len) {

--- a/sshd-common/src/main/java/org/apache/sshd/common/util/security/SecurityUtils.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/util/security/SecurityUtils.java
@@ -134,6 +134,7 @@ public final class SecurityUtils {
     public static final String SECURITY_PROVIDER_REGISTRARS = "org.apache.sshd.security.registrars";
     public static final List<String> DEFAULT_SECURITY_PROVIDER_REGISTRARS = Collections.unmodifiableList(
             Arrays.asList(
+                    "org.apache.sshd.common.util.security.SunJCESecurityProviderRegistrar",
                     "org.apache.sshd.common.util.security.bouncycastle.BouncyCastleSecurityProviderRegistrar",
                     "org.apache.sshd.common.util.security.eddsa.EdDSASecurityProviderRegistrar"));
 

--- a/sshd-common/src/main/java/org/apache/sshd/common/util/security/SunJCESecurityProviderRegistrar.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/util/security/SunJCESecurityProviderRegistrar.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sshd.common.util.security;
+
+import java.security.Provider;
+import java.security.Security;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.sshd.common.util.GenericUtils;
+
+/**
+ * This is registrar ensures that even if other registrars are active, we still use the Java built-in security provider
+ * at least for some security entities.
+ * <p>
+ * The problem is that if the Bouncy Castle registrar is present and enabled, we'll end up using the Bouncy Castle
+ * implementations for just about anything. But not all Bouncy Castle versions have native implementations of the
+ * algorithms. If BC AES is used and is implemented in Java, performance will be very poor. SunJCE's AES uses native
+ * code and is much faster.
+ * </p>
+ * <p>
+ * If no Bouncy Castle is registered, this extra registrar will not have an effect. Like all registrars, this one can be
+ * disabled via a system property {@code org.apache.sshd.security.provider.SunJCEWrapper.enabled=false}. Note that this
+ * does <em>not</em> disable the fallback to the platform provider; it only disables this wrapper which can be used to
+ * force the use of the "SunJCE" standard Java provider even if some other registrar also supports an algorithm (and
+ * would thus normally be preferred).
+ * </p>
+ * <p>
+ * The registrar can be configured as usual. By default it has only the AES cipher and the SHA macs enabled, everything
+ * else is disabled.
+ * </p>
+ *
+ * @author <a href="mailto:dev@mina.apache.org">Apache MINA SSHD Project</a>
+ */
+public class SunJCESecurityProviderRegistrar extends AbstractSecurityProviderRegistrar {
+
+    private final Map<String, String> defaultProperties = new HashMap<>();
+
+    public SunJCESecurityProviderRegistrar() {
+        super("SunJCEWrapper");
+        String baseName = getBasePropertyName();
+        defaultProperties.put(baseName + ".Cipher", "AES");
+        defaultProperties.put(baseName + ".Mac", "HmacSha1,HmacSha224,HmacSha256,HmacSha384,HmacSha512");
+    }
+
+    @Override
+    public boolean isEnabled() {
+        if (!super.isEnabled()) {
+            return false;
+        }
+        return isSupported();
+    }
+
+    @Override
+    public String getDefaultSecurityEntitySupportValue(Class<?> entityType) {
+        return "";
+    }
+
+    @Override
+    public String getString(String name) {
+        String configured = super.getString(name);
+        if (GenericUtils.isEmpty(configured)) {
+            String byDefault = defaultProperties.get(name);
+            if (byDefault != null) {
+                return byDefault;
+            }
+        }
+        return configured;
+    }
+
+    @Override
+    public boolean isNamedProviderUsed() {
+        return false;
+    }
+
+    @Override
+    public Provider getSecurityProvider() {
+        return Security.getProvider("SunJCE");
+    }
+
+    @Override
+    public boolean isSupported() {
+        return getSecurityProvider() != null;
+    }
+
+}

--- a/sshd-common/src/test/java/org/apache/sshd/common/cipher/BaseCipherTest.java
+++ b/sshd-common/src/test/java/org/apache/sshd/common/cipher/BaseCipherTest.java
@@ -22,8 +22,10 @@ package org.apache.sshd.common.cipher;
 import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.security.InvalidKeyException;
+import java.security.spec.AlgorithmParameterSpec;
 import java.util.Arrays;
 
+import javax.crypto.spec.GCMParameterSpec;
 import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 
@@ -78,9 +80,15 @@ public abstract class BaseCipherTest extends JUnitTestSupport {
             javax.crypto.Cipher cipher = SecurityUtils.getCipher(transformation);
             byte[] key = new byte[bsize];
             byte[] iv = new byte[ivsize];
+            AlgorithmParameterSpec params;
+            if (transformation.contains("/GCM/")) {
+                params = new GCMParameterSpec(128, iv);
+            } else {
+                params = new IvParameterSpec(iv);
+            }
             cipher.init(javax.crypto.Cipher.ENCRYPT_MODE,
                     new SecretKeySpec(key, algorithm),
-                    new IvParameterSpec(iv));
+                    params);
         } catch (GeneralSecurityException e) {
             if (e instanceof InvalidKeyException) {
                 Assume.assumeTrue(algorithm + "/" + transformation + "[" + bsize + "/" + ivsize + "]", false /*

--- a/sshd-core/src/main/java/org/apache/sshd/common/kex/SNTRUP761.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/kex/SNTRUP761.java
@@ -21,7 +21,6 @@ package org.apache.sshd.common.kex;
 import java.security.SecureRandom;
 import java.util.Arrays;
 
-import org.apache.sshd.common.util.security.SecurityUtils;
 import org.bouncycastle.crypto.AsymmetricCipherKeyPair;
 import org.bouncycastle.crypto.SecretWithEncapsulation;
 import org.bouncycastle.pqc.crypto.ntruprime.SNTRUPrimeKEMExtractor;
@@ -42,9 +41,6 @@ final class SNTRUP761 {
     }
 
     static boolean isSupported() {
-        if (!SecurityUtils.isBouncyCastleRegistered()) {
-            return false;
-        }
         try {
             return SNTRUPrimeParameters.sntrup761.getSessionKeySize() == 256; // BC < 1.78 had only 128
         } catch (Throwable e) {

--- a/sshd-core/src/main/java/org/apache/sshd/common/session/helpers/AbstractSession.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/session/helpers/AbstractSession.java
@@ -1361,7 +1361,7 @@ public abstract class AbstractSession extends SessionHelper {
     @Override
     public Buffer createBuffer(byte cmd, int len) {
         if (len <= 0) {
-            return prepareBuffer(cmd, new ByteArrayBuffer());
+            return prepareBuffer(cmd, new PacketBuffer());
         }
 
         // Since the caller claims to know how many bytes they will need
@@ -1376,7 +1376,7 @@ public abstract class AbstractSession extends SessionHelper {
             len += outMacSize;
         }
 
-        return prepareBuffer(cmd, new ByteArrayBuffer(new byte[len + Byte.SIZE], false));
+        return prepareBuffer(cmd, new PacketBuffer(new byte[len + Byte.SIZE], false));
     }
 
     @Override

--- a/sshd-core/src/main/java/org/apache/sshd/common/session/helpers/PacketBuffer.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/session/helpers/PacketBuffer.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sshd.common.session.helpers;
+
+import org.apache.sshd.common.util.buffer.ByteArrayBuffer;
+
+/**
+ * A {@link ByteArrayBuffer} that will be prepared with the SSH header (5 bytes).
+ */
+public class PacketBuffer extends ByteArrayBuffer {
+
+    public PacketBuffer() {
+        super();
+    }
+
+    public PacketBuffer(byte[] buf, boolean readOnly) {
+        super(buf, readOnly);
+    }
+}

--- a/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/RawSftpClient.java
+++ b/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/RawSftpClient.java
@@ -28,6 +28,7 @@ import org.apache.sshd.common.util.buffer.Buffer;
  * @author <a href="mailto:dev@mina.apache.org">Apache MINA SSHD Project</a>
  */
 public interface RawSftpClient {
+
     /**
      * @param  cmd         Command to send - <B>Note:</B> only lower 8-bits are used
      * @param  buffer      The {@link Buffer} containing the command data
@@ -35,6 +36,8 @@ public interface RawSftpClient {
      * @throws IOException if failed to send command
      */
     int send(int cmd, Buffer buffer) throws IOException;
+
+    SftpMessage write(int cmd, Buffer buffer) throws IOException;
 
     /**
      * @param  id          The expected request id

--- a/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/SftpClient.java
+++ b/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/SftpClient.java
@@ -24,7 +24,9 @@ import java.io.OutputStream;
 import java.nio.channels.Channel;
 import java.nio.channels.FileChannel;
 import java.nio.charset.Charset;
+import java.nio.file.Files;
 import java.nio.file.OpenOption;
+import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.AclEntry;
 import java.nio.file.attribute.FileTime;
@@ -961,6 +963,76 @@ public interface SftpClient extends SubsystemClient {
      * @throws IOException If failed to execute
      */
     OutputStream write(String path, int bufferSize, Collection<OpenMode> mode) throws IOException;
+
+    default void put(Path localFile, String path) throws IOException {
+        put(localFile, 0, path, EnumSet.of(OpenMode.Write, OpenMode.Create, OpenMode.Truncate));
+    }
+
+    default void put(InputStream stream, String path) throws IOException {
+        put(stream, 0, path, EnumSet.of(OpenMode.Write, OpenMode.Create, OpenMode.Truncate));
+    }
+
+    default void put(Path localFile, int bufferSize, String path) throws IOException {
+        put(localFile, bufferSize, path, EnumSet.of(OpenMode.Write, OpenMode.Create, OpenMode.Truncate));
+    }
+
+    default void put(InputStream stream, int bufferSize, String path) throws IOException {
+        put(stream, bufferSize, path, EnumSet.of(OpenMode.Write, OpenMode.Create, OpenMode.Truncate));
+    }
+
+    default void put(Path localFile, String path, OpenMode... modes) throws IOException {
+        put(localFile, 0, path, GenericUtils.of(modes));
+    }
+
+    default void put(InputStream stream, String path, OpenMode... modes) throws IOException {
+        put(stream, 0, path, GenericUtils.of(modes));
+    }
+
+    default void put(Path localFile, int bufferSize, String path, OpenMode... modes) throws IOException {
+        put(localFile, bufferSize, path, GenericUtils.of(modes));
+    }
+
+    default void put(InputStream stream, int bufferSize, String path, OpenMode... modes) throws IOException {
+        put(stream, bufferSize, path, GenericUtils.of(modes));
+    }
+
+    default void put(Path localFile, String path, Collection<OpenMode> modes) throws IOException {
+        put(localFile, 0, path, modes);
+    }
+
+    default void put(InputStream stream, String path, Collection<OpenMode> modes) throws IOException {
+        put(stream, 0, path, modes);
+    }
+
+    /**
+     * Uploads a local file to a remote file.
+     *
+     * @param  localFile   {@link Path} of the local file to upload
+     * @param  bufferSize  SFTP packet size; i.e., amount of data to send in a single SFTP request. Most servers have a
+     *                     limit of 256kB. If zero, a default buffer size is chosen depending on the peer's channel
+     *                     packet size; so typically about 32kB.
+     * @param  path        The remote file path
+     * @param  mode        The remote file {@link OpenMode}s
+     * @throws IOException if data cannot be read, or cannot be written
+     */
+    default void put(Path localFile, int bufferSize, String path, Collection<OpenMode> modes) throws IOException {
+        try (InputStream in = Files.newInputStream(localFile)) {
+            put(in, bufferSize, path, modes);
+        }
+    }
+
+    /**
+     * Write data from an {@link InputStream} to a remote file.
+     *
+     * @param  stream      {@link InputStream} to read from
+     * @param  bufferSize  SFTP packet size; i.e., amount of data to send in a single SFTP request. Most servers have a
+     *                     limit of 256kB. If zero, a default buffer size is chosen depending on the peer's channel
+     *                     packet size; so typically about 32kB.
+     * @param  path        The remote file path
+     * @param  mode        The remote file {@link OpenMode}s
+     * @throws IOException if data cannot be read, or cannot be written
+     */
+    void put(InputStream stream, int bufferSize, String path, Collection<OpenMode> modes) throws IOException;
 
     /**
      * @param  <E>           The generic extension type

--- a/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/SftpMessage.java
+++ b/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/SftpMessage.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sshd.sftp.client;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Objects;
+
+import org.apache.sshd.common.io.IoWriteFuture;
+
+/**
+ * A representation of a written SFTP message.
+ *
+ * @author <a href="mailto:dev@mina.apache.org">Apache MINA SSHD Project</a>
+ */
+public class SftpMessage {
+
+    private final int id;
+    private final IoWriteFuture future;
+    private final Duration timeout;
+
+    /**
+     * Creates a new instance.
+     *
+     * @param id      SFTP message id
+     * @param future  {@link IoWriteFuture} of the SFTP message; can be used to wait until the message has been actually
+     *                sent
+     * @param timeout the configured SFTP write timeout
+     */
+    public SftpMessage(int id, IoWriteFuture future, Duration timeout) {
+        this.id = id;
+        this.future = Objects.requireNonNull(future);
+        this.timeout = Objects.requireNonNull(timeout);
+    }
+
+    /**
+     * Retrieves the SFTP message id.
+     * 
+     * @return the SFTP message id
+     */
+    public int getId() {
+        return id;
+    }
+
+    /**
+     * Retrieves the {@link IoWriteFuture} of the message; can be used to wait until the message has been actually sent.
+     *
+     * @return the {@link IoWriteFuture}, never {@code null}
+     */
+    public IoWriteFuture getFuture() {
+        return future;
+    }
+
+    /**
+     * Retrieves the write timeout configured when the message was sent.
+     * 
+     * @return the timeout, never {@code null}
+     */
+    public Duration getTimeout() {
+        return timeout;
+    }
+
+    /**
+     * Waits with the configured timeout until the message has been sent.
+     * 
+     * @throws IOException if the message could not be sent, or waiting is interrupted.
+     */
+    public void waitUntilSent() throws IOException {
+        getFuture().verify(getTimeout());
+    }
+}

--- a/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/extensions/helpers/AbstractSftpClientExtension.java
+++ b/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/extensions/helpers/AbstractSftpClientExtension.java
@@ -36,6 +36,7 @@ import org.apache.sshd.common.util.logging.AbstractLoggingBean;
 import org.apache.sshd.sftp.client.RawSftpClient;
 import org.apache.sshd.sftp.client.SftpClient;
 import org.apache.sshd.sftp.client.SftpClient.Handle;
+import org.apache.sshd.sftp.client.SftpMessage;
 import org.apache.sshd.sftp.client.extensions.SftpClientExtension;
 import org.apache.sshd.sftp.client.impl.SftpResponse;
 import org.apache.sshd.sftp.client.impl.SftpStatus;
@@ -91,6 +92,11 @@ public abstract class AbstractSftpClientExtension extends AbstractLoggingBean im
     @Override
     public int send(int cmd, Buffer buffer) throws IOException {
         return raw.send(cmd, buffer);
+    }
+
+    @Override
+    public SftpMessage write(int cmd, Buffer buffer) throws IOException {
+        return raw.write(cmd, buffer);
     }
 
     @Override

--- a/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/fs/SftpFileSystem.java
+++ b/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/fs/SftpFileSystem.java
@@ -25,6 +25,7 @@ import java.io.StreamCorruptedException;
 import java.nio.charset.Charset;
 import java.nio.file.FileStore;
 import java.nio.file.FileSystemException;
+import java.nio.file.Path;
 import java.nio.file.attribute.GroupPrincipal;
 import java.nio.file.attribute.UserPrincipal;
 import java.nio.file.attribute.UserPrincipalLookupService;
@@ -563,6 +564,36 @@ public class SftpFileSystem
         @Override
         public OutputStream write(String path, Collection<OpenMode> mode) throws IOException {
             return write(path, writeSize, mode);
+        }
+
+        @Override
+        public void put(Path localFile, String path) throws IOException {
+            put(localFile, writeSize, path);
+        }
+
+        @Override
+        public void put(InputStream stream, String path) throws IOException {
+            put(stream, writeSize, path);
+        }
+
+        @Override
+        public void put(Path localFile, String path, OpenMode... modes) throws IOException {
+            put(localFile, writeSize, path, GenericUtils.of(modes));
+        }
+
+        @Override
+        public void put(InputStream stream, String path, OpenMode... modes) throws IOException {
+            put(stream, writeSize, path, GenericUtils.of(modes));
+        }
+
+        @Override
+        public void put(Path localFile, String path, Collection<OpenMode> modes) throws IOException {
+            put(localFile, writeSize, path, modes);
+        }
+
+        @Override
+        public void put(InputStream stream, String path, Collection<OpenMode> modes) throws IOException {
+            put(stream, writeSize, path, modes);
         }
 
         @Override

--- a/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/fs/SftpFileSystem.java
+++ b/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/fs/SftpFileSystem.java
@@ -66,6 +66,7 @@ import org.apache.sshd.sftp.client.RawSftpClient;
 import org.apache.sshd.sftp.client.SftpClient;
 import org.apache.sshd.sftp.client.SftpClientFactory;
 import org.apache.sshd.sftp.client.SftpErrorDataHandler;
+import org.apache.sshd.sftp.client.SftpMessage;
 import org.apache.sshd.sftp.client.SftpVersionSelector;
 import org.apache.sshd.sftp.client.impl.AbstractSftpClient;
 import org.apache.sshd.sftp.client.impl.SftpPathImpl;
@@ -602,6 +603,21 @@ public class SftpFileSystem
             } else {
                 throw new StreamCorruptedException(
                         "send(cmd=" + SftpConstants.getCommandMessageName(cmd) + ") delegate is not a "
+                                                   + RawSftpClient.class.getSimpleName());
+            }
+        }
+
+        @Override
+        public SftpMessage write(int cmd, Buffer buffer) throws IOException {
+            if (!isOpen()) {
+                throw new IOException("write(cmd=" + SftpConstants.getCommandMessageName(cmd) + ") client is closed");
+            }
+
+            if (delegate instanceof RawSftpClient) {
+                return ((RawSftpClient) delegate).write(cmd, buffer);
+            } else {
+                throw new StreamCorruptedException(
+                        "write(cmd=" + SftpConstants.getCommandMessageName(cmd) + ") delegate is not a "
                                                    + RawSftpClient.class.getSimpleName());
             }
         }

--- a/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/impl/AbstractSftpClient.java
+++ b/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/impl/AbstractSftpClient.java
@@ -20,7 +20,6 @@ package org.apache.sshd.sftp.client.impl;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
 import java.nio.channels.FileChannel;
 import java.nio.charset.Charset;
 import java.nio.file.attribute.FileTime;
@@ -1239,7 +1238,7 @@ public abstract class AbstractSftpClient
     }
 
     @Override
-    public OutputStream write(String path, int bufferSize, Collection<OpenMode> mode) throws IOException {
+    public SftpOutputStreamAsync write(String path, int bufferSize, Collection<OpenMode> mode) throws IOException {
         if (bufferSize != 0 && bufferSize < MIN_WRITE_BUFFER_SIZE) {
             throw new IllegalArgumentException("Insufficient write buffer size: " + bufferSize + ", min.="
                                                + MIN_WRITE_BUFFER_SIZE);
@@ -1250,6 +1249,13 @@ public abstract class AbstractSftpClient
         }
 
         return new SftpOutputStreamAsync(this, bufferSize, path, mode);
+    }
+
+    @Override
+    public void put(InputStream stream, int bufferSize, String path, Collection<OpenMode> modes) throws IOException {
+        try (SftpOutputStreamAsync out = write(path, bufferSize, modes)) {
+            out.transferFrom(stream);
+        }
     }
 
     protected int getReadBufferSize() {

--- a/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/impl/AbstractSftpClient.java
+++ b/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/impl/AbstractSftpClient.java
@@ -1240,10 +1240,7 @@ public abstract class AbstractSftpClient
 
     @Override
     public OutputStream write(String path, int bufferSize, Collection<OpenMode> mode) throws IOException {
-        if (bufferSize <= 0) {
-            bufferSize = getWriteBufferSize();
-        }
-        if (bufferSize < MIN_WRITE_BUFFER_SIZE) {
+        if (bufferSize != 0 && bufferSize < MIN_WRITE_BUFFER_SIZE) {
             throw new IllegalArgumentException("Insufficient write buffer size: " + bufferSize + ", min.="
                                                + MIN_WRITE_BUFFER_SIZE);
         }
@@ -1260,6 +1257,7 @@ public abstract class AbstractSftpClient
     }
 
     protected int getWriteBufferSize() {
+        // Do not use. -13 is wrong anyway.
         return (int) getClientChannel().getRemoteWindow().getPacketSize() - 13;
     }
 

--- a/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/impl/AbstractSftpClient.java
+++ b/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/impl/AbstractSftpClient.java
@@ -262,10 +262,6 @@ public abstract class AbstractSftpClient
     protected void checkResponseStatus(int cmd, int id, SftpStatus status) throws IOException {
         if (!status.isOk()) {
             throwStatusException(cmd, id, status);
-        } else if (log.isTraceEnabled()) {
-            log.trace("throwStatusException({})[id={}] cmd={} status={}",
-                    getClientChannel(), id, SftpConstants.getCommandMessageName(cmd),
-                    status);
         }
     }
 

--- a/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/impl/SftpOutputStreamAsync.java
+++ b/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/impl/SftpOutputStreamAsync.java
@@ -19,6 +19,7 @@
 package org.apache.sshd.sftp.client.impl;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.Collection;
 import java.util.Deque;
 import java.util.LinkedList;
@@ -163,7 +164,7 @@ public class SftpOutputStreamAsync extends OutputStreamWithChannel implements Sf
                 log.debug("flush({}) waiting for ack #{}: {}", this, ackIndex, ack);
             }
 
-            Buffer buf = client.receive(ack.id, 0L);
+            Buffer buf = client.receive(ack.id, Duration.ZERO);
             if (buf == null) {
                 if (debugEnabled) {
                     log.debug("flush({}) no response for ack #{}: {}", this, ackIndex, ack);


### PR DESCRIPTION
A series of performance optimizations:

* Manual optimizations in the ChaCha20-Poly1305 cipher implementation (loop unrolling, use int instead of long where possible, avoid unnecessary method calls).
* Optimize writing ints/longs into buffers.
* Avoid copying buffers if possible. If we prepare an SSH packet buffer, we should avoid copying it later on if possible.
* Streamline SFTP OutputStreams. Give them a transferFrom operation to be able to read directly into an internal buffer, and internally read-ahead into a second buffer while the first one is being sent.
* Add a convenience operation `SftpClient.put()` for uploading.
* Avoid using the AES implementation from Bouncy Castle (typically a Java implementation). Prefer the one from SunJCE, which uses native code.