### PR TITLE
fix sources.jar Reproducible Builds issue

### DIFF
--- a/sshd-osgi/pom.xml
+++ b/sshd-osgi/pom.xml
@@ -154,7 +154,7 @@ Manifest-Version: 1.0
 Created-By: Maven Antrun Plugin
                                 </echo>
 
-                                <jar destfile="${project.build.directory}/${project.artifactId}-${project.version}-sources.jar" manifest="${project.build.directory}/osgi-sources/META-INF/MANIFEST.MF">
+                                <jar destfile="${project.build.directory}/${project.artifactId}-${project.version}-sources.jar" manifest="${project.build.directory}/osgi-sources/META-INF/MANIFEST.MF" modificationtime="${project.build.outputTimestamp}">
                                     <fileset dir="${project.basedir}/../sshd-common/src/main/java" includes="**/*" />
                                     <fileset dir="${project.basedir}/../sshd-common/src/main/resources" includes="**/*" erroronmissingdir="false" />
                                     <fileset dir="${project.basedir}/../sshd-core/src/main/java" includes="**/*" />


### PR DESCRIPTION
see https://github.com/jvm-repo-rebuild/reproducible-central/blob/master/content/org/apache/sshd/README.md

this `sshd-osgi-*-sources.jar` non-reproducible timestamp (because jar created by `jar` Ant task without predefined `modificationtime`) is the unique issue for 2.14.0 or 2.13.1

2.15.0 has in addition a `org/apache/sshd/client/userKey` file in `sshd-core-2.15.0-reusable-reusable-tests.jar`: I suppose this file is not absolutely necessary in this jar, as it was not there in 2.14.0: you'll need to define what is useful or not