### PR TITLE
GH-643: provide interfaces for caching file attributes on paths

### DIFF
--- a/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/fs/SftpFileSystemProvider.java
+++ b/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/fs/SftpFileSystemProvider.java
@@ -100,7 +100,6 @@ import org.apache.sshd.sftp.client.SftpClientFactory;
 import org.apache.sshd.sftp.client.SftpErrorDataHandler;
 import org.apache.sshd.sftp.client.SftpVersionSelector;
 import org.apache.sshd.sftp.client.extensions.CopyFileExtension;
-import org.apache.sshd.sftp.client.impl.SftpPathImpl;
 import org.apache.sshd.sftp.client.impl.SftpRemotePathChannel;
 import org.apache.sshd.sftp.common.SftpConstants;
 import org.apache.sshd.sftp.common.SftpException;
@@ -1117,7 +1116,7 @@ public class SftpFileSystemProvider extends FileSystemProvider {
         // SftpPathImpl.withAttributeCache() invocation. So we ensure here that if we are already within a caching
         // scope, we do use the cached attributes, but if we are not, we clear any possibly cached attributes and
         // do actually read them from the remote.
-        return SftpPathImpl.withAttributeCache(path, p -> resolveRemoteFileAttributes(path, options));
+        return WithFileAttributeCache.withAttributeCache(path, p -> resolveRemoteFileAttributes(path, options));
     }
 
     protected SftpClient.Attributes resolveRemoteFileAttributes(SftpPath path, LinkOption... options) throws IOException {
@@ -1136,8 +1135,8 @@ public class SftpFileSystemProvider extends FileSystemProvider {
             if (log.isTraceEnabled()) {
                 log.trace("resolveRemoteFileAttributes({})[{}]: {}", fs, path, attrs);
             }
-            if (path instanceof SftpPathImpl) {
-                ((SftpPathImpl) path).cacheAttributes(attrs);
+            if (path instanceof WithFileAttributeCache) {
+                ((WithFileAttributeCache) path).setAttributes(attrs);
             }
             return attrs;
         } catch (SftpException e) {

--- a/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/fs/SftpPath.java
+++ b/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/fs/SftpPath.java
@@ -30,18 +30,13 @@ import org.apache.sshd.sftp.client.SftpClient;
 /**
  * A {@link java.nio.file.Path} on an {@link SftpFileSystem}.
  */
-public class SftpPath extends BasePath<SftpPath, SftpFileSystem> {
+public class SftpPath extends BasePath<SftpPath, SftpFileSystem> implements WithFileAttributes {
 
     public SftpPath(SftpFileSystem fileSystem, String root, List<String> names) {
         super(fileSystem, root, names);
     }
 
-    /**
-     * Retrieves the cached {@link SftpClient.Attributes} of this {@link SftpPath}, if it has any.
-     *
-     * @return the cached {@link SftpClient.Attributes} or {@code null} if there are none cached
-     */
-    @SuppressWarnings("javadoc")
+    @Override
     public SftpClient.Attributes getAttributes() {
         // Subclasses may override
         return null;

--- a/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/fs/SftpPathIterator.java
+++ b/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/fs/SftpPathIterator.java
@@ -30,7 +30,6 @@ import java.util.NoSuchElementException;
 import java.util.Objects;
 
 import org.apache.sshd.sftp.client.SftpClient;
-import org.apache.sshd.sftp.client.impl.SftpPathImpl;
 
 /**
  * Implements and {@link Iterator} of {@link SftpPath}-s returned by a {@link DirectoryStream#iterator()} method.
@@ -116,8 +115,8 @@ public class SftpPathIterator implements Iterator<Path> {
                 dotdotIgnored = true;
             } else {
                 SftpPath candidate = root.resolve(entry.getFilename());
-                if (candidate instanceof SftpPathImpl) {
-                    ((SftpPathImpl) candidate).setAttributes(entry.getAttributes());
+                if (candidate instanceof WithFileAttributeCache) {
+                    ((WithFileAttributeCache) candidate).setAttributes(entry.getAttributes());
                 }
                 try {
                     if ((selector == null) || selector.accept(candidate)) {

--- a/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/fs/WithFileAttributeCache.java
+++ b/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/fs/WithFileAttributeCache.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sshd.sftp.client.fs;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import org.apache.sshd.common.util.io.functors.IOFunction;
+import org.apache.sshd.sftp.client.SftpClient;
+
+/**
+ * A mix-in interface for paths that can carry and cache file attributes of the referenced file.
+ */
+public interface WithFileAttributeCache extends WithFileAttributes {
+
+    /**
+     * Sets the attributes.
+     *
+     * @param attributes {@link SftpClient.Attributes} to set
+     */
+    void setAttributes(SftpClient.Attributes attributes);
+
+    /**
+     * Performs the given operation with attribute caching. If {@code SftpClient.Attributes} are fetched by the
+     * operation, they will be cached and subsequently these cached attributes will be re-used for this {@link SftpPath}
+     * instance throughout the operation. Calls to {@link #withAttributeCache(IOFunction)} may be nested. The cache is
+     * cleared at the start and at the end of the outermost invocation.
+     *
+     * @param  <T>         result type of the {@code operation}
+     * @param  operation   to perform; may return {@code null} if it has no result
+     * @return             the result of the {@code operation}
+     * @throws IOException if thrown by the {@code operation}
+     */
+    <T> T withAttributeCache(IOFunction<Path, T> operation) throws IOException;
+
+    /**
+     * Performs the given operation with attribute caching, if the given {@link Path} implements the
+     * {@link WithFileAttributeCache} interface, otherwise simply executes the operation.
+     *
+     * @param  <T>         result type of the {@code operation}
+     * @param  path        {@link Path} to operate on
+     * @param  operation   to perform; may return {@code null} if it has no result
+     * @return             the result of the {@code operation}
+     * @throws IOException if thrown by the {@code operation}
+     *
+     * @see                #withAttributeCache(IOFunction)
+     */
+    static <T> T withAttributeCache(Path path, IOFunction<Path, T> operation) throws IOException {
+        if (path instanceof WithFileAttributeCache) {
+            return ((WithFileAttributeCache) path).withAttributeCache(operation);
+        }
+        return operation.apply(path);
+    }
+
+}

--- a/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/fs/WithFileAttributes.java
+++ b/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/fs/WithFileAttributes.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sshd.sftp.client.fs;
+
+import org.apache.sshd.sftp.client.SftpClient.Attributes;
+
+/**
+ * A mix-in interface for paths that may have file attributes of the file referenced by the path.
+ */
+public interface WithFileAttributes {
+
+    /**
+     * Retrieves the {@link Attributes} of this object, if it has any.
+     *
+     * @return the {@link Attributes} or {@code null} if there are none
+     */
+    Attributes getAttributes();
+
+}

--- a/sshd-sftp/src/main/java/org/apache/sshd/sftp/server/SftpSubsystem.java
+++ b/sshd-sftp/src/main/java/org/apache/sshd/sftp/server/SftpSubsystem.java
@@ -82,7 +82,7 @@ import org.apache.sshd.server.command.CommandDirectErrorStreamAware;
 import org.apache.sshd.server.session.ServerSession;
 import org.apache.sshd.sftp.SftpModuleProperties;
 import org.apache.sshd.sftp.client.fs.SftpPath;
-import org.apache.sshd.sftp.client.impl.SftpPathImpl;
+import org.apache.sshd.sftp.client.fs.WithFileAttributeCache;
 import org.apache.sshd.sftp.common.SftpConstants;
 import org.apache.sshd.sftp.common.SftpException;
 import org.apache.sshd.sftp.common.SftpHelper;
@@ -782,7 +782,7 @@ public class SftpSubsystem
 
     @Override
     protected String doOpenDir(int id, String path, Path dir, LinkOption... options) throws IOException {
-        SftpPathImpl.withAttributeCache(dir, p -> {
+        WithFileAttributeCache.withAttributeCache(dir, p -> {
             Boolean status = IoUtils.checkFileExistsAnySymlinks(p, !IoUtils.followLinks(options));
             if (status == null) {
                 throw signalOpenFailure(id, path, p, true,


### PR DESCRIPTION
Remote file systems may have a need to cache file attributes on Path instances. A typical use case is iterating over all files in a directory: the directory listing returns paths, but the underlying remote listing operation may also return file attributes for each entry. This is the case in Sftp, but may also occur for other file systems, for instance a file system wrapping Amazon S3.

It would be unfortunate and inefficient if iterating through the paths returned and doing something with the attributes would have to re-fetch the attributes again if they were already available.

By implementing WithFileAttributes on its Paths, a file system can associate file attributes with a path instance, and client code can access them. If a file system also makes its paths implement the second interface WithFileAttributeCache, then the SftpSubsystem uses it internally to avoid making repeated remote calls to get file attributes.