### PR TITLE
GH-733: Fix SftpRemotePathChannel.transferTo

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -37,6 +37,7 @@
 * [GH-700](https://github.com/apache/mina-sshd/issues/700) Fix race in `AbstractCloseable.doCloseImmediately()`
 * [GH-709](https://github.com/apache/mina-sshd/issues/709) `AbstractChannel`: Handle keep-alive channel messages sent by an old OpenSSH server
 * [GH-727](https://github.com/apache/mina-sshd/issues/727) Supply default port 22 for proxy jump hosts for which there is no `HostConfigEntry`
+* [GH-733](https://github.com/apache/mina-sshd/issues/733) Fix `SftpRemotePathChannel.transferTo()` (avoid NPE)
 
 
 * [SSHD-1343](https://issues.apache.org/jira/projects/SSHD/issues/SSHD-1343) Correct documentation in `ChannelDataReceiver`

--- a/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/impl/SftpInputStreamAsync.java
+++ b/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/impl/SftpInputStreamAsync.java
@@ -241,8 +241,9 @@ public class SftpInputStreamAsync extends InputStreamWithChannel implements Sftp
                 return;
             }
             // Beyond the expected file size we do single sequential requests; no ahead of time requests.
-            // Hence the requestOffset is always just beyond the current buffer.
-            requestOffset = clientOffset + buffer.available();
+            // Hence the requestOffset is always just beyond the current buffer. If the initial position
+            // is beyond the file size, buffer may still be null here.
+            requestOffset = clientOffset + (buffer != null ? buffer.available() : 0);
         }
         while (pendingReads.size() < Math.max(1, windowSize / bufferSize)) {
             Buffer buf = session.createBuffer(SshConstants.SSH_MSG_CHANNEL_DATA,

--- a/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/impl/SftpRemotePathChannel.java
+++ b/sshd-sftp/src/main/java/org/apache/sshd/sftp/client/impl/SftpRemotePathChannel.java
@@ -365,7 +365,7 @@ public class SftpRemotePathChannel extends FileChannel {
             beginBlocking("transferTo");
 
             try (SftpInputStreamAsync input = new SftpInputStreamAsync(
-                    (AbstractSftpClient) sftp, copySize, position, count, getRemotePath(), handle, false)) {
+                    (AbstractSftpClient) sftp, copySize, position, position + count, getRemotePath(), handle, false)) {
                 totalRead = input.transferTo(count, target);
                 eof = input.isEof();
                 completed = true;


### PR DESCRIPTION
Give the SftpInputStreamAsync a logical file size larger than the current position transfer is requested to start at. If the user calls transferTo(position, count, output), the logical file size for the SftpInputStreamAsync should be (position + count). It's no problem if that is larger than the real file size, it'll just produce an EOF return.

Also guard against NPE in SftpInputStreamAsync in case the initial position is beyond the alleged file size.

Fixes #733.