### PR TITLE
GH-628: Fix reading directories with trailing blanks in the name

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -41,10 +41,11 @@
 ## Bug Fixes
 
 * [GH-618](https://github.com/apache/mina-sshd/issues/618) Fix reading an `OpenSshCertificate` from a `Buffer`
+* [GH-628](https://github.com/apache/mina-sshd/issues/628) SFTP: fix reading directories with trailing blanks in the name
 
 ## New Features
 
-* [GH-606](https://github.com/apache/mina-sshd/issues/606) Support ML-KEM PQC key exchange
+* [GH-606](https://github.com/apache/mina-sshd/issues/606) Support ML-KEM PQC hybrid key exchanges
 
 ## Potential compatibility issues
 

--- a/sshd-common/src/main/java/org/apache/sshd/common/util/ValidateUtils.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/util/ValidateUtils.java
@@ -51,6 +51,27 @@ public final class ValidateUtils {
         return t;
     }
 
+    public static String hasContent(String t, String message) {
+        if (t == null || t.isEmpty()) {
+            throwIllegalArgumentException(message);
+        }
+        return t;
+    }
+
+    public static String hasContent(String t, String message, Object arg) {
+        if (t == null || t.isEmpty()) {
+            throwIllegalArgumentException(message, arg);
+        }
+        return t;
+    }
+
+    public static String hasContent(String t, String message, Object... args) {
+        if (t == null || t.isEmpty()) {
+            throwIllegalArgumentException(message, args);
+        }
+        return t;
+    }
+
     public static String checkNotNullAndNotEmpty(String t, String message) {
         t = checkNotNull(t, message).trim();
         checkTrue(GenericUtils.length(t) > 0, message);

--- a/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/impl/SftpDirEntryIterator.java
+++ b/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/impl/SftpDirEntryIterator.java
@@ -77,7 +77,7 @@ public class SftpDirEntryIterator extends AbstractLoggingBean implements SftpCli
      */
     public SftpDirEntryIterator(SftpClient client, String path, Handle dirHandle, boolean closeOnFinished) {
         this.client = Objects.requireNonNull(client, "No SFTP client instance");
-        this.dirPath = ValidateUtils.checkNotNullAndNotEmpty(path, "No path");
+        this.dirPath = ValidateUtils.hasContent(path, "No path");
         this.dirHandle = Objects.requireNonNull(dirHandle, "No directory handle");
         this.closeOnFinished = closeOnFinished;
         this.dirEntries = load(dirHandle);

--- a/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/impl/SftpIterableDirEntry.java
+++ b/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/impl/SftpIterableDirEntry.java
@@ -42,7 +42,7 @@ public class SftpIterableDirEntry implements SftpClientHolder, Iterable<DirEntry
      */
     public SftpIterableDirEntry(SftpClient client, String path) {
         this.client = Objects.requireNonNull(client, "No client instance");
-        this.path = ValidateUtils.checkNotNullAndNotEmpty(path, "No remote path");
+        this.path = ValidateUtils.hasContent(path, "No remote path");
     }
 
     @Override


### PR DESCRIPTION
`ValidateUtils.checkNotNullAndNotEmpty(String, ...)` as a side-effect returns the trimmed string!

Add new methods `ValidateUtils.hasContent(String, ...)` that don't do so, and use that instead.

Fixes #628.