### PR TITLE
GH-636: Handle unknown key types in known_hosts

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -43,6 +43,7 @@
 * [GH-618](https://github.com/apache/mina-sshd/issues/618) Fix reading an `OpenSshCertificate` from a `Buffer`
 * [GH-626](https://github.com/apache/mina-sshd/issues/626) Enable `Streaming.Async` for `ChannelDirectTcpip`
 * [GH-628](https://github.com/apache/mina-sshd/issues/628) SFTP: fix reading directories with trailing blanks in the name
+* [GH-636](https://github.com/apache/mina-sshd/issues/636) Fix handling of unsupported key types in `known_hosts` file
 
 ## New Features
 

--- a/sshd-common/src/main/java/org/apache/sshd/client/config/hosts/KnownHostEntry.java
+++ b/sshd-common/src/main/java/org/apache/sshd/client/config/hosts/KnownHostEntry.java
@@ -252,9 +252,8 @@ public class KnownHostEntry extends HostPatternsHolder {
             entry.setHashedEntry(null);
             entry.setPatterns(parsePatterns(GenericUtils.split(hostPattern, ',')));
         }
-
-        AuthorizedKeyEntry key = ValidateUtils.checkNotNull(AuthorizedKeyEntry.parseAuthorizedKeyEntry(line),
-                "No valid key entry recovered from line=%s", data);
+        AuthorizedKeyEntry key = PublicKeyEntry.parsePublicKeyEntry(new AuthorizedKeyEntry(),
+                ValidateUtils.checkNotNullAndNotEmpty(line, "No valid key entry recovered from line=%s", data));
         entry.setKeyEntry(key);
         return entry;
     }

--- a/sshd-common/src/main/java/org/apache/sshd/common/config/keys/KeyUtils.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/config/keys/KeyUtils.java
@@ -859,6 +859,8 @@ public final class KeyUtils {
     public static String getKeyType(Key key) {
         if (key == null) {
             return null;
+        } else if (key instanceof SshPublicKey) {
+            return ((SshPublicKey) key).getKeyType();
         } else if (key instanceof DSAKey) {
             return KeyPairProvider.SSH_DSS;
         } else if (key instanceof RSAKey) {
@@ -872,14 +874,8 @@ public final class KeyUtils {
             } else {
                 return curve.getKeyType();
             }
-        } else if (key instanceof SkEcdsaPublicKey) {
-            return SkECDSAPublicKeyEntryDecoder.KEY_TYPE;
         } else if (SecurityUtils.EDDSA.equalsIgnoreCase(key.getAlgorithm())) {
             return KeyPairProvider.SSH_ED25519;
-        } else if (key instanceof SkED25519PublicKey) {
-            return SkED25519PublicKeyEntryDecoder.KEY_TYPE;
-        } else if (key instanceof OpenSshCertificate) {
-            return ((OpenSshCertificate) key).getKeyType();
         }
 
         return null;
@@ -1063,6 +1059,9 @@ public final class KeyUtils {
     }
 
     public static boolean compareKeys(PublicKey k1, PublicKey k2) {
+        if (Objects.equals(k1, k2)) {
+            return true;
+        }
         if ((k1 instanceof RSAPublicKey) && (k2 instanceof RSAPublicKey)) {
             return compareRSAKeys(RSAPublicKey.class.cast(k1), RSAPublicKey.class.cast(k2));
         } else if ((k1 instanceof DSAPublicKey) && (k2 instanceof DSAPublicKey)) {

--- a/sshd-common/src/main/java/org/apache/sshd/common/config/keys/OpenSshCertificate.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/config/keys/OpenSshCertificate.java
@@ -35,7 +35,7 @@ import org.apache.sshd.common.util.ValidateUtils;
  * @author <a href="mailto:dev@mina.apache.org">Apache MINA SSHD Project</a>
  * @see    <a href= "https://cvsweb.openbsd.org/src/usr.bin/ssh/PROTOCOL.certkeys?annotate=HEAD">PROTOCOL.certkeys</a>
  */
-public interface OpenSshCertificate extends PublicKey, PrivateKey {
+public interface OpenSshCertificate extends SshPublicKey, PrivateKey {
 
     /**
      * {@link OpenSshCertificate}s have a type indicating whether the certificate if for a host key (certifying a host
@@ -89,13 +89,6 @@ public interface OpenSshCertificate extends PublicKey, PrivateKey {
      * @return the nonce.
      */
     byte[] getNonce();
-
-    /**
-     * Retrieves the SSH key type of this certificate.
-     *
-     * @return the key type, for instance "ssh-rsa-cert-v01@openssh.com"
-     */
-    String getKeyType();
 
     /**
      * Retrieves the certified public key.

--- a/sshd-common/src/main/java/org/apache/sshd/common/config/keys/PublicKeyEntryResolver.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/config/keys/PublicKeyEntryResolver.java
@@ -65,6 +65,22 @@ public interface PublicKeyEntryResolver {
     };
 
     /**
+     * A resolver that returns an {@link UnsupportedSshPublicKey} for any input.
+     */
+    PublicKeyEntryResolver UNSUPPORTED = new PublicKeyEntryResolver() {
+        @Override
+        public PublicKey resolve(SessionContext session, String keyType, byte[] keyData, Map<String, String> headers)
+                throws IOException, GeneralSecurityException {
+            return new UnsupportedSshPublicKey(keyType, keyData);
+        }
+
+        @Override
+        public String toString() {
+            return "UNSUPPORTED";
+        }
+    };
+
+    /**
      * @param  session                  The {@link SessionContext} for invoking this load command - may be {@code null}
      *                                  if not invoked within a session context (e.g., offline tool or session unknown).
      * @param  keyType                  The {@code OpenSSH} reported key type

--- a/sshd-common/src/main/java/org/apache/sshd/common/config/keys/SshPublicKey.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/config/keys/SshPublicKey.java
@@ -16,16 +16,22 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.sshd.common.config.keys.u2f;
+package org.apache.sshd.common.config.keys;
 
 import java.security.PublicKey;
 
-import org.apache.sshd.common.config.keys.SshPublicKey;
+/**
+ * A {@link PublicKey} that has an SSH key type.
+ *
+ * @author <a href="mailto:dev@mina.apache.org">Apache MINA SSHD Project</a>
+ */
+public interface SshPublicKey extends PublicKey {
 
-public interface SecurityKeyPublicKey<K extends PublicKey> extends SshPublicKey {
-    String getAppName();
+    /**
+     * Retrieves the SSH key type.
+     *
+     * @return the SSH key type, never {@code null}.
+     */
+    String getKeyType();
 
-    boolean isNoTouchRequired();
-
-    K getDelegatePublicKey();
 }

--- a/sshd-common/src/main/java/org/apache/sshd/common/config/keys/UnsupportedSshPublicKey.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/config/keys/UnsupportedSshPublicKey.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sshd.common.config.keys;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+/**
+ * A representation of an unsupported SSH public key -- just a key type and the raw key data.
+ *
+ * @author <a href="mailto:dev@mina.apache.org">Apache MINA SSHD Project</a>
+ */
+public class UnsupportedSshPublicKey implements SshPublicKey {
+
+    private static final long serialVersionUID = -4870624671501562706L;
+
+    private final String keyType;
+
+    private final byte[] keyData;
+
+    public UnsupportedSshPublicKey(String keyType, byte[] keyData) {
+        this.keyType = keyType;
+        this.keyData = keyData.clone();
+    }
+
+    @Override
+    public String getAlgorithm() {
+        // Won't match any JCE algorithm.
+        return getKeyType();
+    }
+
+    @Override
+    public String getFormat() {
+        // We cannot produce an encoding for an unsupported key.
+        return null;
+    }
+
+    @Override
+    public byte[] getEncoded() {
+        // We cannot produce an encoding for an unsupported key.
+        return null;
+    }
+
+    @Override
+    public String getKeyType() {
+        return keyType;
+    }
+
+    /**
+     * Retrieves the raw key bytes (serialized form).
+     *
+     * @return the key bytes
+     */
+    public byte[] getKeyData() {
+        return keyData.clone();
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(keyData) * 31 + Objects.hash(keyType);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof UnsupportedSshPublicKey)) {
+            return false;
+        }
+        UnsupportedSshPublicKey other = (UnsupportedSshPublicKey) obj;
+        return Arrays.equals(keyData, other.keyData) && Objects.equals(keyType, other.keyType);
+    }
+
+}

--- a/sshd-common/src/main/java/org/apache/sshd/common/config/keys/u2f/SkED25519PublicKey.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/config/keys/u2f/SkED25519PublicKey.java
@@ -21,6 +21,7 @@ package org.apache.sshd.common.config.keys.u2f;
 import java.util.Objects;
 
 import net.i2p.crypto.eddsa.EdDSAPublicKey;
+import org.apache.sshd.common.config.keys.impl.SkED25519PublicKeyEntryDecoder;
 
 public class SkED25519PublicKey implements SecurityKeyPublicKey<EdDSAPublicKey> {
 
@@ -41,6 +42,11 @@ public class SkED25519PublicKey implements SecurityKeyPublicKey<EdDSAPublicKey> 
     @Override
     public String getAlgorithm() {
         return ALGORITHM;
+    }
+
+    @Override
+    public String getKeyType() {
+        return SkED25519PublicKeyEntryDecoder.KEY_TYPE;
     }
 
     @Override
@@ -99,4 +105,5 @@ public class SkED25519PublicKey implements SecurityKeyPublicKey<EdDSAPublicKey> 
                 && this.noTouchRequired == other.noTouchRequired
                 && Objects.equals(this.delegatePublicKey, other.delegatePublicKey);
     }
+
 }

--- a/sshd-common/src/main/java/org/apache/sshd/common/config/keys/u2f/SkEcdsaPublicKey.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/config/keys/u2f/SkEcdsaPublicKey.java
@@ -21,6 +21,8 @@ package org.apache.sshd.common.config.keys.u2f;
 import java.security.interfaces.ECPublicKey;
 import java.util.Objects;
 
+import org.apache.sshd.common.config.keys.impl.SkECDSAPublicKeyEntryDecoder;
+
 public class SkEcdsaPublicKey implements SecurityKeyPublicKey<ECPublicKey> {
 
     public static final String ALGORITHM = "ECDSA-SK";
@@ -40,6 +42,11 @@ public class SkEcdsaPublicKey implements SecurityKeyPublicKey<ECPublicKey> {
     @Override
     public String getAlgorithm() {
         return ALGORITHM;
+    }
+
+    @Override
+    public String getKeyType() {
+        return SkECDSAPublicKeyEntryDecoder.KEY_TYPE;
     }
 
     @Override

--- a/sshd-common/src/main/java/org/apache/sshd/common/util/buffer/Buffer.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/util/buffer/Buffer.java
@@ -61,6 +61,7 @@ import org.apache.sshd.common.SshException;
 import org.apache.sshd.common.cipher.ECCurves;
 import org.apache.sshd.common.config.keys.KeyUtils;
 import org.apache.sshd.common.config.keys.OpenSshCertificate;
+import org.apache.sshd.common.config.keys.UnsupportedSshPublicKey;
 import org.apache.sshd.common.config.keys.u2f.SecurityKeyPublicKey;
 import org.apache.sshd.common.keyprovider.KeyPairProvider;
 import org.apache.sshd.common.util.GenericUtils;
@@ -1015,7 +1016,9 @@ public abstract class Buffer implements Readable {
 
     public void putRawPublicKeyBytes(PublicKey key) {
         Objects.requireNonNull(key, "No key");
-        if (key instanceof RSAPublicKey) {
+        if (key instanceof UnsupportedSshPublicKey) {
+            putRawBytes(((UnsupportedSshPublicKey) key).getKeyData());
+        } else if (key instanceof RSAPublicKey) {
             RSAPublicKey rsaPub = (RSAPublicKey) key;
 
             putMPInt(rsaPub.getPublicExponent());

--- a/sshd-common/src/test/java/org/apache/sshd/client/config/hosts/KnownHostEntryTest.java
+++ b/sshd-common/src/test/java/org/apache/sshd/client/config/hosts/KnownHostEntryTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sshd.client.config.hosts;
+
+import java.io.StringReader;
+import java.security.PublicKey;
+import java.util.List;
+
+import org.apache.sshd.common.config.keys.AuthorizedKeyEntry;
+import org.apache.sshd.common.config.keys.PublicKeyEntry;
+import org.apache.sshd.common.config.keys.PublicKeyEntryResolver;
+import org.apache.sshd.common.config.keys.UnsupportedSshPublicKey;
+import org.apache.sshd.util.test.JUnitTestSupport;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("NoIoTestCase")
+class KnownHostEntryTest extends JUnitTestSupport {
+
+    @Test
+    void testLine() throws Exception {
+        List<KnownHostEntry> entries = KnownHostEntry.readKnownHostEntries(
+                new StringReader(
+                        "[127.0.0.1]:2222 ssh-ed448 AAAAC3NzaC1lZDI1NTE5AAAAIPu6ntmyfSOkqLl3qPxD5XxwW7OONwwSG3KO+TGn+PFu"),
+                true);
+        assertNotNull(entries);
+        assertEquals(1, entries.size());
+        KnownHostEntry entry = entries.get(0);
+        AuthorizedKeyEntry keyEntry = entry.getKeyEntry();
+        assertNotNull(keyEntry);
+        assertEquals("ssh-ed448", keyEntry.getKeyType());
+        PublicKey pk = keyEntry.resolvePublicKey(null, PublicKeyEntryResolver.UNSUPPORTED);
+        assertTrue(pk instanceof UnsupportedSshPublicKey);
+        UnsupportedSshPublicKey sshKey = (UnsupportedSshPublicKey) pk;
+        assertEquals("ssh-ed448", sshKey.getKeyType());
+        assertEquals("ssh-ed448 AAAAC3NzaC1lZDI1NTE5AAAAIPu6ntmyfSOkqLl3qPxD5XxwW7OONwwSG3KO+TGn+PFu",
+                PublicKeyEntry.toString(sshKey));
+    }
+}

--- a/sshd-core/src/test/java/org/apache/sshd/client/keyverifier/KnownHostsServerKeyVerifierTest.java
+++ b/sshd-core/src/test/java/org/apache/sshd/client/keyverifier/KnownHostsServerKeyVerifierTest.java
@@ -63,14 +63,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.mockito.Mockito;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
-
 /**
  * @author <a href="mailto:dev@mina.apache.org">Apache MINA SSHD Project</a>
  */

--- a/sshd-core/src/test/java/org/apache/sshd/client/keyverifier/KnownHostsUnsupportedKeysTest.java
+++ b/sshd-core/src/test/java/org/apache/sshd/client/keyverifier/KnownHostsUnsupportedKeysTest.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sshd.client.keyverifier;
+
+import java.net.SocketAddress;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.KeyPair;
+import java.security.PublicKey;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.sshd.client.config.hosts.KnownHostEntry;
+import org.apache.sshd.client.session.ClientSession;
+import org.apache.sshd.common.config.keys.AuthorizedKeyEntry;
+import org.apache.sshd.common.config.keys.KeyUtils;
+import org.apache.sshd.common.config.keys.PublicKeyEntryResolver;
+import org.apache.sshd.common.config.keys.UnsupportedSshPublicKey;
+import org.apache.sshd.common.util.net.SshdSocketAddress;
+import org.apache.sshd.util.test.CommonTestSupportUtils;
+import org.apache.sshd.util.test.JUnitTestSupport;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mockito;
+
+@Tag("NoIoTestCase")
+class KnownHostsUnsupportedKeysTest extends JUnitTestSupport {
+
+    @TempDir
+    private Path tmp;
+
+    private boolean invokeVerifier(ServerKeyVerifier verifier, SocketAddress hostIdentity, PublicKey serverKey) {
+        ClientSession session = Mockito.mock(ClientSession.class);
+        Mockito.when(session.getConnectAddress()).thenReturn(hostIdentity);
+        Mockito.when(session.toString()).thenReturn(getCurrentTestName() + "[" + hostIdentity + "]");
+        return verifier.verifyServerKey(session, hostIdentity, serverKey);
+    }
+
+    @Test
+    void unknownExistingKey() throws Exception {
+        Path knownHosts = tmp.resolve("known_hosts");
+        List<String> lines = new ArrayList<>();
+        lines.add("[127.0.0.1]:2222 ssh-ed448 AAAAC3NzaC1lZDI1NTE5AAAAIPu6ntmyfSOkqLl3qPxD5XxwW7OONwwSG3KO+TGn+PFu");
+        lines.add(
+                "[127.0.0.1]:2222 ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBCbZVVpqEHGLNWMqMeyU1VbWb91XteoamVcgpy4yxNVbZffb5IDdbo1ons/y9KAhcub6LZeLrvXzVUZbXCZiUkg=");
+        Files.write(knownHosts, lines);
+        KnownHostsServerKeyVerifier verifier = new KnownHostsServerKeyVerifier(RejectAllServerKeyVerifier.INSTANCE, knownHosts);
+        KnownHostEntry knownHost = KnownHostEntry.parseKnownHostEntry(lines.get(1));
+        AuthorizedKeyEntry keyEntry = knownHost.getKeyEntry();
+        assertNotNull(keyEntry);
+        PublicKey key = keyEntry.resolvePublicKey(null, PublicKeyEntryResolver.FAILING);
+        assertTrue(invokeVerifier(verifier, new SshdSocketAddress("127.0.0.1", 2222), key));
+    }
+
+    @Test
+    void unknownNewKey() throws Exception {
+        KeyPair kp = CommonTestSupportUtils.generateKeyPair(KeyUtils.RSA_ALGORITHM, 1024);
+        PublicKey newKey = kp.getPublic();
+        Path knownHosts = tmp.resolve("known_hosts");
+        List<String> lines = new ArrayList<>();
+        lines.add("[127.0.0.1]:2222 ssh-ed448 AAAAC3NzaC1lZDI1NTE5AAAAIPu6ntmyfSOkqLl3qPxD5XxwW7OONwwSG3KO+TGn+PFu");
+        Files.write(knownHosts, lines);
+        AtomicInteger numberOfCalls = new AtomicInteger();
+        KnownHostsServerKeyVerifier verifier = new KnownHostsServerKeyVerifier(RejectAllServerKeyVerifier.INSTANCE,
+                knownHosts) {
+            @Override
+            public boolean acceptModifiedServerKey(
+                    ClientSession clientSession, SocketAddress remoteAddress,
+                    KnownHostEntry entry, PublicKey expected, PublicKey actual) throws Exception {
+                numberOfCalls.incrementAndGet();
+                assertSame(newKey, actual, "Mismatched actual key for " + remoteAddress);
+                assertTrue(expected instanceof UnsupportedSshPublicKey);
+                String fingerprint = KeyUtils.getFingerPrint(expected);
+                assertNotNull(fingerprint);
+                assertTrue(fingerprint.length() > 0);
+                return true;
+            }
+        };
+        assertTrue(invokeVerifier(verifier, new SshdSocketAddress("127.0.0.1", 2222), newKey));
+        assertEquals(1, numberOfCalls.get());
+        // Load the file again. We should have two entries now, and the second one should be our newKey
+        List<KnownHostEntry> newEntries = KnownHostEntry.readKnownHostEntries(knownHosts);
+        assertNotNull(newEntries);
+        assertEquals(2, newEntries.size());
+        KnownHostEntry knownHost = newEntries.get(1);
+        AuthorizedKeyEntry keyEntry = knownHost.getKeyEntry();
+        assertNotNull(keyEntry);
+        PublicKey key = keyEntry.resolvePublicKey(null, PublicKeyEntryResolver.FAILING);
+        assertTrue(KeyUtils.compareKeys(newKey, key));
+    }
+}


### PR DESCRIPTION
Harden the parser so that it can parse known_host and authorized_key lines with unknown key types. Introduce a new UnsupportedSshPublicKey class to be able to deal with such entries later on when the server host key is compared. (An alternative would have been not to create PublicKeys from known_host lines at all but to serialize the given server key into string form and then just compare against the string from the known_host line. But that is not possible without breaking API...)

Such an UnsupportedSshPublicKey supports getting its key type, its raw key data, its fingerprint, and it can be written into a Buffer.

Fixes #636.