### PR TITLE
GH-709: Handle keep-alive channel messages sent by an old OpenSSH server

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -35,6 +35,7 @@
 * [GH-678](https://github.com/apache/mina-sshd/issues/678) `ScpShell`: write month names in English for WinSCP
 * [GH-690](https://github.com/apache/mina-sshd/issues/690) Handle append mode for buggy SFTP v3 servers
 * [GH-700](https://github.com/apache/mina-sshd/issues/700) Fix race in `AbstractCloseable.doCloseImmediately()`
+* [GH-709](https://github.com/apache/mina-sshd/issues/709) `AbstractChannel`: Handle keep-alive channel messages sent by an old OpenSSH server
 
 ## New Features
 

--- a/sshd-core/src/main/java/org/apache/sshd/common/channel/AbstractChannel.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/channel/AbstractChannel.java
@@ -362,6 +362,9 @@ public abstract class AbstractChannel extends AbstractInnerCloseable implements 
             if (log.isDebugEnabled()) {
                 log.debug("handleInternalRequest({})[want-reply={}] received keep-alive: {}", this, wantReply, req);
             }
+            if (req.equals("keepalive@openssh.com")) {
+                return RequestHandler.Result.ReplyFailure;
+            }
             return RequestHandler.Result.ReplySuccess;
         }
         if (log.isDebugEnabled()) {


### PR DESCRIPTION
OpenSSH < 5.1p1 (from 2008!) does not handle a success reply and then disconnects after a few keepalives. It really needs a failure reply. Since 5.1p1, OpenSSH can handle both failure and success replies to its keepalive channel messages.

Always return a failure reply if the request is "keepalive@openssh.com".

Fixes #709.