### PR TITLE
ML-KEM key exchanges using Bouncy Castle 1.79

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,7 +34,7 @@
 
 # [Version 2.13.1 to 2.13.2](./docs/changes/2.13.2.md)
 
-# [Version 2.13.1 to 2.14.0](./docs/changes/2.14.0.md)
+# [Version 2.13.2 to 2.14.0](./docs/changes/2.14.0.md)
 
 # Planned for next version
 
@@ -43,6 +43,8 @@
 * [GH-618](https://github.com/apache/mina-sshd/issues/618) Fix reading an `OpenSshCertificate` from a `Buffer`
 
 ## New Features
+
+* [GH-606](https://github.com/apache/mina-sshd/issues/606) Support ML-KEM PQC key exchange
 
 ## Potential compatibility issues
 

--- a/docs/standards.md
+++ b/docs/standards.md
@@ -30,6 +30,7 @@
 * [RFC 8731 - Secure Shell (SSH) Key Exchange Method Using Curve25519 and Curve448](https://tools.ietf.org/html/rfc8731)
 * [Key Exchange (KEX) Method Updates and Recommendations for Secure Shell](https://tools.ietf.org/html/draft-ietf-curdle-ssh-kex-sha2-03)
 * [Secure Shell (SSH) Key Exchange Method Using Hybrid Streamlined NTRU Prime sntrup761 and X25519 with SHA-512: sntrup761x25519-sha512](https://www.ietf.org/archive/id/draft-josefsson-ntruprime-ssh-02.html)
+* [PQ/T Hybrid Key Exchange in SSH](https://datatracker.ietf.org/doc/html/draft-kampanakis-curdle-ssh-pq-ke-04)
 
 ### OpenSSH
 
@@ -96,10 +97,11 @@ aes128-gcm@openssh.com, aes256-gcm@openssh.com, chacha20-poly1305@openssh.com, 3
 
 * diffie-hellman-group1-sha1, diffie-hellman-group-exchange-sha256, diffie-hellman-group14-sha1, diffie-hellman-group14-sha256
 , diffie-hellman-group15-sha512, diffie-hellman-group16-sha512, diffie-hellman-group17-sha512, diffie-hellman-group18-sha512
-, ecdh-sha2-nistp256, ecdh-sha2-nistp384, ecdh-sha2-nistp521, curve25519-sha256, curve25519-sha256@libssh.org, curve448-sha512,
-sntrup761x25519-sha512@openssh.com
-    * On Java versions before Java 11, [Bouncy Castle](./dependencies.md#bouncy-castle) is required for curve25519-sha256, curve25519-sha256@libssh.org, or curve448-sha512.
-    * [Bouncy Castle](./dependencies.md#bouncy-castle) is required for sntrup761x25519-sha512@openssh.com.
+, ecdh-sha2-nistp256, ecdh-sha2-nistp384, ecdh-sha2-nistp521, curve25519-sha256, curve25519-sha256@<!-- -->libssh.org, curve448-sha512
+    * On Java versions before Java 11, [Bouncy Castle](./dependencies.md#bouncy-castle) is required for curve25519-sha256, curve25519-sha256@<!-- -->libssh.org, or curve448-sha512.
+
+* If [Bouncy Castle](./dependencies.md#bouncy-castle) is present, the following post-quantum cryptography (PQC) hybrid key exchanges are also supported: sntrup761x25519-sha512, sntrup761x25519-sha512@<!-- -->openssh.com, mlkem768x25519-sha256, mlkem768nistp256-sha256, and
+mlkem1024nistp384-sha384.
 
 ### Compressions
 
@@ -108,9 +110,10 @@ sntrup761x25519-sha512@openssh.com
 ### Signatures/Keys
 
 * ssh-dss, ssh-rsa, rsa-sha2-256, rsa-sha2-512, nistp256, nistp384, nistp521
-, ssh-ed25519 (requires `eddsa` optional module), sk-ecdsa-sha2-nistp256@openssh.com, sk-ssh-ed25519@openssh.com
-, ssh-rsa-cert-v01@openssh.com, ssh-dss-cert-v01@openssh.com, ssh-ed25519-cert-v01@openssh.com
-, ecdsa-sha2-nistp256-cert-v01@openssh.com, ecdsa-sha2-nistp384-cert-v01@openssh.com, ecdsa-sha2-nistp521-cert-v01@openssh.com
+, ssh-ed25519 (requires `eddsa` optional module), sk-ecdsa-sha2-nistp256@openssh.com, sk-ssh-ed25519@<!-- -->openssh.com
+, ssh-rsa-cert-v01@<!-- -->openssh.com, ssh-dss-cert-v01<!-- -->@openssh.com, ssh-ed25519-cert-v01@<!-- -->openssh.com
+, ecdsa-sha2-nistp256-cert-v01@<!-- -->openssh.com, ecdsa-sha2-nistp384-cert-v01<!-- -->@openssh.com
+, ecdsa-sha2-nistp521-cert-v01<!-- -->@openssh.com
 
 **Note:** The above list contains all the supported security settings in the code. However, in accordance with the latest recommendations
 the default client/server setup includes only the security settings that are currently considered safe to use. Users who wish to include

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
         <ant.build.javac.target>${javac.target}</ant.build.javac.target>
 
         <groovy.version>4.0.17</groovy.version>
-        <bouncycastle.version>1.78.1</bouncycastle.version>
+        <bouncycastle.version>1.79</bouncycastle.version>
             <!-- NOTE: upgrading slf4j beyond this version causes
             
             Execution verify-style of goal org.apache.maven.plugins:maven-checkstyle-plugin:3.1.2:check failed.: NullPointerException

--- a/sshd-core/src/main/java/org/apache/sshd/common/BaseBuilder.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/BaseBuilder.java
@@ -89,6 +89,9 @@ public class BaseBuilder<T extends AbstractFactoryManager, S extends BaseBuilder
             Arrays.asList(
                     BuiltinDHFactories.sntrup761x25519,
                     BuiltinDHFactories.sntrup761x25519_openssh,
+                    BuiltinDHFactories.mlkem768x25519,
+                    BuiltinDHFactories.mlkem1024nistp384,
+                    BuiltinDHFactories.mlkem768nistp256,
                     BuiltinDHFactories.curve25519,
                     BuiltinDHFactories.curve25519_libssh,
                     BuiltinDHFactories.curve448,

--- a/sshd-core/src/main/java/org/apache/sshd/common/BaseBuilder.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/BaseBuilder.java
@@ -88,6 +88,7 @@ public class BaseBuilder<T extends AbstractFactoryManager, S extends BaseBuilder
     public static final List<BuiltinDHFactories> DEFAULT_KEX_PREFERENCE = Collections.unmodifiableList(
             Arrays.asList(
                     BuiltinDHFactories.sntrup761x25519,
+                    BuiltinDHFactories.sntrup761x25519_openssh,
                     BuiltinDHFactories.curve25519,
                     BuiltinDHFactories.curve25519_libssh,
                     BuiltinDHFactories.curve448,

--- a/sshd-core/src/main/java/org/apache/sshd/common/kex/BuiltinDHFactories.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/kex/BuiltinDHFactories.java
@@ -303,6 +303,86 @@ public enum BuiltinDHFactories implements DHFactory {
         }
     },
     /**
+     * @see <a href= "https://datatracker.ietf.org/doc/html/draft-kampanakis-curdle-ssh-pq-ke-04">PQ/T Hybrid Key
+     *      Exchange in SSH</a>
+     */
+    mlkem768x25519(Constants.MLKEM768_25519_SHA256) {
+        @Override
+        public XDH create(Object... params) throws Exception {
+            if (!GenericUtils.isEmpty(params)) {
+                throw new IllegalArgumentException("No accepted parameters for " + getName());
+            }
+            return new XDH(MontgomeryCurve.x25519, true) {
+
+                @Override
+                public KeyEncapsulationMethod getKeyEncapsulation() {
+                    return BuiltinKEM.mlkem768;
+                }
+
+                @Override
+                public Digest getHash() throws Exception {
+                    return BuiltinDigests.sha256.create();
+                }
+            };
+        }
+
+        @Override
+        public boolean isSupported() {
+            return MontgomeryCurve.x25519.isSupported() && BuiltinDigests.sha256.isSupported()
+                    && BuiltinKEM.mlkem768.isSupported();
+        }
+    },
+    /**
+     * @see <a href= "https://datatracker.ietf.org/doc/html/draft-kampanakis-curdle-ssh-pq-ke-04">PQ/T Hybrid Key
+     *      Exchange in SSH</a>
+     */
+    mlkem768nistp256(Constants.MLKEM768_NISTP256_SHA256) {
+        @Override
+        public ECDH create(Object... params) throws Exception {
+            if (!GenericUtils.isEmpty(params)) {
+                throw new IllegalArgumentException("No accepted parameters for " + getName());
+            }
+            return new ECDH(ECCurves.nistp256, true) {
+
+                @Override
+                public KeyEncapsulationMethod getKeyEncapsulation() {
+                    return BuiltinKEM.mlkem768;
+                }
+
+            };
+        }
+
+        @Override
+        public boolean isSupported() {
+            return ECCurves.nistp256.isSupported() && BuiltinKEM.mlkem768.isSupported();
+        }
+    },
+    /**
+     * @see <a href= "https://datatracker.ietf.org/doc/html/draft-kampanakis-curdle-ssh-pq-ke-04">PQ/T Hybrid Key
+     *      Exchange in SSH</a>
+     */
+    mlkem1024nistp384(Constants.MLKEM1024_NISTP384_SHA384) {
+        @Override
+        public ECDH create(Object... params) throws Exception {
+            if (!GenericUtils.isEmpty(params)) {
+                throw new IllegalArgumentException("No accepted parameters for " + getName());
+            }
+            return new ECDH(ECCurves.nistp384, true) {
+
+                @Override
+                public KeyEncapsulationMethod getKeyEncapsulation() {
+                    return BuiltinKEM.mlkem1024;
+                }
+
+            };
+        }
+
+        @Override
+        public boolean isSupported() {
+            return ECCurves.nistp384.isSupported() && BuiltinKEM.mlkem1024.isSupported();
+        }
+    },
+    /**
      * @see <a href=
      *      "https://www.ietf.org/archive/id/draft-josefsson-ntruprime-ssh-02.html">draft-josefsson-ntruprime-ssh-02.html</a>
      */
@@ -524,6 +604,9 @@ public enum BuiltinDHFactories implements DHFactory {
         public static final String CURVE25519_SHA256 = "curve25519-sha256";
         public static final String CURVE25519_SHA256_LIBSSH = CURVE25519_SHA256 + "@libssh.org";
         public static final String CURVE448_SHA512 = "curve448-sha512";
+        public static final String MLKEM768_25519_SHA256 = "mlkem768x25519-sha256";
+        public static final String MLKEM768_NISTP256_SHA256 = "mlkem768nistp256-sha256";
+        public static final String MLKEM1024_NISTP384_SHA384 = "mlkem1024nistp384-sha384";
         public static final String SNTRUP761_25519_SHA512 = "sntrup761x25519-sha512";
         public static final String SNTRUP761_25519_SHA512_OPENSSH = SNTRUP761_25519_SHA512 + "@openssh.com";
 

--- a/sshd-core/src/main/java/org/apache/sshd/common/kex/BuiltinDHFactories.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/kex/BuiltinDHFactories.java
@@ -270,23 +270,13 @@ public enum BuiltinDHFactories implements DHFactory {
     },
     curve25519_libssh(Constants.CURVE25519_SHA256_LIBSSH) {
         @Override
-        public XDH create(Object... params) throws Exception {
-            if (!GenericUtils.isEmpty(params)) {
-                throw new IllegalArgumentException("No accepted parameters for " + getName());
-            }
-            return new XDH(MontgomeryCurve.x25519, false) {
-
-                @Override
-                public Digest getHash() throws Exception {
-                    return BuiltinDigests.sha256.create();
-                }
-
-            };
+        public AbstractDH create(Object... params) throws Exception {
+            return curve25519.create(params);
         }
 
         @Override
         public boolean isSupported() {
-            return MontgomeryCurve.x25519.isSupported() && BuiltinDigests.sha256.isSupported();
+            return curve25519.isSupported();
         }
     },
     /**
@@ -348,28 +338,13 @@ public enum BuiltinDHFactories implements DHFactory {
      */
     sntrup761x25519_openssh(Constants.SNTRUP761_25519_SHA512_OPENSSH) {
         @Override
-        public XDH create(Object... params) throws Exception {
-            if (!GenericUtils.isEmpty(params)) {
-                throw new IllegalArgumentException("No accepted parameters for " + getName());
-            }
-            return new XDH(MontgomeryCurve.x25519, true) {
-
-                @Override
-                public KeyEncapsulationMethod getKeyEncapsulation() {
-                    return BuiltinKEM.sntrup761;
-                }
-
-                @Override
-                public Digest getHash() throws Exception {
-                    return BuiltinDigests.sha512.create();
-                }
-            };
+        public AbstractDH create(Object... params) throws Exception {
+            return sntrup761x25519.create(params);
         }
 
         @Override
         public boolean isSupported() {
-            return MontgomeryCurve.x25519.isSupported() && BuiltinDigests.sha512.isSupported()
-                    && BuiltinKEM.sntrup761.isSupported();
+            return sntrup761x25519.isSupported();
         }
     };
 
@@ -547,10 +522,10 @@ public enum BuiltinDHFactories implements DHFactory {
         public static final String ECDH_SHA2_NISTP384 = "ecdh-sha2-nistp384";
         public static final String ECDH_SHA2_NISTP521 = "ecdh-sha2-nistp521";
         public static final String CURVE25519_SHA256 = "curve25519-sha256";
-        public static final String CURVE25519_SHA256_LIBSSH = "curve25519-sha256@libssh.org";
+        public static final String CURVE25519_SHA256_LIBSSH = CURVE25519_SHA256 + "@libssh.org";
         public static final String CURVE448_SHA512 = "curve448-sha512";
         public static final String SNTRUP761_25519_SHA512 = "sntrup761x25519-sha512";
-        public static final String SNTRUP761_25519_SHA512_OPENSSH = "sntrup761x25519-sha512@openssh.com";
+        public static final String SNTRUP761_25519_SHA512_OPENSSH = SNTRUP761_25519_SHA512 + "@openssh.com";
 
         private Constants() {
             throw new UnsupportedOperationException("No instance allowed");

--- a/sshd-core/src/main/java/org/apache/sshd/common/kex/BuiltinKEM.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/kex/BuiltinKEM.java
@@ -26,6 +26,44 @@ import org.apache.sshd.common.OptionalFeature;
  */
 public enum BuiltinKEM implements KeyEncapsulationMethod, NamedResource, OptionalFeature {
 
+    mlkem768("mlkem768") {
+
+        @Override
+        public Client getClient() {
+            return MLKEM.getClient(MLKEM.Parameters.mlkem768);
+        }
+
+        @Override
+        public Server getServer() {
+            return MLKEM.getServer(MLKEM.Parameters.mlkem768);
+        }
+
+        @Override
+        public boolean isSupported() {
+            return MLKEM.Parameters.mlkem768.isSupported();
+        }
+
+    },
+
+    mlkem1024("mlkem1024") {
+
+        @Override
+        public Client getClient() {
+            return MLKEM.getClient(MLKEM.Parameters.mlkem1024);
+        }
+
+        @Override
+        public Server getServer() {
+            return MLKEM.getServer(MLKEM.Parameters.mlkem1024);
+        }
+
+        @Override
+        public boolean isSupported() {
+            return MLKEM.Parameters.mlkem1024.isSupported();
+        }
+
+    },
+
     sntrup761("sntrup761") {
 
         @Override

--- a/sshd-core/src/main/java/org/apache/sshd/common/kex/CurveSizeIndicator.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/kex/CurveSizeIndicator.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sshd.common.kex;
+
+/**
+ * @author <a href="mailto:dev@mina.apache.org">Apache MINA SSHD Project</a>
+ */
+public interface CurveSizeIndicator {
+
+    /**
+     * Retrieves the length of a point coordinate in bytes.
+     *
+     * @return the length
+     */
+    int getByteLength();
+}

--- a/sshd-core/src/main/java/org/apache/sshd/common/kex/KeyEncapsulationMethod.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/kex/KeyEncapsulationMethod.java
@@ -64,6 +64,13 @@ public interface KeyEncapsulationMethod {
     interface Server {
 
         /**
+         * Retrieves the required length of the KEM public key, in bytes.
+         *
+         * @return the length of the key
+         */
+        int getPublicKeyLength();
+
+        /**
          * Initializes the KEM with a public key received from a client and prepares an encapsulated secret.
          *
          * @param  publicKey                data received from the client, expected to contain the public key at the

--- a/sshd-core/src/main/java/org/apache/sshd/common/kex/MLKEM.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/kex/MLKEM.java
@@ -1,0 +1,182 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sshd.common.kex;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+import org.apache.sshd.common.OptionalFeature;
+import org.apache.sshd.common.random.JceRandom;
+import org.bouncycastle.crypto.AsymmetricCipherKeyPair;
+import org.bouncycastle.crypto.SecretWithEncapsulation;
+import org.bouncycastle.pqc.crypto.mlkem.MLKEMExtractor;
+import org.bouncycastle.pqc.crypto.mlkem.MLKEMGenerator;
+import org.bouncycastle.pqc.crypto.mlkem.MLKEMKeyGenerationParameters;
+import org.bouncycastle.pqc.crypto.mlkem.MLKEMKeyPairGenerator;
+import org.bouncycastle.pqc.crypto.mlkem.MLKEMParameters;
+import org.bouncycastle.pqc.crypto.mlkem.MLKEMPrivateKeyParameters;
+import org.bouncycastle.pqc.crypto.mlkem.MLKEMPublicKeyParameters;
+
+/**
+ * An implementation of the mlkem768 key encapsulation method (KEM), formerly known as Kyber, using Bouncy Castle. But
+ * see appendix C of FIPS 203 ("Differences From the CRYSTALS-Kyber Submission").
+ * <p>
+ * NIST specifies that they removed a hash in the encapsulation/decapsulation methods.
+ * </p>
+ *
+ * @see <a href="https://nvlpubs.nist.gov/nistpubs/fips/nist.fips.203.pdf">NIST FIPS 203</a>
+ */
+final class MLKEM {
+
+    enum Parameters implements OptionalFeature {
+        // For key sizes see NIST FIPS 203, section 8, table 3. Bouncy Castle does not expose the
+        // public key sizes through its API. (Though they compute them internally.)
+        mlkem768(1184) {
+
+            @Override
+            Object getMLKEMParameters() {
+                return MLKEMParameters.ml_kem_768;
+            }
+        },
+        mlkem1024(1568) {
+
+            @Override
+            Object getMLKEMParameters() {
+                return MLKEMParameters.ml_kem_1024;
+            }
+        };
+
+        private final int publicKeySize;
+
+        Parameters(int publicKeySize) {
+            this.publicKeySize = publicKeySize;
+        }
+
+        // Return type is Object on purpose. We want delayed class loading here so that we can use this
+        // even if Bouncy Castle is not present. (If it isn't, we'll return false from isSupported at
+        // run-time, and then never use this algorithm.)
+        abstract Object getMLKEMParameters();
+
+        int getPublicKeySize() {
+            return publicKeySize;
+        }
+
+        @Override
+        public boolean isSupported() {
+            try {
+                // If we get a ClassNotFoundException or some such, we return false.
+                return getMLKEMParameters() != null;
+            } catch (Throwable e) {
+                return false;
+            }
+        }
+    }
+
+    private MLKEM() {
+        // No instantiation
+    }
+
+    static KeyEncapsulationMethod.Client getClient(Parameters parameters) {
+        return new Client(parameters);
+    }
+
+    static KeyEncapsulationMethod.Server getServer(Parameters parameters) {
+        return new Server(parameters);
+    }
+
+    private static class Client implements KeyEncapsulationMethod.Client {
+
+        private final Parameters parameters;
+
+        private MLKEMExtractor extractor;
+        private MLKEMPublicKeyParameters publicKey;
+
+        Client(Parameters parameters) {
+            this.parameters = Objects.requireNonNull(parameters, "No MLKEM.Parameters given");
+        }
+
+        @Override
+        public void init() {
+            MLKEMKeyPairGenerator gen = new MLKEMKeyPairGenerator();
+            gen.init(new MLKEMKeyGenerationParameters(JceRandom.getGlobalInstance(),
+                    (MLKEMParameters) parameters.getMLKEMParameters()));
+            AsymmetricCipherKeyPair pair = gen.generateKeyPair();
+            extractor = new MLKEMExtractor((MLKEMPrivateKeyParameters) pair.getPrivate());
+            publicKey = (MLKEMPublicKeyParameters) pair.getPublic();
+        }
+
+        @Override
+        public byte[] getPublicKey() {
+            return publicKey.getEncoded();
+        }
+
+        @Override
+        public byte[] extractSecret(byte[] encapsulated) {
+            if (encapsulated.length != getEncapsulationLength()) {
+                throw new IllegalArgumentException("KEM encpsulation has wrong length: " + encapsulated.length);
+            }
+            return extractor.extractSecret(encapsulated);
+        }
+
+        @Override
+        public int getEncapsulationLength() {
+            return extractor.getEncapsulationLength();
+        }
+    }
+
+    private static class Server implements KeyEncapsulationMethod.Server {
+
+        private final Parameters parameters;
+
+        private SecretWithEncapsulation value;
+
+        Server(Parameters parameters) {
+            this.parameters = Objects.requireNonNull(parameters, "No MLKEM.Parameters given");
+        }
+
+        @Override
+        public int getPublicKeyLength() {
+            return parameters.getPublicKeySize();
+        }
+
+        @Override
+        public byte[] init(byte[] publicKey) {
+            int pkBytes = getPublicKeyLength();
+            if (publicKey.length < pkBytes) {
+                throw new IllegalArgumentException("KEM public key too short: " + publicKey.length);
+            }
+            byte[] pk = Arrays.copyOf(publicKey, pkBytes);
+            MLKEMGenerator kemGenerator = new MLKEMGenerator(JceRandom.getGlobalInstance());
+            MLKEMPublicKeyParameters params = new MLKEMPublicKeyParameters((MLKEMParameters) parameters.getMLKEMParameters(),
+                    pk);
+            value = kemGenerator.generateEncapsulated(params);
+            return Arrays.copyOfRange(publicKey, pkBytes, publicKey.length);
+        }
+
+        @Override
+        public byte[] getSecret() {
+            return value.getSecret();
+        }
+
+        @Override
+        public byte[] getEncapsulation() {
+            return value.getEncapsulation();
+        }
+    }
+}

--- a/sshd-core/src/main/java/org/apache/sshd/common/kex/SNTRUP761.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/kex/SNTRUP761.java
@@ -98,8 +98,13 @@ final class SNTRUP761 {
         }
 
         @Override
+        public int getPublicKeyLength() {
+            return SNTRUPrimeParameters.sntrup761.getPublicKeyBytes();
+        }
+
+        @Override
         public byte[] init(byte[] publicKey) {
-            int pkBytes = SNTRUPrimeParameters.sntrup761.getPublicKeyBytes();
+            int pkBytes = getPublicKeyLength();
             if (publicKey.length < pkBytes) {
                 throw new IllegalArgumentException("KEM public key too short: " + publicKey.length);
             }

--- a/sshd-core/src/main/java/org/apache/sshd/common/kex/XDH.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/kex/XDH.java
@@ -29,7 +29,7 @@ import org.apache.sshd.common.util.buffer.Buffer;
  *
  * @see <a href="https://www.rfc-editor.org/info/rfc8731">RFC 8731</a>
  */
-public abstract class XDH extends AbstractDH {
+public abstract class XDH extends AbstractDH implements CurveSizeIndicator {
 
     protected final MontgomeryCurve curve;
     protected final boolean raw;
@@ -41,8 +41,9 @@ public abstract class XDH extends AbstractDH {
         myKeyAgree = curve.createKeyAgreement();
     }
 
-    public int getKeySize() {
-        return curve.getKeySize();
+    @Override
+    public int getByteLength() {
+        return curve.getByteLength();
     }
 
     @Override

--- a/sshd-core/src/test/java/org/apache/sshd/common/kex/OpenSshMlKemTest.java
+++ b/sshd-core/src/test/java/org/apache/sshd/common/kex/OpenSshMlKemTest.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sshd.common.kex;
+
+import java.security.Security;
+import java.util.Collections;
+
+import org.apache.sshd.client.ClientBuilder;
+import org.apache.sshd.client.SshClient;
+import org.apache.sshd.client.future.AuthFuture;
+import org.apache.sshd.client.session.ClientSession;
+import org.apache.sshd.common.keyprovider.FileKeyPairProvider;
+import org.apache.sshd.util.test.BaseTestSupport;
+import org.apache.sshd.util.test.CommonTestSupportUtils;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.images.builder.ImageFromDockerfile;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.MountableFile;
+
+/**
+ * Test ciphers against OpenSSH. Force resetting ciphers every time to verify that they are res-initialized correctly.
+ *
+ * @author <a href="mailto:dev@mina.apache.org">Apache MINA SSHD Project</a>
+ */
+@Tag("ContainerTestCase")
+@Testcontainers
+class OpenSshMlKemTest extends BaseTestSupport {
+
+    private static final Logger LOG = LoggerFactory.getLogger(OpenSshMlKemTest.class);
+
+    // Re-use an already defined key
+    private static final String TEST_RESOURCES = "org/apache/sshd/common/kex/extensions/client";
+
+    @Container
+    GenericContainer<?> sshdContainer = new GenericContainer<>(new ImageFromDockerfile()
+            .withDockerfileFromBuilder(builder -> builder.from("alpine:20240807") //
+                    .run("apk --update add openssh-server") // Installs OpenSSH 9.9
+                    // Enable deprecated ciphers
+                    .run("ssh-keygen -A") // Generate multiple host keys
+                    .run("adduser -D bob") // Add a user
+                    .run("echo 'bob:passwordBob' | chpasswd") // Give it a password to unlock the user
+                    .run("mkdir -p /home/bob/.ssh") // Create the SSH config directory
+                    .entryPoint("/entrypoint.sh") // Sets bob as owner of anything under /home/bob and launches sshd
+                    .build())) //
+            .withCopyFileToContainer(MountableFile.forClasspathResource(TEST_RESOURCES + "/bob_key.pub"),
+                    "/home/bob/.ssh/authorized_keys")
+            // entrypoint must be executable. Spotbugs doesn't like 0777, so use hex
+            .withCopyFileToContainer(
+                    MountableFile.forClasspathResource(TEST_RESOURCES + "/entrypoint.sh", 0x1ff),
+                    "/entrypoint.sh")
+            .waitingFor(Wait.forLogMessage(".*Server listening on :: port 22.*\\n", 1)).withExposedPorts(22) //
+            .withLogConsumer(new Slf4jLogConsumer(LOG));
+
+    @BeforeAll
+    static void registerBouncyCastleProviderIfNecessary() {
+        if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
+            Security.addProvider(new BouncyCastleProvider());
+        }
+    }
+
+    @Test
+    void mlkem768x25519() throws Exception {
+        Assumptions.assumeTrue(BuiltinDHFactories.mlkem768x25519.isSupported());
+        FileKeyPairProvider keyPairProvider = CommonTestSupportUtils.createTestKeyPairProvider(TEST_RESOURCES + "/bob_key");
+        SshClient client = setupTestClient();
+        client.setKeyIdentityProvider(keyPairProvider);
+        client.setKeyExchangeFactories(
+                Collections.singletonList(ClientBuilder.DH2KEX.apply(BuiltinDHFactories.mlkem768x25519)));
+        client.start();
+
+        Integer actualPort = sshdContainer.getMappedPort(22);
+        String actualHost = sshdContainer.getHost();
+        try (ClientSession session = client.connect("bob", actualHost, actualPort).verify(CONNECT_TIMEOUT).getSession()) {
+            AuthFuture authed = session.auth().verify(AUTH_TIMEOUT);
+            assertTrue(authed.isDone() && authed.isSuccess());
+        } finally {
+            client.stop();
+        }
+    }
+}

--- a/sshd-mina/pom.xml
+++ b/sshd-mina/pom.xml
@@ -125,6 +125,7 @@
                         <exclude>**/SessionReKeyHostKeyExchangeTest.java</exclude>
                         <exclude>**/HostBoundPubKeyAuthTest.java</exclude>
                         <exclude>**/OpenSshCipherTest.java</exclude>
+                        <exclude>**/OpenSshMlKemTest.java</exclude>
                         <exclude>**/PortForwardingWithOpenSshTest.java</exclude>
                         <exclude>**/StrictKexInteroperabilityTest.java</exclude>
                         <!-- reading files from classpath doesn't work correctly w/ reusable test jar -->

--- a/sshd-netty/pom.xml
+++ b/sshd-netty/pom.xml
@@ -149,6 +149,7 @@
                         <exclude>**/SessionReKeyHostKeyExchangeTest.java</exclude>
                         <exclude>**/HostBoundPubKeyAuthTest.java</exclude>
                         <exclude>**/OpenSshCipherTest.java</exclude>
+                        <exclude>**/OpenSshMlKemTest.java</exclude>
                         <exclude>**/PortForwardingWithOpenSshTest.java</exclude>
                         <exclude>**/StrictKexInteroperabilityTest.java</exclude>
                         <!-- reading files from classpath doesn't work correctly w/ reusable test jar -->


### PR DESCRIPTION
Implement ML-KEM key exchanges; see https://datatracker.ietf.org/doc/html/draft-kampanakis-curdle-ssh-pq-ke-04 .
All three algorithms proposed in that draft RFC are implemented.

Includes an interoperability test for mlkem768x25519-sha256 against OpenSSH 9.9.

Fixes #606.

