### PR TITLE
Add Android-specific exception message when finding user home

### DIFF
--- a/sshd-common/src/main/java/org/apache/sshd/common/util/io/PathUtils.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/util/io/PathUtils.java
@@ -28,6 +28,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
 import org.apache.sshd.common.util.GenericUtils;
+import org.apache.sshd.common.util.OsUtils;
 import org.apache.sshd.common.util.ValidateUtils;
 import org.apache.sshd.common.util.functors.UnaryEquator;
 
@@ -53,10 +54,19 @@ public final class PathUtils {
     private static final AtomicReference<Supplier<? extends Path>> USER_HOME_RESOLVER_HOLDER = new AtomicReference<>();
 
     private static final class LazyDefaultUserHomeFolderHolder {
-        private static final Path PATH
-                = Paths.get(ValidateUtils.checkNotNullAndNotEmpty(System.getProperty("user.home"), "No user home"))
-                        .toAbsolutePath()
-                        .normalize();
+        private static final Path PATH;
+
+        static {
+            String exceptionMessage = OsUtils.isAndroid()
+                    ? "No user home folder available. You should call " +
+                      "org.apache.sshd.common.util.io.PathUtils.setUserHomeFolderResolver() " +
+                      "method to set user home folder as there is no home folder on Android"
+                    : "No user home folder available";
+            PATH = Paths
+                    .get(ValidateUtils.checkNotNullAndNotEmpty(System.getProperty("user.home"), exceptionMessage))
+                    .toAbsolutePath()
+                    .normalize();
+        }
 
         private LazyDefaultUserHomeFolderHolder() {
             throw new UnsupportedOperationException("No instance allowed");


### PR DESCRIPTION
In the Android world, there is no concept similar to a home directory.
That is to say `System.getProperty("user.home")` is always `null`.
This PR can guide developer who target Android to add their own home directory implementation by modifying the exception message.
