### PR TITLE
Implement client-side support of X11 forwarding

### DIFF
--- a/sshd-core/src/main/java/org/apache/sshd/client/channel/ChannelX11.java
+++ b/sshd-core/src/main/java/org/apache/sshd/client/channel/ChannelX11.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sshd.client.channel;
+
+import org.apache.sshd.client.future.DefaultOpenFuture;
+import org.apache.sshd.client.future.OpenFuture;
+import org.apache.sshd.client.session.ClientConnectionService;
+import org.apache.sshd.client.x11.X11IoHandler;
+import org.apache.sshd.common.Property;
+import org.apache.sshd.common.SshConstants;
+import org.apache.sshd.common.channel.ChannelOutputStream;
+import org.apache.sshd.common.io.IoConnectFuture;
+import org.apache.sshd.common.io.IoConnector;
+import org.apache.sshd.common.io.IoHandler;
+import org.apache.sshd.common.io.IoSession;
+import org.apache.sshd.common.util.buffer.Buffer;
+import org.apache.sshd.common.util.buffer.ByteArrayBuffer;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * @author <a href="mailto:dev@mina.apache.org">Apache MINA SSHD Project</a>
+ */
+public class ChannelX11 extends AbstractClientChannel {
+
+    public static final Property<Object> X11_COOKIE = Property.object("x11-cookie");
+    public static final Property<Object> X11_COOKIE_HEX = Property.object("x11-cookie-hex");
+
+    private final AtomicBoolean isInitialized = new AtomicBoolean(false);
+    private final String host;
+    private final int port;
+
+    private IoSession x11;
+
+    public ChannelX11(String host, int port) {
+        super("x11");
+        this.host = host;
+        this.port = port;
+    }
+
+    @Override
+    public OpenFuture open(long recipient, long rwSize, long packetSize, Buffer buffer) {
+        final DefaultOpenFuture defaultOpenFuture = new DefaultOpenFuture(this, futureLock);
+        super.openFuture = defaultOpenFuture;
+
+        final IoConnector connector
+                = getSession().getFactoryManager().getIoServiceFactory().createConnector(createX11IoHandler());
+        addCloseFutureListener(future -> {
+            if (future.isClosed()) {
+                connector.close(true);
+            }
+        });
+
+        final IoConnectFuture connectFuture = connector.connect(new InetSocketAddress(host, port), this, null);
+        connectFuture.addListener(future -> {
+            if (future.isConnected()) {
+                x11 = future.getSession();
+                handleOpenSuccess(recipient, rwSize, packetSize, buffer);
+            } else {
+                if (future.getException() != null) {
+                    defaultOpenFuture.setException(future.getException());
+                } else {
+                    defaultOpenFuture.setValue(false);
+                }
+                unregisterSelf();
+            }
+        });
+
+        return defaultOpenFuture;
+
+    }
+
+    @Override
+    protected void doOpen() throws IOException {
+        setOut(new ChannelOutputStream(this, getRemoteWindow(), log, SshConstants.SSH_MSG_CHANNEL_DATA, true));
+    }
+
+    @Override
+    protected void doWriteData(byte[] data, int off, long len) throws IOException {
+        if (isInitialized.compareAndSet(false, true)) {
+            final byte[] xCookie = getXCookie();
+            if (xCookie == null) {
+                sendEof();
+                return;
+            }
+
+            int l = (int) len;
+            int s = 0;
+            byte[] foo = new byte[l];
+            System.arraycopy(data, off, foo, 0, l);
+
+            if (l < 9) {
+                return;
+            }
+
+            int plen = (foo[s + 6] & 0xff) * 256 + (foo[s + 7] & 0xff);
+            int dlen = (foo[s + 8] & 0xff) * 256 + (foo[s + 9] & 0xff);
+
+            if ((foo[s] & 0xff) == 0x6c) {
+                plen = ((plen >>> 8) & 0xff) | ((plen << 8) & 0xff00);
+                dlen = ((dlen >>> 8) & 0xff) | ((dlen << 8) & 0xff00);
+            }
+
+            if (l < 12 + plen + ((-plen) & 3) + dlen) {
+                return;
+            }
+
+            byte[] bar = new byte[dlen];
+            System.arraycopy(foo, s + 12 + plen + ((-plen) & 3), bar, 0, dlen);
+
+            if (Objects.deepEquals(xCookie, bar)) {
+                x11.writeBuffer(new ByteArrayBuffer(foo, s, l));
+            } else {
+                sendEof();
+            }
+
+        } else if (x11.isOpen()) {
+            x11.writeBuffer(new ByteArrayBuffer(data, off, (int) len));
+        } else if (x11.isClosing() || x11.isClosed()) {
+            sendEof();
+        }
+    }
+
+    @Override
+    public void handleEof() throws IOException {
+        super.handleEof();
+        close(true);
+    }
+
+    private void unregisterSelf() {
+        getSession().getService(ClientConnectionService.class)
+                .unregisterChannel(this);
+        close(true);
+    }
+
+    protected byte[] getXCookie() {
+        final Object xCookie = X11_COOKIE.getOrNull(getSession());
+        if (xCookie instanceof byte[]) {
+            return (byte[]) xCookie;
+        }
+        return null;
+    }
+
+    protected IoHandler createX11IoHandler() {
+        return new X11IoHandler(this, log);
+    }
+}

--- a/sshd-core/src/main/java/org/apache/sshd/client/x11/X11ChannelFactory.java
+++ b/sshd-core/src/main/java/org/apache/sshd/client/x11/X11ChannelFactory.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sshd.client.x11;
+
+import org.apache.sshd.client.channel.ChannelX11;
+import org.apache.sshd.common.channel.Channel;
+import org.apache.sshd.common.channel.ChannelFactory;
+import org.apache.sshd.common.session.Session;
+import org.apache.sshd.core.CoreModuleProperties;
+
+import java.io.IOException;
+
+/**
+ * @author <a href="mailto:dev@mina.apache.org">Apache MINA SSHD Project</a>
+ */
+public class X11ChannelFactory implements ChannelFactory {
+
+    public static final X11ChannelFactory INSTANCE = new X11ChannelFactory();
+
+    public X11ChannelFactory() {
+    }
+
+    @Override
+    public Channel createChannel(Session session) throws IOException {
+        final String host = CoreModuleProperties.X11_BIND_HOST.get(session).orElse(null);
+        final Integer port = CoreModuleProperties.X11_BASE_PORT.get(session).orElse(null);
+        if (host == null || port == null) {
+            return null;
+        }
+        return new ChannelX11(host, port);
+    }
+
+    @Override
+    public String getName() {
+        return "x11";
+    }
+}

--- a/sshd-core/src/main/java/org/apache/sshd/client/x11/X11IoHandler.java
+++ b/sshd-core/src/main/java/org/apache/sshd/client/x11/X11IoHandler.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sshd.client.x11;
+
+import org.apache.sshd.client.channel.ChannelX11;
+import org.apache.sshd.common.io.IoHandler;
+import org.apache.sshd.common.io.IoSession;
+import org.apache.sshd.common.util.io.IoUtils;
+import org.slf4j.Logger;
+
+/**
+ * @author <a href="mailto:dev@mina.apache.org">Apache MINA SSHD Project</a>
+ */
+public class X11IoHandler implements IoHandler {
+    private final ChannelX11 channel;
+    private final Logger log;
+
+    public X11IoHandler(ChannelX11 channel, Logger log) {
+        this.channel = channel;
+        this.log = log;
+    }
+
+    @Override
+    public void sessionCreated(IoSession session) throws Exception {
+        if (log.isDebugEnabled()) {
+            log.debug("X11 session created");
+        }
+    }
+
+    @Override
+    public void sessionClosed(IoSession session) throws Exception {
+        if (log.isDebugEnabled()) {
+            log.debug("X11 session closed");
+        }
+        if (channel.isOpen() && !channel.isClosing() && !channel.isClosed()) {
+            channel.close(true);
+        }
+    }
+
+    @Override
+    public void exceptionCaught(IoSession session, Throwable cause) throws Exception {
+        if (log.isErrorEnabled()) {
+            log.error("X11 exception caught", cause);
+        }
+    }
+
+    @Override
+    public void messageReceived(IoSession session, org.apache.sshd.common.util.Readable message) throws Exception {
+        final byte[] bytes = new byte[Math.min(IoUtils.DEFAULT_COPY_SIZE, message.available())];
+        if (bytes.length < 1) {
+            return;
+        }
+
+        while (message.available() > 0) {
+            final int len = Math.min(message.available(), bytes.length);
+            message.getRawBytes(bytes, 0, len);
+            channel.getOut().write(bytes, 0, len);
+        }
+
+        channel.getOut().flush();
+    }
+
+}

--- a/sshd-core/src/test/java/org/apache/sshd/client/channel/ChannelX11Test.java
+++ b/sshd-core/src/test/java/org/apache/sshd/client/channel/ChannelX11Test.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sshd.client.channel;
+
+import org.apache.sshd.client.SshClient;
+import org.apache.sshd.client.session.ClientSession;
+import org.apache.sshd.client.x11.X11ChannelFactory;
+import org.apache.sshd.common.util.GenericUtils;
+import org.apache.sshd.server.SshServer;
+import org.apache.sshd.server.channel.ChannelSession;
+import org.apache.sshd.server.forward.AcceptAllForwardingFilter;
+import org.apache.sshd.server.session.ServerConnectionService;
+import org.apache.sshd.server.x11.X11ForwardSupport;
+import org.apache.sshd.util.test.BaseTestSupport;
+import org.apache.sshd.util.test.CoreTestSupportUtils;
+import org.junit.jupiter.api.*;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.images.builder.ImageFromDockerfile;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+
+/**
+ * @author <a href="mailto:dev@mina.apache.org">Apache MINA SSHD Project</a>
+ */
+@Testcontainers
+@TestMethodOrder(MethodOrderer.MethodName.class)
+public class ChannelX11Test extends BaseTestSupport {
+
+    // @Container
+    private static GenericContainer<?> sshdContainer = new GenericContainer<>(
+            new ImageFromDockerfile().withDockerfileFromBuilder(builder -> builder.from("linuxserver/openssh-server") //
+                    // allows forwarding
+                    .run("sed -i 's/#AllowAgentForwarding yes/AllowAgentForwarding yes/g' /etc/ssh/sshd_config")
+                    .run("sed -i 's/AllowTcpForwarding no/AllowTcpForwarding yes/g' /etc/ssh/sshd_config")
+                    .run("sed -i 's/GatewayPorts no/GatewayPorts yes/g' /etc/ssh/sshd_config")
+                    .run("sed -i 's/X11Forwarding no/X11Forwarding yes/g' /etc/ssh/sshd_config")
+                    // Install xcalc
+                    .run("apk update")
+                    .run("apk add xcalc xorg-server xinit")
+                    .build()))
+            .withEnv("PUID", "1000")
+            .withEnv("PGID", "1000")
+            .withEnv("SUDO_ACCESS", "true")
+            .withEnv("PASSWORD_ACCESS", "true")
+            .withEnv("USER_NAME", "foo")
+            .withEnv("USER_PASSWORD", "bar")
+            .withEnv("SUDO_ACCESS", "true")
+            .withExposedPorts(2222);
+
+    private static SshServer sshd;
+    private static int port;
+    private static SshClient client;
+
+    public ChannelX11Test() {
+        super();
+    }
+
+    @BeforeEach
+    void setupClientAndServer() throws Exception {
+        sshd = CoreTestSupportUtils.setupTestServer(ChannelX11Test.class);
+        sshd.setForwardingFilter(AcceptAllForwardingFilter.INSTANCE);
+        sshd.start();
+        port = sshd.getPort();
+
+        client = CoreTestSupportUtils.setupTestClient(ChannelX11Test.class);
+        client.setChannelFactories(Collections.singletonList(X11ChannelFactory.INSTANCE));
+        client.start();
+    }
+
+    @AfterEach
+    void tearDownClientAndServer() throws Exception {
+        if (sshd != null) {
+            try {
+                sshd.stop(true);
+            } finally {
+                sshd = null;
+            }
+        }
+
+        if (client != null) {
+            try {
+                client.stop();
+            } finally {
+                client = null;
+            }
+        }
+    }
+
+    @Test
+    void x11Forwarding() throws Exception {
+        try (ClientSession session = client.connect(getCurrentTestName(), TEST_LOCALHOST, port)
+                .verify(CONNECT_TIMEOUT).getSession()) {
+
+            session.addPasswordIdentity(getCurrentTestName());
+            session.auth().verify(AUTH_TIMEOUT);
+
+            try (ChannelShell channel = session.createShellChannel();
+                 PipedInputStream inPis = new PipedInputStream();
+                 PipedOutputStream inPos = new PipedOutputStream(inPis);
+                 PipedInputStream outPis = new PipedInputStream();
+                 PipedOutputStream outPos = new PipedOutputStream(outPis)) {
+
+                channel.setXForwarding(true);
+                channel.setIn(inPis);
+                channel.setOut(outPos);
+                channel.open().verify(OPEN_TIMEOUT).await();
+
+                try (BufferedWriter writer = new BufferedWriter(
+                        new OutputStreamWriter(inPos, StandardCharsets.UTF_8));
+                     BufferedReader reader = new BufferedReader(
+                             new InputStreamReader(outPis, StandardCharsets.UTF_8))) {
+                    writer.write("xcalc");
+                    writer.newLine();
+                    writer.flush();
+
+                    assertEquals("xcalc", reader.readLine());
+
+                    // ENV_DISPLAY
+                    try (ChannelSession serverChannel
+                            = (ChannelSession) GenericUtils.head(GenericUtils.head(sshd.getActiveSessions())
+                                    .getService(ServerConnectionService.class).getChannels())) {
+                        assertNotNull(serverChannel.getEnvironment().getEnv().get(X11ForwardSupport.ENV_DISPLAY));
+                    }
+                }
+            }
+
+        }
+
+    }
+
+    //  @Test
+    void x11ForwardOnMachine() throws Exception {
+
+        try (ClientSession session = client.connect("foo", "127.0.0.1", sshdContainer.getMappedPort(2222))
+                .verify(CONNECT_TIMEOUT).getSession()) {
+
+            session.addPasswordIdentity("bar");
+            session.auth().verify(AUTH_TIMEOUT).await();
+
+            final ChannelExec exec = session.createExecChannel("xcalc");
+            exec.setXForwarding(true);
+            exec.open().verify(CONNECT_TIMEOUT).await();
+            Thread.currentThread().join();
+        }
+    }
+
+}


### PR DESCRIPTION
Closes #712

## example

```java
// create client...
SshClient client;
// set X11ChannelFactory
client.setChannelFactories(Collections.singletonList(X11ChannelFactory.INSTANCE));

// create session...
ClientSession session = client.connect("host").verify(CONNECT_TIMEOUT).getSession();
// set X11 server
CoreModuleProperties.X11_BIND_HOST.set(session, "localhost");
CoreModuleProperties.X11_BASE_PORT.set(session, 6000);

// create channel...
ChannelShell channel = session.createShellChannel();
// enable X11 forwarding
channel.setXForwarding(true);


```