### PR TITLE
Client sent empty ssh package to keep connection issue

### DIFF
--- a/sshd-core/src/main/java/org/apache/sshd/common/session/helpers/SessionHelper.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/session/helpers/SessionHelper.java
@@ -403,7 +403,12 @@ public abstract class SessionHelper extends AbstractKexFactoryManager implements
             }
             return;
         }
-        resetIdleTimeout();
+        if (log.isTraceEnabled()) {
+            log.trace("MESSAGE_SSH_IGNORE_FLAG: {}", CoreModuleProperties.MESSAGE_SSH_IGNORE_FLAG.getRequired(getFactoryManager()));
+        }
+        if (CoreModuleProperties.MESSAGE_SSH_IGNORE_FLAG.getRequired(getFactoryManager())) {
+            resetIdleTimeout();
+        }
         doInvokeIgnoreMessageHandler(buffer);
     }
 

--- a/sshd-core/src/main/java/org/apache/sshd/core/CoreModuleProperties.java
+++ b/sshd-core/src/main/java/org/apache/sshd/core/CoreModuleProperties.java
@@ -251,6 +251,8 @@ public final class CoreModuleProperties {
     public static final Property<Boolean> REQUEST_SUBSYSTEM_REPLY
             = Property.bool("channel-subsystem-want-reply", true);
 
+    public static final Property<Boolean> MESSAGE_SSH_IGNORE_FLAG
+            = Property.bool("message-ssh-ignore-flag", true);
     public static final Property<Integer> PROP_DHGEX_CLIENT_MIN_KEY
             = Property.integer("dhgex-client-min");
 


### PR DESCRIPTION
I use sshd family libs(version: 2.14.0) to run a sftp server.
But many clients send some empty_ssh_packages to keep the connection.
Based on our business requirements, we do not wish to maintain such persistent connections. 
Therefore, I have made this modification, hoping to add an additional parameter to control this behavior.
