### PR TITLE
GH-727: supply default port for proxyJump if no HostConfigEntry

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,6 +36,7 @@
 * [GH-690](https://github.com/apache/mina-sshd/issues/690) Handle append mode for buggy SFTP v3 servers
 * [GH-700](https://github.com/apache/mina-sshd/issues/700) Fix race in `AbstractCloseable.doCloseImmediately()`
 * [GH-709](https://github.com/apache/mina-sshd/issues/709) `AbstractChannel`: Handle keep-alive channel messages sent by an old OpenSSH server
+* [GH-727](https://github.com/apache/mina-sshd/issues/727) Supply default port 22 for proxy jump hosts for which there is no `HostConfigEntry`
 
 
 * [SSHD-1343](https://issues.apache.org/jira/projects/SSHD/issues/SSHD-1343) Correct documentation in `ChannelDataReceiver`

--- a/sshd-core/src/main/java/org/apache/sshd/client/SshClient.java
+++ b/sshd-core/src/main/java/org/apache/sshd/client/SshClient.java
@@ -77,6 +77,7 @@ import org.apache.sshd.common.Closeable;
 import org.apache.sshd.common.Factory;
 import org.apache.sshd.common.NamedResource;
 import org.apache.sshd.common.ServiceFactory;
+import org.apache.sshd.common.SshConstants;
 import org.apache.sshd.common.channel.ChannelFactory;
 import org.apache.sshd.common.config.keys.FilePasswordProvider;
 import org.apache.sshd.common.config.keys.FilePasswordProviderManager;
@@ -735,6 +736,9 @@ public class SshClient extends AbstractFactoryManager implements ClientFactoryMa
         HostConfigEntry entry = resolver.resolveEffectiveHost(host, port, localAddress, username, null, context);
         if (entry == null) {
             // generate a synthetic entry
+            if (port <= 0) {
+                port = SshConstants.DEFAULT_PORT;
+            }
             if (log.isDebugEnabled()) {
                 log.debug("connect({}@{}:{}) no overrides", username, host, port);
             }


### PR DESCRIPTION
If SshClient creates an empty HostConfigEntry, supply the default port if the given port is <= 0.

I'd have liked to do that once and for all in HostConfigEntry.getPort(), but HostConfigEntry.append(Appendable a) relies on getPort() returning a value <= 0 if not set.

If there _is_ a HostConfigEntry for the proxyJump, then HostConfigEntryResolver.resolveEffectiveHost() would already supply the default port. (That bit was fixed in version 2.10.)

Fixes #727.