### PR TITLE
GH-590: Be more careful with Bouncy Castle in FIPS environment

### DIFF
--- a/docs/security-providers.md
+++ b/docs/security-providers.md
@@ -107,3 +107,30 @@ In any case, the values are auto-detected by the code but the user can intervene
 * Setting a value of zero indicates a **lazy** auto-detection of the supported range the next time these values are needed.
 
 Furthermore, if all possible primes have been exhausted the code no longer falls back to DH group exchange using SHA-1 unless the `ALLOW_DHG1_KEX_FALLBACK` core module property is set.
+
+## FIPS Mode
+
+Apache MINA sshd supports running in environments restricted by FIPS 140 through a special "FIPS mode".
+In FIPS mode, crypto-algorithms not approved by FIPS-140 are disabled.
+
+FIPS mode can be switched on in two ways:
+* via System property `org.apache.sshd.security.fipsEnabled=true`, or
+* if the system property is not set to `true` also programmatically via a call to `SecurityUtils.setFipsMode()` before any other call to the library.
+
+In FIPS mode, the following algorithms are disabled completely:
+* key exchange methods sntrup761x25519-sha512, sntrup761x25519-sha512<!-- -->@openssh.com, curve25519-sha256, curve25519-sha256<!-- -->@libssh.org, and curve448-sha512.
+* the chacha20-poly1305 cipher.
+* the bcrypt KDF used in encrypted private key files in [OpenSSH format](https://github.com/openssh/openssh-portable/blob/master/PROTOCOL.key).
+* all ed25519 keys and signatures.
+
+The `BouncyCastleSecurityProviderRegistrar` only considers the "BCFIPS" provider from `bc-fips`
+and disregards the "BC" provider from normal Bouncy Castle. The registrar for _EdDSA_ is disabled.
+For random numbers, `SecureRandom.getInstanceStrong()` is used.
+
+This FIPS mode does not automatically make an application using Apache MINA sshd FIPS-140-compliant.
+It only ensures that the Apache MINA sshd library does not provide or use algorithms that should not
+be used in FIPS-140-compliant applications running in approved mode.
+
+It is usually necessary to configure the JVM for full FIPS 140 compliance, for instance, by defining
+appropriate security providers statically. Any such configuration is beyond the scope of the Apache MINA
+sshd library.

--- a/sshd-common/src/main/java/org/apache/sshd/common/config/keys/loader/openssh/OpenSSHKeyPairResourceParser.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/config/keys/loader/openssh/OpenSSHKeyPairResourceParser.java
@@ -196,6 +196,9 @@ public class OpenSSHKeyPairResourceParser extends AbstractKeyPairResourceParser 
         OpenSSHKdfOptions options;
         // TODO define a factory class where users can register extra KDF options
         if (BCryptKdfOptions.NAME.equalsIgnoreCase(kdfName)) {
+            if (SecurityUtils.isFipsMode()) {
+                throw new NoSuchAlgorithmException(BCryptKdfOptions.NAME + " is disabled in FIPS mode");
+            }
             options = new BCryptKdfOptions();
         } else {
             options = new RawKdfOptions();

--- a/sshd-common/src/main/java/org/apache/sshd/common/random/JceRandom.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/random/JceRandom.java
@@ -18,7 +18,11 @@
  */
 package org.apache.sshd.common.random;
 
+import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A <code>Random</code> implementation using the built-in {@link SecureRandom} PRNG.
@@ -26,13 +30,25 @@ import java.security.SecureRandom;
  * @author <a href="mailto:dev@mina.apache.org">Apache MINA SSHD Project</a>
  */
 public class JceRandom extends AbstractRandom {
+
     public static final String NAME = "JCE";
 
+    private static final Logger LOG = LoggerFactory.getLogger(JceRandom.class);
+
     private byte[] tmp = new byte[16];
-    private final SecureRandom random = new SecureRandom();
+    private final SecureRandom random = getRandom();
 
     public JceRandom() {
         super();
+    }
+
+    private static SecureRandom getRandom() {
+        try {
+            return SecureRandom.getInstanceStrong();
+        } catch (NoSuchAlgorithmException e) {
+            LOG.warn("No strong SecureRandom algorithm available; falling back to non-strong SecureRandom PRNG.");
+            return new SecureRandom();
+        }
     }
 
     @Override

--- a/sshd-common/src/main/java/org/apache/sshd/common/util/security/AbstractSecurityProviderRegistrar.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/util/security/AbstractSecurityProviderRegistrar.java
@@ -100,7 +100,7 @@ public abstract class AbstractSecurityProviderRegistrar
                 return provider;
             }
 
-            provider = Security.getProvider(getName());
+            provider = Security.getProvider(getProviderName());
             if (provider == null) {
                 provider = createProviderInstance(providerClassName);
                 created = true;

--- a/sshd-common/src/main/java/org/apache/sshd/common/util/security/SecurityEntityFactory.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/util/security/SecurityEntityFactory.java
@@ -60,12 +60,12 @@ public interface SecurityEntityFactory<T> {
             if ((defaultProvider == null) || (defaultProvider == SecurityProviderChoice.EMPTY)) {
                 return toDefaultFactory(entityType);
             } else if (defaultProvider.isNamedProviderUsed()) {
-                return toNamedProviderFactory(entityType, defaultProvider.getName());
+                return toNamedProviderFactory(entityType, defaultProvider.getProviderName());
             } else {
                 return toProviderInstanceFactory(entityType, defaultProvider.getSecurityProvider());
             }
         } else if (registrar.isNamedProviderUsed()) {
-            return toNamedProviderFactory(entityType, registrar.getName());
+            return toNamedProviderFactory(entityType, registrar.getProviderName());
         } else {
             return toProviderInstanceFactory(entityType, registrar.getSecurityProvider());
         }

--- a/sshd-common/src/main/java/org/apache/sshd/common/util/security/SecurityProviderChoice.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/util/security/SecurityProviderChoice.java
@@ -61,6 +61,17 @@ public interface SecurityProviderChoice extends NamedResource {
     }
 
     /**
+     * Retrieves the underlying {@link Provider}'s name.
+     *
+     * @return the {@link Provider}'s name
+     */
+    default String getProviderName() {
+        // By default, assume choice name and provider name are the same. For a SecurityProviderRegistrar, these may be
+        // different!
+        return getName();
+    }
+
+    /**
      * @return The security {@link Provider} to use in case {@link #isNamedProviderUsed()} is {@code false}. Can be
      *         {@code null} if {@link #isNamedProviderUsed()} is {@code true}, but not recommended.
      */

--- a/sshd-common/src/main/java/org/apache/sshd/common/util/security/SecurityProviderRegistrar.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/util/security/SecurityProviderRegistrar.java
@@ -307,14 +307,14 @@ public interface SecurityProviderRegistrar extends SecurityProviderChoice, Optio
      */
     static boolean registerSecurityProvider(SecurityProviderRegistrar registrar) {
         String name = ValidateUtils.checkNotNullAndNotEmpty(
-                (registrar == null) ? null : registrar.getName(), "No name for registrar=%s", registrar);
+                (registrar == null) ? null : registrar.getProviderName(), "No name for registrar=%s", registrar);
         Provider p = Security.getProvider(name);
         if (p != null) {
             return false;
         }
 
         p = ValidateUtils.checkNotNull(
-                registrar.getSecurityProvider(), "No provider created for registrar of %s", name);
+                registrar.getSecurityProvider(), "No provider created for registrar %s of %s", registrar.getName(), name);
         if (registrar.isNamedProviderUsed()) {
             Security.addProvider(p);
         }

--- a/sshd-common/src/main/java/org/apache/sshd/common/util/security/SecurityUtils.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/util/security/SecurityUtils.java
@@ -90,7 +90,7 @@ import org.slf4j.LoggerFactory;
  */
 public final class SecurityUtils {
     /**
-     * Bouncycastle JCE provider name
+     * Bouncy Castle {@link SecurityProviderRegistrar} name.
      */
     public static final String BOUNCY_CASTLE = "BC";
 
@@ -552,7 +552,7 @@ public final class SecurityUtils {
      *         {@link JceRandomFactory} one
      */
     public static RandomFactory getRandomFactory() {
-        if (isBouncyCastleRegistered()) {
+        if (isBouncyCastleRegistered() && BouncyCastleRandomFactory.INSTANCE.isSupported()) {
             return BouncyCastleRandomFactory.INSTANCE;
         } else {
             return JceRandomFactory.INSTANCE;

--- a/sshd-common/src/main/java/org/apache/sshd/common/util/security/SunJCESecurityProviderRegistrar.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/util/security/SunJCESecurityProviderRegistrar.java
@@ -61,7 +61,7 @@ public class SunJCESecurityProviderRegistrar extends AbstractSecurityProviderReg
 
     @Override
     public boolean isEnabled() {
-        if (!super.isEnabled()) {
+        if (SecurityUtils.isFipsMode() || !super.isEnabled()) {
             return false;
         }
         return isSupported();

--- a/sshd-common/src/main/java/org/apache/sshd/common/util/security/SunJCESecurityProviderRegistrar.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/util/security/SunJCESecurityProviderRegistrar.java
@@ -68,6 +68,11 @@ public class SunJCESecurityProviderRegistrar extends AbstractSecurityProviderReg
     }
 
     @Override
+    public String getProviderName() {
+        return "SunJCE";
+    }
+
+    @Override
     public String getDefaultSecurityEntitySupportValue(Class<?> entityType) {
         return "";
     }
@@ -91,7 +96,7 @@ public class SunJCESecurityProviderRegistrar extends AbstractSecurityProviderReg
 
     @Override
     public Provider getSecurityProvider() {
-        return Security.getProvider("SunJCE");
+        return Security.getProvider(getProviderName());
     }
 
     @Override

--- a/sshd-common/src/main/java/org/apache/sshd/common/util/security/bouncycastle/BouncyCastleEncryptedPrivateKeyInfoDecryptor.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/util/security/bouncycastle/BouncyCastleEncryptedPrivateKeyInfoDecryptor.java
@@ -52,7 +52,7 @@ public enum BouncyCastleEncryptedPrivateKeyInfoDecryptor implements Decryptor {
         try {
             JcePKCSPBEInputDecryptorProviderBuilder builder = new JcePKCSPBEInputDecryptorProviderBuilder();
             if (registrar.isNamedProviderUsed()) {
-                builder.setProvider(registrar.getName());
+                builder.setProvider(registrar.getProviderName());
             } else {
                 builder.setProvider(registrar.getSecurityProvider());
             }

--- a/sshd-common/src/main/java/org/apache/sshd/common/util/security/bouncycastle/BouncyCastleKeyPairResourceParser.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/util/security/bouncycastle/BouncyCastleKeyPairResourceParser.java
@@ -114,7 +114,7 @@ public class BouncyCastleKeyPairResourceParser extends AbstractKeyPairResourcePa
 
             JcaPEMKeyConverter pemConverter = new JcaPEMKeyConverter();
             if (registrar.isNamedProviderUsed()) {
-                pemConverter.setProvider(registrar.getName());
+                pemConverter.setProvider(registrar.getProviderName());
             } else {
                 pemConverter.setProvider(registrar.getSecurityProvider());
             }

--- a/sshd-common/src/main/java/org/apache/sshd/common/util/security/bouncycastle/BouncyCastleRandomFactory.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/util/security/bouncycastle/BouncyCastleRandomFactory.java
@@ -21,6 +21,7 @@ package org.apache.sshd.common.util.security.bouncycastle;
 import org.apache.sshd.common.random.AbstractRandomFactory;
 import org.apache.sshd.common.random.Random;
 import org.apache.sshd.common.util.security.SecurityUtils;
+import org.bouncycastle.crypto.prng.RandomGenerator;
 
 /**
  * Named factory for the BouncyCastle <code>Random</code>
@@ -35,7 +36,11 @@ public final class BouncyCastleRandomFactory extends AbstractRandomFactory {
 
     @Override
     public boolean isSupported() {
-        return SecurityUtils.isBouncyCastleRegistered();
+        try {
+            return SecurityUtils.isBouncyCastleRegistered() && RandomGenerator.class.getName() != null;
+        } catch (Throwable e) {
+            return false;
+        }
     }
 
     @Override

--- a/sshd-common/src/main/java/org/apache/sshd/common/util/security/bouncycastle/BouncyCastleSecurityProviderRegistrar.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/util/security/bouncycastle/BouncyCastleSecurityProviderRegistrar.java
@@ -132,8 +132,11 @@ public class BouncyCastleSecurityProviderRegistrar extends AbstractSecurityProvi
             if (supported != null) {
                 return supported.booleanValue();
             }
-
-            Class<?> clazz = ThreadUtils.resolveDefaultClass(getClass(), PROVIDER_CLASS);
+            boolean requireFips = SecurityUtils.isFipsMode();
+            Class<?> clazz = null;
+            if (!requireFips) {
+                clazz = ThreadUtils.resolveDefaultClass(getClass(), PROVIDER_CLASS);
+            }
             if (clazz == null) {
                 clazz = ThreadUtils.resolveDefaultClass(getClass(), FIPS_PROVIDER_CLASS);
             }
@@ -145,7 +148,7 @@ public class BouncyCastleSecurityProviderRegistrar extends AbstractSecurityProvi
                 Provider provider = Security.getProvider(BCFIPS_PROVIDER_NAME);
                 if (provider != null) {
                     providerName = BCFIPS_PROVIDER_NAME;
-                } else {
+                } else if (!requireFips) {
                     provider = Security.getProvider(BC_PROVIDER_NAME);
                     if (provider != null) {
                         providerName = BC_PROVIDER_NAME;

--- a/sshd-common/src/main/java/org/apache/sshd/common/util/security/bouncycastle/BouncyCastleSecurityProviderRegistrar.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/util/security/bouncycastle/BouncyCastleSecurityProviderRegistrar.java
@@ -18,9 +18,11 @@
  */
 package org.apache.sshd.common.util.security.bouncycastle;
 
+import java.lang.reflect.Field;
 import java.security.KeyFactory;
 import java.security.KeyPairGenerator;
 import java.security.Provider;
+import java.security.Security;
 import java.security.Signature;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
@@ -37,9 +39,17 @@ import org.apache.sshd.common.util.threads.ThreadUtils;
 public class BouncyCastleSecurityProviderRegistrar extends AbstractSecurityProviderRegistrar {
     // We want to use reflection API so as not to require BouncyCastle to be present in the classpath
     public static final String PROVIDER_CLASS = "org.bouncycastle.jce.provider.BouncyCastleProvider";
+    public static final String FIPS_PROVIDER_CLASS = "org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider";
+    private static final String BCFIPS_PROVIDER_NAME = "BCFIPS";
+    private static final String BC_PROVIDER_NAME = "BC";
+    private static final String NAME_FIELD = "PROVIDER_NAME";
+
     // Do not define a static registrar instance to minimize class loading issues
     private final AtomicReference<Boolean> supportHolder = new AtomicReference<>(null);
     private final AtomicReference<String> allSupportHolder = new AtomicReference<>();
+
+    private String providerClass;
+    private String providerName;
 
     public BouncyCastleSecurityProviderRegistrar() {
         super(SecurityUtils.BOUNCY_CASTLE);
@@ -56,13 +66,18 @@ public class BouncyCastleSecurityProviderRegistrar extends AbstractSecurityProvi
     }
 
     @Override
+    public String getProviderName() {
+        return providerName;
+    }
+
+    @Override
     public Provider getSecurityProvider() {
         try {
-            return getOrCreateProvider(PROVIDER_CLASS);
+            return getOrCreateProvider(providerClass);
         } catch (ReflectiveOperationException t) {
             Throwable e = ExceptionUtils.peelException(t);
             log.error("getSecurityProvider({}) failed ({}) to instantiate {}: {}",
-                    getName(), e.getClass().getSimpleName(), PROVIDER_CLASS, e.getMessage());
+                    getName(), e.getClass().getSimpleName(), providerClass, e.getMessage());
             if (e instanceof RuntimeException) {
                 throw (RuntimeException) e;
             }
@@ -119,7 +134,40 @@ public class BouncyCastleSecurityProviderRegistrar extends AbstractSecurityProvi
             }
 
             Class<?> clazz = ThreadUtils.resolveDefaultClass(getClass(), PROVIDER_CLASS);
-            supported = clazz != null;
+            if (clazz == null) {
+                clazz = ThreadUtils.resolveDefaultClass(getClass(), FIPS_PROVIDER_CLASS);
+            }
+            if (clazz != null) {
+                // Apache MINA sshd assumes that if we can get at the provider class, we can also get any other class we
+                // need. However, and BC-based optional stuff should actually check if it does have the concrete
+                // classes it needs accessible. The FIPS version has only a subset of the full BC.
+                providerClass = clazz.getName();
+                Provider provider = Security.getProvider(BCFIPS_PROVIDER_NAME);
+                if (provider != null) {
+                    providerName = BCFIPS_PROVIDER_NAME;
+                } else {
+                    provider = Security.getProvider(BC_PROVIDER_NAME);
+                    if (provider != null) {
+                        providerName = BC_PROVIDER_NAME;
+                    }
+                }
+                if (providerName == null) {
+                    Field f;
+                    try {
+                        f = clazz.getField(NAME_FIELD);
+                        Object nameValue = f.get(null);
+                        if (nameValue instanceof String) {
+                            providerName = nameValue.toString();
+                        }
+                    } catch (Exception e) {
+                        log.warn("Alleged Bouncy Castle class {} has no {}; ignoring this provider.", providerClass, NAME_FIELD,
+                                e);
+                    }
+                }
+                supported = Boolean.valueOf(providerName != null);
+            } else {
+                supported = Boolean.FALSE;
+            }
             supportHolder.set(supported);
         }
 

--- a/sshd-common/src/main/java/org/apache/sshd/common/util/security/eddsa/EdDSASecurityProviderRegistrar.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/util/security/eddsa/EdDSASecurityProviderRegistrar.java
@@ -44,7 +44,7 @@ public class EdDSASecurityProviderRegistrar extends AbstractSecurityProviderRegi
 
     @Override
     public boolean isEnabled() {
-        if (!super.isEnabled()) {
+        if (SecurityUtils.isFipsMode() || !super.isEnabled()) {
             return false;
         }
 

--- a/sshd-core/src/main/java/org/apache/sshd/common/kex/MontgomeryCurve.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/kex/MontgomeryCurve.java
@@ -136,7 +136,7 @@ public enum MontgomeryCurve implements KeySizeIndicator, OptionalFeature {
 
     @Override
     public boolean isSupported() {
-        return supported;
+        return supported && !SecurityUtils.isFipsMode();
     }
 
     public KeyAgreement createKeyAgreement() throws GeneralSecurityException {

--- a/sshd-core/src/main/java/org/apache/sshd/common/kex/SNTRUP761.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/kex/SNTRUP761.java
@@ -21,6 +21,7 @@ package org.apache.sshd.common.kex;
 import java.security.SecureRandom;
 import java.util.Arrays;
 
+import org.apache.sshd.common.util.security.SecurityUtils;
 import org.bouncycastle.crypto.AsymmetricCipherKeyPair;
 import org.bouncycastle.crypto.SecretWithEncapsulation;
 import org.bouncycastle.pqc.crypto.ntruprime.SNTRUPrimeKEMExtractor;
@@ -41,6 +42,9 @@ final class SNTRUP761 {
     }
 
     static boolean isSupported() {
+        if (SecurityUtils.isFipsMode()) {
+            return false;
+        }
         try {
             return SNTRUPrimeParameters.sntrup761.getSessionKeySize() == 256; // BC < 1.78 had only 128
         } catch (Throwable e) {


### PR DESCRIPTION
Decouple the registrar name from the security provider name. Also check whether the BC RandomGenerator exists at all; in BC-FIPS, it doesn't.