### PR TITLE
GH-705: Make ChannelToPortHandler accessible to user code

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -38,6 +38,9 @@
 
 ## New Features
 
+* [GH-705](https://github.com/apache/mina-sshd/issues/705) New method `TcpipServerChannel.getPort()` returning the `ChannelToPortHandler`
+
+
 * [SSHD-1161](https://issues.apache.org/jira/projects/SSHD/issues/SSHD-1161) Support pubkey auth with user certificates (server-side)
     * Client-side support was introduced in version 2.8.0 already 
 * [SSHD-1167](https://issues.apache.org/jira/projects/SSHD/issues/SSHD-1167) Check host certificates against known_hosts file (implements @<!-- -->cert-authority)


### PR DESCRIPTION
Provide a getter, and in the port handler itself a method to write data directly, without adjusting the channel window.

Fixes #705.