### PR TITLE
GH-618: Fix reading an OpenSshCertificate from a Buffer

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -40,6 +40,8 @@
 
 ## Bug Fixes
 
+* [GH-618](https://github.com/apache/mina-sshd/issues/618) Fix reading an `OpenSshCertificate` from a `Buffer`
+
 ## New Features
 
 ## Potential compatibility issues

--- a/sshd-common/src/main/java/org/apache/sshd/common/util/buffer/Buffer.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/util/buffer/Buffer.java
@@ -119,6 +119,11 @@ public abstract class Buffer implements Readable {
     public abstract byte[] getBytesConsumed();
 
     /**
+     * @return The bytes consumed since the given position
+     */
+    public abstract byte[] getBytesConsumed(int from);
+
+    /**
      * @param  pos A position in the <U>raw</U> underlying data bytes
      * @return     The byte at the specified position without changing the current {@link #rpos() read position}.
      *             <B>Note:</B> no validation is made whether the position lies within array boundaries

--- a/sshd-common/src/main/java/org/apache/sshd/common/util/buffer/ByteArrayBuffer.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/util/buffer/ByteArrayBuffer.java
@@ -164,6 +164,14 @@ public class ByteArrayBuffer extends Buffer {
     }
 
     @Override
+    public byte[] getBytesConsumed(int from) {
+        if (from >= rpos) {
+            return new byte[0];
+        }
+        return Arrays.copyOfRange(data, from, rpos);
+    }
+
+    @Override
     public byte rawByte(int pos) {
         return data[pos];
     }

--- a/sshd-common/src/main/java/org/apache/sshd/common/util/buffer/keys/OpenSSHCertPublicKeyParser.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/util/buffer/keys/OpenSSHCertPublicKeyParser.java
@@ -54,6 +54,7 @@ public class OpenSSHCertPublicKeyParser extends AbstractBufferPublicKeyParser<Op
     public OpenSshCertificate getRawPublicKey(String keyType, Buffer buffer) throws GeneralSecurityException {
         OpenSshCertificateImpl certificate = new OpenSshCertificateImpl();
         certificate.setKeyType(keyType);
+        final int pos = buffer.rpos();
 
         certificate.setNonce(buffer.getBytes());
 
@@ -84,7 +85,10 @@ public class OpenSSHCertPublicKeyParser extends AbstractBufferPublicKeyParser<Op
             throw new InvalidKeyException("Could not parse public CA key with ID: " + certificate.getId(), ex);
         }
 
-        certificate.setMessage(buffer.getBytesConsumed());
+        Buffer tmp = new ByteArrayBuffer();
+        tmp.putString(keyType);
+        tmp.putRawBytes(buffer.getBytesConsumed(pos));
+        certificate.setMessage(tmp.getCompactData());
         certificate.setSignature(buffer.getBytes());
 
         if (buffer.rpos() != buffer.wpos()) {

--- a/sshd-core/src/test/java/org/apache/sshd/certificates/OpenSSHCertificateParserTest.java
+++ b/sshd-core/src/test/java/org/apache/sshd/certificates/OpenSSHCertificateParserTest.java
@@ -32,15 +32,13 @@ import org.apache.sshd.common.config.keys.OpenSshCertificate;
 import org.apache.sshd.common.config.keys.PublicKeyEntry;
 import org.apache.sshd.common.signature.Signature;
 import org.apache.sshd.common.util.GenericUtils;
+import org.apache.sshd.common.util.buffer.Buffer;
+import org.apache.sshd.common.util.buffer.ByteArrayBuffer;
 import org.apache.sshd.common.util.io.IoUtils;
 import org.apache.sshd.util.test.BaseTestSupport;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Tag("NoIoTestCase") // see https://github.com/junit-team/junit/wiki/Parameterized-tests
 public class OpenSSHCertificateParserTest extends BaseTestSupport {
@@ -108,6 +106,13 @@ public class OpenSSHCertificateParserTest extends BaseTestSupport {
                     typedCert.getExtensions());
             assertEquals(params.sigAlgorithm, typedCert.getSignatureAlgorithm());
             verifySignature(typedCert);
+            Buffer buffer = new ByteArrayBuffer();
+            buffer.putPublicKey(typedCert);
+            PublicKey readFromBuffer = buffer.getPublicKey();
+            assertTrue(readFromBuffer instanceof OpenSshCertificate,
+                    () -> "Expected an OpenSshCertificate but got " + readFromBuffer.getClass().getName());
+            OpenSshCertificate readBack = (OpenSshCertificate) readFromBuffer;
+            verifySignature(readBack);
         }
     }
 


### PR DESCRIPTION
`Buffer.getBytesConsumed()` is broken. It'll return wrong data for buffers created on a slice of an array not starting at zero. Using it in `OpenSSHCertPublicKeyParser ` will return data before the raw certificate in the buffer if that raw certificate is not the first thing in the buffer.

Fix this by adding a `Buffer.getBytesConsumed(int from)` method, and use that in `OpenSSHCertPublicKeyParser`.

Fixes #618.