### PR TITLE
GH-754: Don't close DefaultForwarder on bind error

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -40,6 +40,7 @@
 * [GH-727](https://github.com/apache/mina-sshd/issues/727) Supply default port 22 for proxy jump hosts for which there is no `HostConfigEntry`
 * [GH-733](https://github.com/apache/mina-sshd/issues/733) Fix `SftpRemotePathChannel.transferTo()` (avoid NPE)
 * [GH-751](https://github.com/apache/mina-sshd/issues/751) Fix SFTP v3 "long name" if SFTP server uses an `SftpFileSystem` to another server
+* [GH-754](https://github.com/apache/mina-sshd/issues/754) `DefaultFowarder` must not be closed after a bind error
 * [GH-767](https://github.com/apache/mina-sshd/issues/767) Remove dependency on net.i2p.crypto in `SkED25519PublicKey`
 * [GH-771](https://github.com/apache/mina-sshd/issues/771) Remove dependency on net.i2p.crypto in `EdDSAPuttyKeyDecoder`
 * [GH-774](https://github.com/apache/mina-sshd/issues/774) Fix `WritePendingException` in SFTP file copy

--- a/sshd-core/src/main/java/org/apache/sshd/common/forward/DefaultForwarder.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/forward/DefaultForwarder.java
@@ -932,31 +932,23 @@ public class DefaultForwarder
             throws IOException {
         // TODO find a better way to determine the resulting bind address - what if multi-threaded calls...
         Collection<SocketAddress> before = acceptor.getBoundAddresses();
-        try {
-            InetSocketAddress bindAddress = address.toInetSocketAddress();
-            acceptor.bind(bindAddress);
+        InetSocketAddress bindAddress = address.toInetSocketAddress();
+        acceptor.bind(bindAddress);
 
-            Collection<SocketAddress> after = acceptor.getBoundAddresses();
-            if (GenericUtils.size(after) > 0) {
-                after.removeAll(before);
-            }
-            if (GenericUtils.isEmpty(after)) {
-                throw new IOException("Error binding to " + address + "[" + bindAddress + "]: no local addresses bound");
-            }
-
-            if (after.size() > 1) {
-                throw new IOException("Multiple local addresses have been bound for " + address + "[" + bindAddress + "]");
-            }
-
-            InetSocketAddress boundAddress = (InetSocketAddress) GenericUtils.head(after);
-            return boundAddress;
-        } catch (IOException bindErr) {
-            Collection<SocketAddress> after = acceptor.getBoundAddresses();
-            if (GenericUtils.isEmpty(after)) {
-                close();
-            }
-            throw bindErr;
+        Collection<SocketAddress> after = acceptor.getBoundAddresses();
+        if (GenericUtils.size(after) > 0) {
+            after.removeAll(before);
         }
+        if (GenericUtils.isEmpty(after)) {
+            throw new IOException("Error binding to " + address + "[" + bindAddress + "]: no local addresses bound");
+        }
+
+        if (after.size() > 1) {
+            throw new IOException("Multiple local addresses have been bound for " + address + "[" + bindAddress + "]");
+        }
+
+        InetSocketAddress boundAddress = (InetSocketAddress) GenericUtils.head(after);
+        return boundAddress;
     }
 
     @Override


### PR DESCRIPTION
The ConnectionService keeps a single DefaultForwarder throughout its lifetime. If a port forwarding produces a bind error, the forwarding may throw an exception, but the forwarder must not be closed. If it is closed, no further forwardings are possible anymore in that session.

Fixes #754.