### PR TITLE
Also test sshd-mina using mina-core 2.2.4

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,3 +35,6 @@ updates:
         versions: [ ">= 2.0.0" ]
       - dependency-name: "ch.qos.logback:*"
         versions: [ ">= 1.3.0" ]
+      # We *do* test against 2.2.X. We only want to get patch version updates for mina-core
+      - dependency-name: "org.apache.mina:mina-core"
+        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]

--- a/sshd-mina/pom.xml
+++ b/sshd-mina/pom.xml
@@ -150,4 +150,71 @@
             </plugin>
         </plugins>
     </build>
+    
+    <profiles>
+        <profile>
+            <id>test-mina-2.2.X</id>
+            <activation>
+                <property>
+                    <name>test.mina22</name>
+                    <value>!disable</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>test-mina-2.2.X</id>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                 <configuration>
+                                    <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                                    <reportsDirectory>${project.build.directory}/surefire-reports-mina-22</reportsDirectory>
+                                    <forkCount>1</forkCount>
+                                    <reuseForks>false</reuseForks>
+                                    <excludes>
+                                        <!-- These tests use NIO2 explicitly -->
+                                        <exclude>**/Nio2ServiceTest.java</exclude>
+                                        <!-- testcontainers filesystem building from classpath doesn't work from reusable test jar classpath -->
+                                        <exclude>**/ArcFourOpenSshTest.java</exclude>
+                                        <exclude>**/ClientOpenSSHCertificatesTest.java</exclude>
+                                        <exclude>**/SessionReKeyHostKeyExchangeTest.java</exclude>
+                                        <exclude>**/HostBoundPubKeyAuthTest.java</exclude>
+                                        <exclude>**/OpenSshCipherTest.java</exclude>
+                                        <exclude>**/OpenSshMlKemTest.java</exclude>
+                                        <exclude>**/PortForwardingWithOpenSshTest.java</exclude>
+                                        <exclude>**/StrictKexInteroperabilityTest.java</exclude>
+                                        <!-- reading files from classpath doesn't work correctly w/ reusable test jar -->
+                                        <exclude>**/OpenSSHCertificateTest.java</exclude>
+                                        <!-- A MinaServiceFactory cannot be instantiated with a mock CloseableExecutorService. -->
+                                        <exclude>**/DefaultIoServiceFactoryFactoryTest.java</exclude>
+                                    </excludes>
+                                    <!-- No need to re-run core tests that do not involve session creation -->
+                                    <excludedGroups>NoIoTestCase</excludedGroups>
+                                    <!-- Tests are located in the sshd-core reusable test jar -->
+                                    <dependenciesToScan>
+                                        <dependency>org.apache.sshd:sshd-core</dependency>
+                                    </dependenciesToScan>
+                                    <classpathDependencyExcludes>
+                                        <classpathDependencyExclude>org.apache.mina:mina-core</classpathDependencyExclude>
+                                    </classpathDependencyExcludes>
+                                    <additionalClasspathDependencies>
+                                        <additionalClasspathDependency>
+                                            <groupId>org.apache.mina</groupId>
+                                            <artifactId>mina-core</artifactId>
+                                            <version>2.2.4</version>
+                                        </additionalClasspathDependency>
+                                    </additionalClasspathDependencies>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/sshd-mina/src/test/java/org/apache/sshd/mina/MinaSessionTest.java
+++ b/sshd-mina/src/test/java/org/apache/sshd/mina/MinaSessionTest.java
@@ -20,29 +20,33 @@
 package org.apache.sshd.mina;
 
 import java.lang.reflect.Field;
+import java.util.stream.Stream;
 
+import org.apache.mina.core.service.IoHandler;
 import org.apache.mina.core.service.IoProcessor;
 import org.apache.sshd.client.SshClient;
 import org.apache.sshd.common.helpers.AbstractFactoryManager;
 import org.apache.sshd.common.io.IoServiceFactory;
 import org.apache.sshd.server.SshServer;
 import org.apache.sshd.util.test.BaseTestSupport;
-import org.junit.jupiter.api.MethodOrderer.MethodName;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestMethodOrder;
-
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests specific to the MINA connection back-end.
  *
  * @author <a href="mailto:dev@mina.apache.org">Apache MINA SSHD Project</a>
  */
-@TestMethodOrder(MethodName.class)
-public class MinaSessionTest extends BaseTestSupport {
+class MinaSessionTest extends BaseTestSupport {
 
-    public MinaSessionTest() {
+    MinaSessionTest() {
         super();
+    }
+
+    @BeforeAll
+    static void minaVersion() {
+        boolean is22x = Stream.of(IoHandler.class.getMethods()).anyMatch(m -> "event".equals(m.getName()));
+        System.err.println("Testing with MINA " + (is22x ? "2.2.X" : "2.0.X"));
     }
 
     private IoProcessor<?> getProcessor(AbstractFactoryManager manager) throws Exception {
@@ -70,4 +74,5 @@ public class MinaSessionTest extends BaseTestSupport {
         }
         assertTrue(ioProcessor.isDisposed() || ioProcessor.isDisposing(), "MINA server IoProcessor should be closed");
     }
+
 }


### PR DESCRIPTION
Frankly said I don't quite understand why this even works. The code certainly doesn't compile against 2.2.4: there's a new (abstract) method in interface IoHandler, and our MinaService inherits that but doesn't implement it. Apparently at runtime this can still work as long as the new method isn't called?

(In mina-core 2.2.5, that method will be a default method, and then everything should be totally fine.)

Also tell dependabot to give us only patch version updates for mina-core. We want to keep the minimum requirement at 2.0.X.