### PR TITLE
Trigger ClientChannelEvent.Timeout and ClientSessionEvent.TIMEOUT independently to host's program cycle times

### DIFF
--- a/sshd-core/src/main/java/org/apache/sshd/client/channel/AbstractClientChannel.java
+++ b/sshd-core/src/main/java/org/apache/sshd/client/channel/AbstractClientChannel.java
@@ -27,7 +27,6 @@ import java.util.Collections;
 import java.util.EnumSet;
 import java.util.Objects;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 

--- a/sshd-core/src/main/java/org/apache/sshd/client/channel/AbstractClientChannel.java
+++ b/sshd-core/src/main/java/org/apache/sshd/client/channel/AbstractClientChannel.java
@@ -262,6 +262,7 @@ public abstract class AbstractClientChannel extends AbstractChannel implements C
                 if (timeout > 0L) {
                     long now = System.currentTimeMillis();
                     long usedTime = now - startTime;
+                    remWait = timeout - usedTime;
                     if ((usedTime >= timeout) || (remWait <= 0L)) {
                         if (traceEnabled) {
                             log.trace("waitFor({}) call timeout {}/{} for mask={}: {}",
@@ -289,14 +290,6 @@ public abstract class AbstractClientChannel extends AbstractChannel implements C
                     long nanoDuration = nanoEnd - nanoStart;
                     if (traceEnabled) {
                         log.trace("waitFor({}) lock notified on channel after {} nanos", this, nanoDuration);
-                    }
-
-                    if (timeout > 0L) {
-                        long waitDuration = TimeUnit.MILLISECONDS.convert(nanoDuration, TimeUnit.NANOSECONDS);
-                        if (waitDuration <= 0L) {
-                            waitDuration = 123L;
-                        }
-                        remWait -= waitDuration;
                     }
                 } catch (InterruptedException e) {
                     long nanoEnd = System.nanoTime();

--- a/sshd-core/src/main/java/org/apache/sshd/client/session/ClientSessionImpl.java
+++ b/sshd-core/src/main/java/org/apache/sshd/client/session/ClientSessionImpl.java
@@ -28,7 +28,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -266,6 +265,7 @@ public class ClientSessionImpl extends AbstractClientSession {
                 if (timeout > 0L) {
                     long now = System.currentTimeMillis();
                     long usedTime = now - startTime;
+                    remWait = timeout - usedTime;
                     if ((usedTime >= timeout) || (remWait <= 0L)) {
                         if (traceEnabled) {
                             log.trace("waitFor({}) call timeout {}/{} for mask={}: {}",
@@ -293,14 +293,6 @@ public class ClientSessionImpl extends AbstractClientSession {
                     long nanoDuration = nanoEnd - nanoStart;
                     if (traceEnabled) {
                         log.trace("waitFor({}) Lock notified after {} nanos", this, nanoDuration);
-                    }
-
-                    if (timeout > 0L) {
-                        long waitDuration = TimeUnit.MILLISECONDS.convert(nanoDuration, TimeUnit.NANOSECONDS);
-                        if (waitDuration <= 0L) {
-                            waitDuration = 123L;
-                        }
-                        remWait -= waitDuration;
                     }
                 } catch (InterruptedException e) {
                     long nanoEnd = System.nanoTime();


### PR DESCRIPTION
On some hosts, on which waiting for the `futureLock.wait(remWait)` is faster than 1 millisecond, `remWait` gets reduced by 123 milliseconds although not even one passed.
As each host has different cycle times, this happens an unknown amount of times.
This causes a `ClientChannelEvent.Timeout` after a much smaller time passed than the configured timeout.
With these changes, the `remWait` is calculated based on the milliseconds passed instead of transformed nanoseconds.

The same code is found in `ClientSessionImpl@waitFor`. This is also addressed.