### PR TITLE
GH-582: Fix filtering of unsupported algorithms in NamedFactory

### DIFF
--- a/sshd-common/src/main/java/org/apache/sshd/common/NamedFactory.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/NamedFactory.java
@@ -48,18 +48,36 @@ public interface NamedFactory<T> extends Factory<T>, NamedResource {
         }
     }
 
+    /**
+     * Converts a list of factories to a list of transformed factories, optionally excluding unsupported factories.
+     *
+     * @param  <S>               initial factory type
+     * @param  <E>               transformed factory type
+     * @param  ignoreUnsupported whether to filter out unsupported factories from {@code preferred}
+     * @param  preferred         initial list to filter
+     * @param  xform             the transformation to apply
+     * @return                   the filtered list of transformed factories
+     */
     static <S extends OptionalFeature, E extends NamedResource> List<E> setUpTransformedFactories(
             boolean ignoreUnsupported, Collection<? extends S> preferred, Function<? super S, ? extends E> xform) {
         return preferred.stream()
-                .filter(f -> ignoreUnsupported || f.isSupported())
+                .filter(f -> ignoreUnsupported ? f.isSupported() : true)
                 .map(xform)
                 .collect(Collectors.toList());
     }
 
+    /**
+     * Filters out unsupported factories from a given list if {@code ignoreUnsupported == true}.
+     *
+     * @param  <E>               factory type
+     * @param  ignoreUnsupported whether to filter out unsupported factories from {@code preferred}
+     * @param  preferred         initial list to filter
+     * @return                   the filtered list of factories
+     */
     static <E extends NamedResource & OptionalFeature> List<E> setUpBuiltinFactories(
             boolean ignoreUnsupported, Collection<? extends E> preferred) {
         return preferred.stream()
-                .filter(f -> ignoreUnsupported || f.isSupported())
+                .filter(f -> ignoreUnsupported ? f.isSupported() : true)
                 .collect(Collectors.toList());
     }
 }

--- a/sshd-common/src/test/java/org/apache/sshd/common/NamedFactoryTest.java
+++ b/sshd-common/src/test/java/org/apache/sshd/common/NamedFactoryTest.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sshd.common;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.sshd.util.test.JUnitTestSupport;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("NoIoTestCase")
+class NamedFactoryTest extends JUnitTestSupport {
+
+    @Test
+    void testBuiltinSupported() {
+        List<Factory> input = new ArrayList<>();
+        input.add(new Factory("A", false));
+        input.add(new Factory("B", true));
+        input.add(new Factory("C", false));
+        input.add(new Factory("D", true));
+        input.add(new Factory("E", false));
+        List<Factory> filtered = NamedFactory.setUpBuiltinFactories(true, input);
+        assertEquals(2, filtered.size());
+        assertEquals("B", filtered.get(0).getName());
+        assertEquals("D", filtered.get(1).getName());
+    }
+
+    @Test
+    void testBuiltinUnsupported() {
+        List<Factory> input = new ArrayList<>();
+        input.add(new Factory("A", false));
+        input.add(new Factory("B", true));
+        input.add(new Factory("C", false));
+        input.add(new Factory("D", true));
+        input.add(new Factory("E", false));
+        List<Factory> filtered = NamedFactory.setUpBuiltinFactories(false, input);
+        assertIterableEquals(input, filtered);
+    }
+
+    @Test
+    void testTransformedSupported() {
+        List<OptionalFeature> input = new ArrayList<>();
+        input.add(OptionalFeature.FALSE);
+        input.add(OptionalFeature.TRUE);
+        input.add(OptionalFeature.FALSE);
+        input.add(OptionalFeature.TRUE);
+        input.add(OptionalFeature.FALSE);
+        List<Factory> filtered = NamedFactory.setUpTransformedFactories(true, input,
+                o -> new Factory(o.toString(), o.isSupported()));
+        assertEquals(2, filtered.size());
+        assertTrue(filtered.stream().allMatch(Factory::isSupported));
+    }
+
+    @Test
+    void testTransformedUnsupported() {
+        List<OptionalFeature> input = new ArrayList<>();
+        input.add(OptionalFeature.FALSE);
+        input.add(OptionalFeature.TRUE);
+        input.add(OptionalFeature.FALSE);
+        input.add(OptionalFeature.TRUE);
+        input.add(OptionalFeature.FALSE);
+        List<Factory> filtered = NamedFactory.setUpTransformedFactories(false, input,
+                o -> new Factory(o.toString(), o.isSupported()));
+        assertEquals(input.size(), filtered.size());
+        for (int i = 0; i < input.size(); i++) {
+            assertEquals(input.get(i).isSupported(), filtered.get(i).isSupported());
+        }
+    }
+
+    private static class Factory implements NamedResource, OptionalFeature {
+
+        private final String name;
+
+        private final boolean supported;
+
+        Factory(String name, boolean supported) {
+            this.name = name;
+            this.supported = supported;
+        }
+
+        @Override
+        public String getName() {
+            return name;
+        }
+
+        @Override
+        public boolean isSupported() {
+            return supported;
+        }
+    }
+}

--- a/sshd-core/src/main/java/org/apache/sshd/client/ClientBuilder.java
+++ b/sshd-core/src/main/java/org/apache/sshd/client/ClientBuilder.java
@@ -114,15 +114,15 @@ public class ClientBuilder extends BaseBuilder<SshClient, ClientBuilder> {
         super.fillWithDefaultValues();
 
         if (signatureFactories == null) {
-            signatureFactories = setUpDefaultSignatureFactories(false);
+            signatureFactories = setUpDefaultSignatureFactories(true);
         }
 
         if (compressionFactories == null) {
-            compressionFactories = setUpDefaultCompressionFactories(false);
+            compressionFactories = setUpDefaultCompressionFactories(true);
         }
 
         if (keyExchangeFactories == null) {
-            keyExchangeFactories = setUpDefaultKeyExchanges(false);
+            keyExchangeFactories = setUpDefaultKeyExchanges(true);
         }
 
         if (kexExtensionHandler == null) {

--- a/sshd-core/src/main/java/org/apache/sshd/common/BaseBuilder.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/BaseBuilder.java
@@ -168,11 +168,11 @@ public class BaseBuilder<T extends AbstractFactoryManager, S extends BaseBuilder
         }
 
         if (cipherFactories == null) {
-            cipherFactories = setUpDefaultCiphers(false);
+            cipherFactories = setUpDefaultCiphers(true);
         }
 
         if (macFactories == null) {
-            macFactories = setUpDefaultMacs(false);
+            macFactories = setUpDefaultMacs(true);
         }
 
         if (fileSystemFactory == null) {

--- a/sshd-core/src/main/java/org/apache/sshd/server/ServerBuilder.java
+++ b/sshd-core/src/main/java/org/apache/sshd/server/ServerBuilder.java
@@ -130,15 +130,15 @@ public class ServerBuilder extends BaseBuilder<SshServer, ServerBuilder> {
         super.fillWithDefaultValues();
 
         if (compressionFactories == null) {
-            compressionFactories = setUpDefaultCompressionFactories(false);
+            compressionFactories = setUpDefaultCompressionFactories(true);
         }
 
         if (signatureFactories == null) {
-            signatureFactories = setUpDefaultSignatureFactories(false);
+            signatureFactories = setUpDefaultSignatureFactories(true);
         }
 
         if (keyExchangeFactories == null) {
-            keyExchangeFactories = setUpDefaultKeyExchanges(false);
+            keyExchangeFactories = setUpDefaultKeyExchanges(true);
         }
 
         if (kexExtensionHandler == null) {


### PR DESCRIPTION
Also give the methods some javadoc.

Note that `ignoreUnsupported ? f.isSupported : true` is the same as `!ignoreUnsupported || f.isSupported()`, but I find the former easier to read and understand.

Fixes #582.