### PR TITLE
GH-700: Fix race in AbstractCloseable.doCloseImmediately()

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,6 +34,7 @@
 * [GH-677](https://github.com/apache/mina-sshd/issues/677) Fix current directory handling in `ScpShell` for WinSCP
 * [GH-678](https://github.com/apache/mina-sshd/issues/678) `ScpShell`: write month names in English for WinSCP
 * [GH-690](https://github.com/apache/mina-sshd/issues/690) Handle append mode for buggy SFTP v3 servers
+* [GH-700](https://github.com/apache/mina-sshd/issues/700) Fix race in `AbstractCloseable.doCloseImmediately()`
 
 ## New Features
 

--- a/sshd-common/src/main/java/org/apache/sshd/common/util/closeable/AbstractCloseable.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/util/closeable/AbstractCloseable.java
@@ -167,8 +167,8 @@ public abstract class AbstractCloseable extends IoBaseCloseable {
      * </P>
      */
     protected void doCloseImmediately() {
-        closeFuture.setClosed();
         state.set(State.Closed);
+        closeFuture.setClosed();
     }
 
     protected Builder builder() {

--- a/sshd-core/src/main/java/org/apache/sshd/client/session/ClientSessionImpl.java
+++ b/sshd-core/src/main/java/org/apache/sshd/client/session/ClientSessionImpl.java
@@ -324,7 +324,7 @@ public class ClientSessionImpl extends AbstractClientSession {
 
     // NOTE: assumed to be called under lock
     protected <C extends Collection<ClientSessionEvent>> C updateCurrentSessionState(C state) {
-        if (closeFuture.isClosed()) {
+        if (isClosed()) {
             state.add(ClientSessionEvent.CLOSED);
         }
         if (isAuthenticated()) { // authFuture.isSuccess()


### PR DESCRIPTION
Set the state to "closed" before fulfilling the closeFuture.

Fixes #700.