### PR TITLE
GH-664: Skip MAC negotiation if an AEAD cipher was negotiated

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,6 +29,7 @@
 ## Bug Fixes
 
 * [GH-650](https://github.com/apache/mina-sshd/issues/650) Use the correct key from a user certificate in server-side pubkey auth
+* [GH-664](https://github.com/apache/mina-sshd/issues/664) Skip MAC negotiation if an AEAD cipher was negotiated
 
 ## New Features
 

--- a/sshd-core/src/test/java/org/apache/sshd/client/kex/NegotiationTest.java
+++ b/sshd-core/src/test/java/org/apache/sshd/client/kex/NegotiationTest.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sshd.client.kex;
+
+import java.util.Collections;
+
+import org.apache.sshd.client.SshClient;
+import org.apache.sshd.client.session.ClientSession;
+import org.apache.sshd.common.cipher.BuiltinCiphers;
+import org.apache.sshd.common.mac.BuiltinMacs;
+import org.apache.sshd.server.SshServer;
+import org.apache.sshd.util.test.BaseTestSupport;
+import org.apache.sshd.util.test.CoreTestSupportUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test key exchange negotiation.
+ *
+ * @author <a href="mailto:dev@mina.apache.org">Apache MINA SSHD Project</a>
+ */
+class NegotiationTest extends BaseTestSupport {
+
+    private SshServer sshd;
+    private int port;
+
+    private SshClient client;
+
+    @BeforeEach
+    void setupClientAndServer() throws Exception {
+        sshd = CoreTestSupportUtils.setupTestFullSupportServer(NegotiationTest.class);
+        sshd.start();
+        port = sshd.getPort();
+
+        client = CoreTestSupportUtils.setupTestFullSupportClient(NegotiationTest.class);
+        client.start();
+    }
+
+    @AfterEach
+    void tearDownClientAndServer() throws Exception {
+        if (sshd != null) {
+            try {
+                sshd.stop(true);
+            } finally {
+                sshd = null;
+            }
+        }
+
+        if (client != null) {
+            try {
+                client.stop();
+            } finally {
+                client = null;
+            }
+        }
+    }
+
+    @Test
+    void aeadCipherNeedsNoMacNegotiation() throws Exception {
+        client.setCipherFactories(Collections.singletonList(BuiltinCiphers.cc20p1305_openssh)); // An AEAD cipher
+        client.setMacFactories(Collections.singletonList(BuiltinMacs.hmacsha1));
+        sshd.setMacFactories(Collections.singletonList(BuiltinMacs.hmacsha256));
+        try (ClientSession session = client.connect(getCurrentTestName(), TEST_LOCALHOST, port).verify(CONNECT_TIMEOUT)
+                .getSession()) {
+            session.addPasswordIdentity(getCurrentTestName());
+            session.auth().verify(AUTH_TIMEOUT);
+            assertTrue(session.isAuthenticated());
+        }
+    }
+}

--- a/sshd-core/src/test/java/org/apache/sshd/common/mac/EncryptThenMacTest.java
+++ b/sshd-core/src/test/java/org/apache/sshd/common/mac/EncryptThenMacTest.java
@@ -26,6 +26,7 @@ import java.util.List;
 
 import org.apache.sshd.client.SshClient;
 import org.apache.sshd.client.session.ClientSession;
+import org.apache.sshd.common.cipher.BuiltinCiphers;
 import org.apache.sshd.common.kex.KexProposalOption;
 import org.apache.sshd.server.SshServer;
 import org.apache.sshd.util.test.BaseTestSupport;
@@ -37,8 +38,6 @@ import org.junit.jupiter.api.MethodOrderer.MethodName;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * @author <a href="mailto:dev@mina.apache.org">Apache MINA SSHD Project</a>
@@ -53,6 +52,8 @@ public class EncryptThenMacTest extends BaseTestSupport {
 
     public void initEncryptThenMacTest(MacFactory factory) throws Exception {
         this.factory = factory;
+        sshd.setCipherFactories(Collections.singletonList(BuiltinCiphers.aes128ctr));
+        client.setCipherFactories(Collections.singletonList(BuiltinCiphers.aes128ctr));
         sshd.setMacFactories(Collections.singletonList(this.factory));
         client.setMacFactories(Collections.singletonList(this.factory));
     }
@@ -109,7 +110,7 @@ public class EncryptThenMacTest extends BaseTestSupport {
 
     @MethodSource("parameters")
     @ParameterizedTest(name = "{0}")
-    public void clientConnection(MacFactory factory) throws Exception {
+    void clientConnection(MacFactory factory) throws Exception {
         initEncryptThenMacTest(factory);
         try (ClientSession session = client.connect(getCurrentTestName(), TEST_LOCALHOST, port)
                 .verify(CONNECT_TIMEOUT).getSession()) {

--- a/sshd-core/src/test/java/org/apache/sshd/util/test/CoreTestSupportUtils.java
+++ b/sshd-core/src/test/java/org/apache/sshd/util/test/CoreTestSupportUtils.java
@@ -22,6 +22,7 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -31,6 +32,8 @@ import org.apache.sshd.client.SshClient;
 import org.apache.sshd.client.config.hosts.HostConfigEntryResolver;
 import org.apache.sshd.client.keyverifier.AcceptAllServerKeyVerifier;
 import org.apache.sshd.common.NamedFactory;
+import org.apache.sshd.common.cipher.BuiltinCiphers;
+import org.apache.sshd.common.cipher.Cipher;
 import org.apache.sshd.common.kex.BuiltinDHFactories;
 import org.apache.sshd.common.keyprovider.KeyIdentityProvider;
 import org.apache.sshd.common.signature.BuiltinSignatures;
@@ -86,6 +89,9 @@ public final class CoreTestSupportUtils {
     }
 
     public static <S extends SshServer> S setupTestServer(S sshd, Class<?> anchor) {
+        List<NamedFactory<Cipher>> cipherFactories = new ArrayList<>(sshd.getCipherFactories());
+        cipherFactories.add(BuiltinCiphers.aes128cbc);
+        sshd.setCipherFactories(cipherFactories);
         sshd.setKeyPairProvider(CommonTestSupportUtils.createTestHostKeyProvider(anchor));
         sshd.setPasswordAuthenticator(BogusPasswordAuthenticator.INSTANCE);
         sshd.setPublickeyAuthenticator(AcceptAllPublickeyAuthenticator.INSTANCE);


### PR DESCRIPTION
An AEAD cipher has a built-in MAC, and no extra MAC will be applied. So there is no need to negotiate one.

Fixes #664.