### PR TITLE
#771 Avoid NoClassDefFoundError: net/i2p/crypto/eddsa/EdDSAPublicKey

### DIFF
--- a/sshd-common/src/main/java/org/apache/sshd/common/util/security/eddsa/EdDSASecurityProviderUtils.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/util/security/eddsa/EdDSASecurityProviderUtils.java
@@ -55,14 +55,6 @@ public final class EdDSASecurityProviderUtils {
         throw new UnsupportedOperationException("No instance");
     }
 
-    public static Class<? extends PublicKey> getEDDSAPublicKeyType() {
-        return EdDSAPublicKey.class;
-    }
-
-    public static Class<? extends PrivateKey> getEDDSAPrivateKeyType() {
-        return EdDSAPrivateKey.class;
-    }
-
     public static boolean isEDDSAKey(Key key) {
         return getEDDSAKeySize(key) == KEY_SIZE;
     }

--- a/sshd-common/src/main/java/org/apache/sshd/common/util/security/eddsa/NetI2pCryptoEdDSASupport.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/util/security/eddsa/NetI2pCryptoEdDSASupport.java
@@ -64,13 +64,13 @@ public class NetI2pCryptoEdDSASupport implements EdDSASupport<EdDSAPublicKey, Ed
     }
 
     @Override
-    public Class<? extends PublicKey> getEDDSAPublicKeyType() {
-        return EdDSASecurityProviderUtils.getEDDSAPublicKeyType();
+    public Class<EdDSAPublicKey> getEDDSAPublicKeyType() {
+        return EdDSAPublicKey.class;
     }
 
     @Override
-    public Class<? extends PrivateKey> getEDDSAPrivateKeyType() {
-        return EdDSASecurityProviderUtils.getEDDSAPrivateKeyType();
+    public Class<EdDSAPrivateKey> getEDDSAPrivateKeyType() {
+        return EdDSAPrivateKey.class;
     }
 
     @Override

--- a/sshd-common/src/main/java/org/apache/sshd/common/util/security/eddsa/bouncycastle/BouncyCastleEdDSASupport.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/util/security/eddsa/bouncycastle/BouncyCastleEdDSASupport.java
@@ -75,12 +75,12 @@ public class BouncyCastleEdDSASupport implements EdDSASupport<EdDSAPublicKey, Ed
     }
 
     @Override
-    public Class<? extends PublicKey> getEDDSAPublicKeyType() {
+    public Class<EdDSAPublicKey> getEDDSAPublicKeyType() {
         return EdDSAPublicKey.class;
     }
 
     @Override
-    public Class<? extends PrivateKey> getEDDSAPrivateKeyType() {
+    public Class<EdDSAPrivateKey> getEDDSAPrivateKeyType() {
         return EdDSAPrivateKey.class;
     }
 

--- a/sshd-common/src/main/java/org/apache/sshd/common/util/security/eddsa/generic/EdDSASupport.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/util/security/eddsa/generic/EdDSASupport.java
@@ -108,12 +108,12 @@ public interface EdDSASupport<PUB extends PublicKey, PRV extends PrivateKey> {
     /**
      * @return the public key class type associated with the security provider.
      */
-    Class<? extends PublicKey> getEDDSAPublicKeyType();
+    Class<PUB> getEDDSAPublicKeyType();
 
     /**
      * @return the private key class type associated with the security provider.
      */
-    Class<? extends PrivateKey> getEDDSAPrivateKeyType();
+    Class<PRV> getEDDSAPrivateKeyType();
 
     /**
      * @param  k1 the first key

--- a/sshd-putty/src/main/java/org/apache/sshd/putty/EdDSAPuttyKeyDecoder.java
+++ b/sshd-putty/src/main/java/org/apache/sshd/putty/EdDSAPuttyKeyDecoder.java
@@ -42,7 +42,9 @@ public class EdDSAPuttyKeyDecoder<PUB extends PublicKey, PRIV extends PrivateKey
     public static final EdDSAPuttyKeyDecoder INSTANCE = new EdDSAPuttyKeyDecoder();
 
     public EdDSAPuttyKeyDecoder() {
-        super((Class<PUB>) SecurityUtils.getEdDSASupport().get().getEDDSAPublicKeyType(), (Class<PRIV>) SecurityUtils.getEdDSASupport().get().getEDDSAPrivateKeyType(), Collections.singletonList(KeyPairProvider.SSH_ED25519));
+        super((Class<PUB>) SecurityUtils.getEdDSASupport().get().getEDDSAPublicKeyType(),
+              (Class<PRIV>) SecurityUtils.getEdDSASupport().get().getEDDSAPrivateKeyType(),
+              Collections.singletonList(KeyPairProvider.SSH_ED25519));
     }
 
     @Override

--- a/sshd-putty/src/main/java/org/apache/sshd/putty/EdDSAPuttyKeyDecoder.java
+++ b/sshd-putty/src/main/java/org/apache/sshd/putty/EdDSAPuttyKeyDecoder.java
@@ -29,23 +29,20 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 
-import net.i2p.crypto.eddsa.EdDSAPrivateKey;
-import net.i2p.crypto.eddsa.EdDSAPublicKey;
 import org.apache.sshd.common.NamedResource;
 import org.apache.sshd.common.keyprovider.KeyPairProvider;
 import org.apache.sshd.common.util.security.SecurityUtils;
-import org.apache.sshd.common.util.security.eddsa.EdDSASecurityProviderUtils;
 
 /**
  * TODO Add javadoc
  *
  * @author <a href="mailto:dev@mina.apache.org">Apache MINA SSHD Project</a>
  */
-public class EdDSAPuttyKeyDecoder extends AbstractPuttyKeyDecoder<EdDSAPublicKey, EdDSAPrivateKey> {
+public class EdDSAPuttyKeyDecoder<PUB extends PublicKey, PRIV extends PrivateKey> extends AbstractPuttyKeyDecoder<PUB, PRIV> {
     public static final EdDSAPuttyKeyDecoder INSTANCE = new EdDSAPuttyKeyDecoder();
 
     public EdDSAPuttyKeyDecoder() {
-        super(EdDSAPublicKey.class, EdDSAPrivateKey.class, Collections.singletonList(KeyPairProvider.SSH_ED25519));
+        super((Class<PUB>) SecurityUtils.getEdDSASupport().get().getEDDSAPublicKeyType(), (Class<PRIV>) SecurityUtils.getEdDSASupport().get().getEDDSAPrivateKeyType(), Collections.singletonList(KeyPairProvider.SSH_ED25519));
     }
 
     @Override
@@ -63,9 +60,9 @@ public class EdDSAPuttyKeyDecoder extends AbstractPuttyKeyDecoder<EdDSAPublicKey
         }
 
         byte[] seed = pubReader.read(Short.MAX_VALUE); // reasonable max. allowed size
-        PublicKey pubKey = EdDSASecurityProviderUtils.generateEDDSAPublicKey(seed);
+        PublicKey pubKey = SecurityUtils.getEdDSASupport().get().generateEDDSAPublicKey(seed);
         seed = prvReader.read(Short.MAX_VALUE); // reasonable max. allowed size
-        PrivateKey prvKey = EdDSASecurityProviderUtils.generateEDDSAPrivateKey(seed);
+        PrivateKey prvKey = SecurityUtils.getEdDSASupport().get().generateEDDSAPrivateKey(seed);
         return Collections.singletonList(new KeyPair(pubKey, prvKey));
     }
 }


### PR DESCRIPTION
Using PuttyKeyUtils we can get an error if we don't want dependency net.i2p.crypto but having BC dependency, I made some change using SecurityUtils.getEdDSASupport to remove net.i2p.crypto dependency

