### PR TITLE
Abstract revoked key handling in KnownHostsServerKeyVerifier

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -50,6 +50,7 @@
 ## New Features
 
 * [GH-606](https://github.com/apache/mina-sshd/issues/606) Support ML-KEM PQC hybrid key exchanges
+* [GH-652](https://github.com/apache/mina-sshd/issues/652) New method `KnownHostsServerKeyVerifier.handleRevokedKey()`
 
 * [SSHD-988](https://issues.apache.org/jira/projects/SSHD/issues/SSHD-988) Support ed25519 keys via the Bouncy Castle library
 

--- a/sshd-core/src/main/java/org/apache/sshd/client/keyverifier/KnownHostsServerKeyVerifier.java
+++ b/sshd-core/src/main/java/org/apache/sshd/client/keyverifier/KnownHostsServerKeyVerifier.java
@@ -285,8 +285,7 @@ public class KnownHostsServerKeyVerifier
 
         if (keyMatches.stream()
                 .anyMatch(k -> "revoked".equals(k.getHostEntry().getMarker()))) {
-            log.debug("acceptKnownHostEntry({})[{}] key={}-{} marked as revoked",
-                    clientSession, remoteAddress, KeyUtils.getKeyType(serverKey), KeyUtils.getFingerPrint(serverKey));
+            handleRevokedKey(clientSession, remoteAddress, serverKey);
             return false;
         }
 
@@ -534,6 +533,18 @@ public class KnownHostsServerKeyVerifier
         }
 
         return matches;
+    }
+
+    /**
+     * Invoked if any matching host entry has a 'revoked' marker
+     *
+     * @param clientSession The {@link ClientSession}
+     * @param remoteAddress The remote host address
+     * @param serverKey     The presented server {@link PublicKey}
+     */
+    protected void handleRevokedKey(ClientSession clientSession, SocketAddress remoteAddress, PublicKey serverKey) {
+        log.debug("acceptKnownHostEntry({})[{}] key={}-{} marked as revoked",
+                clientSession, remoteAddress, KeyUtils.getKeyType(serverKey), KeyUtils.getFingerPrint(serverKey));
     }
 
     /**


### PR DESCRIPTION
Abstract handling of revoked key so extending classes has an easier way to add functionality when a matching host entry has a 'revoked' marker. 

Fixes #652.