### PR TITLE
GH-807: Handle "verified" flag for sk-* keys

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,6 +29,8 @@
 
 ## Bug Fixes
 
+* [GH-807](https://github.com/apache/mina-sshd/issues/807) Handle "verified" flag for sk-* keys
+
 ## New Features
 
 ## Potential Compatibility Issues

--- a/sshd-common/src/main/java/org/apache/sshd/common/config/keys/KeyUtils.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/config/keys/KeyUtils.java
@@ -1261,6 +1261,7 @@ public final class KeyUtils {
         } else {
             return Objects.equals(k1.getAppName(), k2.getAppName())
                     && Objects.equals(k1.isNoTouchRequired(), k2.isNoTouchRequired())
+                    && Objects.equals(k1.isVerifyRequired(), k2.isVerifyRequired())
                     && compareECKeys(k1.getDelegatePublicKey(), k2.getDelegatePublicKey());
         }
     }
@@ -1273,6 +1274,7 @@ public final class KeyUtils {
         } else {
             return Objects.equals(k1.getAppName(), k2.getAppName())
                     && Objects.equals(k1.isNoTouchRequired(), k2.isNoTouchRequired())
+                    && Objects.equals(k1.isVerifyRequired(), k2.isVerifyRequired())
                     && SecurityUtils.compareEDDSAPPublicKeys(k1.getDelegatePublicKey(), k2.getDelegatePublicKey());
         }
     }

--- a/sshd-common/src/main/java/org/apache/sshd/common/config/keys/impl/SkECDSAPublicKeyEntryDecoder.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/config/keys/impl/SkECDSAPublicKeyEntryDecoder.java
@@ -48,6 +48,7 @@ public class SkECDSAPublicKeyEntryDecoder extends AbstractPublicKeyEntryDecoder<
     public static final SkECDSAPublicKeyEntryDecoder INSTANCE = new SkECDSAPublicKeyEntryDecoder();
 
     private static final String NO_TOUCH_REQUIRED_HEADER = "no-touch-required";
+    private static final String VERIFY_REQUIRED_HEADER = "verify-required";
 
     public SkECDSAPublicKeyEntryDecoder() {
         super(SkEcdsaPublicKey.class, PrivateKey.class, Collections.singleton(KEY_TYPE));
@@ -62,9 +63,10 @@ public class SkECDSAPublicKeyEntryDecoder extends AbstractPublicKeyEntryDecoder<
         }
 
         boolean noTouchRequired = parseBooleanHeader(headers, NO_TOUCH_REQUIRED_HEADER, false);
+        boolean verifyRequired = parseBooleanHeader(headers, VERIFY_REQUIRED_HEADER, false);
         ECPublicKey ecPublicKey = ECDSAPublicKeyEntryDecoder.INSTANCE.decodePublicKey(ECCurves.nistp256, keyData);
         String appName = KeyEntryResolver.decodeString(keyData, MAX_APP_NAME_LENGTH);
-        return new SkEcdsaPublicKey(appName, noTouchRequired, ecPublicKey);
+        return new SkEcdsaPublicKey(appName, noTouchRequired, verifyRequired, ecPublicKey);
     }
 
     @Override
@@ -74,7 +76,7 @@ public class SkECDSAPublicKeyEntryDecoder extends AbstractPublicKeyEntryDecoder<
         }
 
         return new SkEcdsaPublicKey(
-                key.getAppName(), key.isNoTouchRequired(),
+                key.getAppName(), key.isNoTouchRequired(), key.isVerifyRequired(),
                 ECDSAPublicKeyEntryDecoder.INSTANCE.clonePublicKey(key.getDelegatePublicKey()));
     }
 

--- a/sshd-common/src/main/java/org/apache/sshd/common/config/keys/impl/SkED25519PublicKeyEntryDecoder.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/config/keys/impl/SkED25519PublicKeyEntryDecoder.java
@@ -51,6 +51,7 @@ public class SkED25519PublicKeyEntryDecoder extends AbstractPublicKeyEntryDecode
     public static final SkED25519PublicKeyEntryDecoder INSTANCE = new SkED25519PublicKeyEntryDecoder();
 
     private static final String NO_TOUCH_REQUIRED_HEADER = "no-touch-required";
+    private static final String VERIFY_REQUIRED_HEADER = "verify-required";
 
     public SkED25519PublicKeyEntryDecoder() {
         super(SkED25519PublicKey.class, PrivateKey.class, Collections.singleton(KEY_TYPE));
@@ -65,10 +66,11 @@ public class SkED25519PublicKeyEntryDecoder extends AbstractPublicKeyEntryDecode
         }
 
         boolean noTouchRequired = parseBooleanHeader(headers, NO_TOUCH_REQUIRED_HEADER, false);
+        boolean verifyRequired = parseBooleanHeader(headers, VERIFY_REQUIRED_HEADER, false);
         PublicKey pk = SecurityUtils.getEDDSAPublicKeyEntryDecoder().decodePublicKey(session, KeyPairProvider.SSH_ED25519,
                 keyData, headers);
         String appName = KeyEntryResolver.decodeString(keyData, MAX_APP_NAME_LENGTH);
-        return new SkED25519PublicKey(appName, noTouchRequired, pk);
+        return new SkED25519PublicKey(appName, noTouchRequired, verifyRequired, pk);
     }
 
     @Override
@@ -77,7 +79,8 @@ public class SkED25519PublicKeyEntryDecoder extends AbstractPublicKeyEntryDecode
             return null;
         }
 
-        return new SkED25519PublicKey(key.getAppName(), key.isNoTouchRequired(), key.getDelegatePublicKey());
+        return new SkED25519PublicKey(key.getAppName(), key.isNoTouchRequired(), key.isVerifyRequired(),
+                key.getDelegatePublicKey());
     }
 
     @Override

--- a/sshd-common/src/main/java/org/apache/sshd/common/config/keys/u2f/SecurityKeyPublicKey.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/config/keys/u2f/SecurityKeyPublicKey.java
@@ -23,9 +23,12 @@ import java.security.PublicKey;
 import org.apache.sshd.common.config.keys.SshPublicKey;
 
 public interface SecurityKeyPublicKey<K extends PublicKey> extends SshPublicKey {
+
     String getAppName();
 
     boolean isNoTouchRequired();
+
+    boolean isVerifyRequired();
 
     K getDelegatePublicKey();
 }

--- a/sshd-common/src/main/java/org/apache/sshd/common/config/keys/u2f/SkED25519PublicKey.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/config/keys/u2f/SkED25519PublicKey.java
@@ -34,11 +34,26 @@ public class SkED25519PublicKey implements SecurityKeyPublicKey<PublicKey> {
 
     private final String appName;
     private final boolean noTouchRequired;
+    private final boolean verifyRequired;
     private final PublicKey delegatePublicKey;
 
+    /**
+     * Creates a new instance.
+     *
+     * @param      appName           application name
+     * @param      noTouchRequired   whether the "no-touch-required" flag was present in authorized_keys
+     * @param      delegatePublicKey the underlying real public key
+     * @deprecated                   use {@link #SkED25519PublicKey(String, boolean, boolean, PublicKey)} instead
+     */
+    @Deprecated
     public SkED25519PublicKey(String appName, boolean noTouchRequired, PublicKey delegatePublicKey) {
+        this(appName, noTouchRequired, false, delegatePublicKey);
+    }
+
+    public SkED25519PublicKey(String appName, boolean noTouchRequired, boolean verifyRequired, PublicKey delegatePublicKey) {
         this.appName = appName;
         this.noTouchRequired = noTouchRequired;
+        this.verifyRequired = verifyRequired;
         ValidateUtils.checkTrue(KeyPairProvider.SSH_ED25519.equals(KeyUtils.getKeyType(delegatePublicKey)),
                 "Key is not an ed25519 key");
         this.delegatePublicKey = delegatePublicKey;
@@ -75,6 +90,11 @@ public class SkED25519PublicKey implements SecurityKeyPublicKey<PublicKey> {
     }
 
     @Override
+    public boolean isVerifyRequired() {
+        return verifyRequired;
+    }
+
+    @Override
     public PublicKey getDelegatePublicKey() {
         return delegatePublicKey;
     }
@@ -84,6 +104,7 @@ public class SkED25519PublicKey implements SecurityKeyPublicKey<PublicKey> {
         return getClass().getSimpleName()
                + "[appName=" + getAppName()
                + ", noTouchRequired=" + isNoTouchRequired()
+               + ", verifyRequired=" + isVerifyRequired()
                + ", delegatePublicKey=" + getDelegatePublicKey()
                + "]";
     }

--- a/sshd-common/src/main/java/org/apache/sshd/common/config/keys/u2f/SkEcdsaPublicKey.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/config/keys/u2f/SkEcdsaPublicKey.java
@@ -31,11 +31,26 @@ public class SkEcdsaPublicKey implements SecurityKeyPublicKey<ECPublicKey> {
 
     private final String appName;
     private final boolean noTouchRequired;
+    private final boolean verifyRequired;
     private final ECPublicKey delegatePublicKey;
 
+    /**
+     * Creates a new instance.
+     *
+     * @param      appName           application name
+     * @param      noTouchRequired   whether the "no-touch-required" flag was present in authorized_keys
+     * @param      delegatePublicKey the underlying real public key
+     * @deprecated                   use {@link #SkEcdsaPublicKey(String, boolean, boolean, ECPublicKey)} instead
+     */
+    @Deprecated
     public SkEcdsaPublicKey(String appName, boolean noTouchRequired, ECPublicKey delegatePublicKey) {
+        this(appName, noTouchRequired, false, delegatePublicKey);
+    }
+
+    public SkEcdsaPublicKey(String appName, boolean noTouchRequired, boolean verifyRequired, ECPublicKey delegatePublicKey) {
         this.appName = appName;
         this.noTouchRequired = noTouchRequired;
+        this.verifyRequired = verifyRequired;
         this.delegatePublicKey = delegatePublicKey;
     }
 
@@ -70,6 +85,11 @@ public class SkEcdsaPublicKey implements SecurityKeyPublicKey<ECPublicKey> {
     }
 
     @Override
+    public boolean isVerifyRequired() {
+        return verifyRequired;
+    }
+
+    @Override
     public ECPublicKey getDelegatePublicKey() {
         return delegatePublicKey;
     }
@@ -79,6 +99,7 @@ public class SkEcdsaPublicKey implements SecurityKeyPublicKey<ECPublicKey> {
         return getClass().getSimpleName()
                + "[appName=" + getAppName()
                + ", noTouchRequired=" + isNoTouchRequired()
+               + ", verifyRequired=" + isVerifyRequired()
                + ", delegatePublicKey=" + getDelegatePublicKey()
                + "]";
     }

--- a/sshd-common/src/main/java/org/apache/sshd/common/signature/AbstractSecurityKeySignature.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/signature/AbstractSecurityKeySignature.java
@@ -30,7 +30,10 @@ import org.apache.sshd.common.util.buffer.ByteArrayBuffer;
 import org.apache.sshd.common.util.security.SecurityUtils;
 
 public abstract class AbstractSecurityKeySignature implements Signature {
-    private static final int FLAG_USER_PRESENCE = 0x01;
+
+    private static final int FLAG_USER_PRESENCE = 1 << 0;
+
+    private static final int FLAG_VERIFIED = 1 << 2;
 
     private final String keyType;
     private SecurityKeyPublicKey<?> publicKey;
@@ -76,12 +79,11 @@ public abstract class AbstractSecurityKeySignature implements Signature {
         byte flags = data.getByte();
         long counter = data.getUInt();
 
-        // Return false if we don't understand the flags
-        if ((flags & ~FLAG_USER_PRESENCE) != 0) {
-            return false;
-        }
         // Check user-presence flag is present if required by the public key
         if ((flags & FLAG_USER_PRESENCE) != FLAG_USER_PRESENCE && !publicKey.isNoTouchRequired()) {
+            return false;
+        }
+        if ((flags & FLAG_VERIFIED) != FLAG_VERIFIED && publicKey.isVerifyRequired()) {
             return false;
         }
 


### PR DESCRIPTION
Parse the "verify_required" flag from authorized_keys and set it on the keys; add a getter. When checking the signature, also check the "verified" flag if "verified-required" is set.

Fixes #807.