### PR TITLE
Fix server-side authentication with FIDO/U2F sk-* keys

### DIFF
--- a/sshd-common/src/main/java/org/apache/sshd/common/signature/AbstractSecurityKeySignature.java
+++ b/sshd-common/src/main/java/org/apache/sshd/common/signature/AbstractSecurityKeySignature.java
@@ -23,6 +23,7 @@ import java.security.GeneralSecurityException;
 import java.security.MessageDigest;
 import java.security.PrivateKey;
 import java.security.PublicKey;
+import java.security.SignatureException;
 
 import org.apache.sshd.common.config.keys.u2f.SecurityKeyPublicKey;
 import org.apache.sshd.common.session.SessionContext;
@@ -85,6 +86,10 @@ public abstract class AbstractSecurityKeySignature implements Signature {
         }
         if ((flags & FLAG_VERIFIED) != FLAG_VERIFIED && publicKey.isVerifyRequired()) {
             return false;
+        }
+
+        if (data.available() > 0) {
+            throw new SignatureException("Unexpected trailing data in signature");
         }
 
         // Re-encode signature in a format to match the delegate

--- a/sshd-core/src/main/java/org/apache/sshd/server/auth/pubkey/AuthorizedKeyEntriesPublickeyAuthenticator.java
+++ b/sshd-core/src/main/java/org/apache/sshd/server/auth/pubkey/AuthorizedKeyEntriesPublickeyAuthenticator.java
@@ -61,8 +61,7 @@ public class AuthorizedKeyEntriesPublickeyAuthenticator extends AbstractLoggingB
         } else {
             resolvedKeys = new HashMap<>(numEntries);
             for (AuthorizedKeyEntry e : entries) {
-                Map<String, String> headers = e.getLoginOptions();
-                PublicKey k = e.resolvePublicKey(session, headers, fallbackResolver);
+                PublicKey k = e.resolvePublicKey(session, Collections.emptyMap(), fallbackResolver);
                 if (k != null) {
                     resolvedKeys.put(e, k);
                 }

--- a/sshd-core/src/main/java/org/apache/sshd/server/auth/pubkey/UserAuthPublicKey.java
+++ b/sshd-core/src/main/java/org/apache/sshd/server/auth/pubkey/UserAuthPublicKey.java
@@ -31,8 +31,11 @@ import org.apache.sshd.common.NamedFactory;
 import org.apache.sshd.common.NamedResource;
 import org.apache.sshd.common.RuntimeSshException;
 import org.apache.sshd.common.SshConstants;
+import org.apache.sshd.common.config.keys.AuthorizedKeyEntry;
 import org.apache.sshd.common.config.keys.KeyUtils;
 import org.apache.sshd.common.config.keys.OpenSshCertificate;
+import org.apache.sshd.common.config.keys.PublicKeyEntryResolver;
+import org.apache.sshd.common.config.keys.u2f.SecurityKeyPublicKey;
 import org.apache.sshd.common.net.InetAddressRange;
 import org.apache.sshd.common.signature.Signature;
 import org.apache.sshd.common.signature.SignatureFactoriesManager;
@@ -126,14 +129,16 @@ public class UserAuthPublicKey extends AbstractUserAuth implements SignatureFact
             log.debug("doAuth({}@{}) verify key type={}, factories={}, fingerprint={}",
                     username, session, alg, NamedResource.getNames(factories), KeyUtils.getFingerPrint(key));
         }
-        Signature verifier = ValidateUtils.checkNotNull(
+        final Signature verifier = ValidateUtils.checkNotNull(
                 NamedFactory.create(factories, alg),
                 "No verifier located for algorithm=%s",
                 alg);
-        verifier.initVerifier(session, verifyKey);
         buffer.wpos(oldLim);
 
-        byte[] sig = hasSig ? buffer.getBytes() : null;
+        final byte[] sig = hasSig ? buffer.getBytes() : null;
+        if (buffer.available() > 0) {
+            throw new SignatureException("Unexpected trailing data after signature");
+        }
         PublickeyAuthenticator authenticator = session.getPublickeyAuthenticator();
         if (authenticator == null) {
             if (debugEnabled) {
@@ -167,6 +172,15 @@ public class UserAuthPublicKey extends AbstractUserAuth implements SignatureFact
             return null;
         }
 
+        if (verifyKey instanceof SecurityKeyPublicKey<?>) {
+            AuthorizedKeyEntry entry = session.getAttribute(AuthorizedKeyEntriesPublickeyAuthenticator.AUTHORIZED_KEY);
+            if (entry != null) {
+                // Use the key including the options defined in the entry.
+                verifyKey = entry.resolvePublicKey(session, entry.getLoginOptions(), PublicKeyEntryResolver.FAILING);
+            }
+        }
+        verifier.initVerifier(session, verifyKey);
+
         buffer.rpos(oldPos);
         buffer.wpos(oldPos + 4 + len);
         if (!verifySignature(session, username, alg, key, buffer, verifier, sig)) {
@@ -192,7 +206,8 @@ public class UserAuthPublicKey extends AbstractUserAuth implements SignatureFact
                     "Found invalid signature alg " + sigAlg + " for key ID=" + keyId + " using a " + keyAlg + " CA key");
         }
 
-        Signature verif = ValidateUtils.checkNotNull(NamedFactory.create(session.getSignatureFactories(), sigAlg),
+        Signature verif = ValidateUtils.checkNotNull(
+                NamedFactory.create(SignatureFactoriesManager.resolveSignatureFactories(this, session), sigAlg),
                 "No CA verifier located for algorithm=%s of key ID=%s", sigAlg, keyId);
         verif.initVerifier(session, signatureKey);
         verif.update(session, cert.getMessage());

--- a/sshd-core/src/test/java/org/apache/sshd/server/auth/AuthorizedKeyEntriesPublickeyAuthenticatorTest.java
+++ b/sshd-core/src/test/java/org/apache/sshd/server/auth/AuthorizedKeyEntriesPublickeyAuthenticatorTest.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sshd.server.auth;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.interfaces.ECPublicKey;
+import java.util.Collections;
+import java.util.stream.Stream;
+
+import org.apache.sshd.common.config.keys.AuthorizedKeyEntry;
+import org.apache.sshd.common.config.keys.PublicKeyEntry;
+import org.apache.sshd.common.config.keys.PublicKeyEntryResolver;
+import org.apache.sshd.common.config.keys.u2f.SkEcdsaPublicKey;
+import org.apache.sshd.common.util.ValidateUtils;
+import org.apache.sshd.server.auth.pubkey.AuthorizedKeyEntriesPublickeyAuthenticator;
+import org.apache.sshd.util.test.BaseTestSupport;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@Tag("NoIoTestCase")
+class AuthorizedKeyEntriesPublickeyAuthenticatorTest extends BaseTestSupport {
+
+    private static Stream<Arguments> options() {
+        return Stream.of(Arguments.of("", ""), //
+                Arguments.of("no-touch-required", ""), //
+                Arguments.of("verify-required", ""), //
+                Arguments.of("no-touch-required", "verify-required") //
+        );
+    }
+
+    @ParameterizedTest(name = "match {0} {1}")
+    @MethodSource("options")
+    void testMatch(String first, String second) throws Exception {
+        KeyPairGenerator gen = KeyPairGenerator.getInstance("EC");
+        gen.initialize(256);
+        KeyPair pair = gen.generateKeyPair();
+        ECPublicKey key = ValidateUtils.checkInstanceOf(pair.getPublic(), ECPublicKey.class, "Expected an EC key");
+        SkEcdsaPublicKey pubKey = new SkEcdsaPublicKey("ssh", false, false, key);
+        String line = first;
+        if (!second.isEmpty()) {
+            line += ',' + second;
+        }
+        if (!line.isEmpty()) {
+            line = line + ' ';
+        }
+        line += PublicKeyEntry.toString(pubKey);
+        AuthorizedKeyEntry entry = AuthorizedKeyEntry.parseAuthorizedKeyEntry(line);
+        AuthorizedKeyEntriesPublickeyAuthenticator auth = new AuthorizedKeyEntriesPublickeyAuthenticator("test", null,
+                Collections.singletonList(entry), PublicKeyEntryResolver.FAILING);
+        assertTrue(auth.authenticate("user", pubKey, null));
+    }
+}

--- a/sshd-core/src/test/java/org/apache/sshd/server/auth/UserAuthPublicKeySkTest.java
+++ b/sshd-core/src/test/java/org/apache/sshd/server/auth/UserAuthPublicKeySkTest.java
@@ -1,0 +1,207 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sshd.server.auth;
+
+import java.nio.charset.StandardCharsets;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.MessageDigest;
+import java.security.PrivateKey;
+import java.security.SignatureException;
+import java.security.interfaces.ECPublicKey;
+import java.util.Collections;
+import java.util.concurrent.ThreadLocalRandom;
+
+import org.apache.sshd.common.Factory;
+import org.apache.sshd.common.SshConstants;
+import org.apache.sshd.common.auth.AbstractUserAuthServiceFactory;
+import org.apache.sshd.common.config.keys.AuthorizedKeyEntry;
+import org.apache.sshd.common.config.keys.PublicKeyEntry;
+import org.apache.sshd.common.config.keys.PublicKeyEntryResolver;
+import org.apache.sshd.common.config.keys.u2f.SkEcdsaPublicKey;
+import org.apache.sshd.common.io.IoSession;
+import org.apache.sshd.common.random.JceRandomFactory;
+import org.apache.sshd.common.random.Random;
+import org.apache.sshd.common.random.SingletonRandomFactory;
+import org.apache.sshd.common.signature.BuiltinSignatures;
+import org.apache.sshd.common.signature.Signature;
+import org.apache.sshd.common.util.ValidateUtils;
+import org.apache.sshd.common.util.buffer.BufferUtils;
+import org.apache.sshd.common.util.buffer.ByteArrayBuffer;
+import org.apache.sshd.common.util.security.SecurityUtils;
+import org.apache.sshd.server.ServerFactoryManager;
+import org.apache.sshd.server.auth.pubkey.AuthorizedKeyEntriesPublickeyAuthenticator;
+import org.apache.sshd.server.auth.pubkey.UserAuthPublicKey;
+import org.apache.sshd.server.session.ServerSessionImpl;
+import org.apache.sshd.util.test.BaseTestSupport;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.Mockito;
+
+/**
+ * Unit test for {@link UserAuthPublickey} handling sk-* authentication on the server-side.
+ */
+@Tag("NoIoTestCase")
+class UserAuthPublicKeySkTest extends BaseTestSupport {
+
+    @ParameterizedTest(name = "auth {0} sig {1}")
+    @CsvSource({ //
+            "0,0", "0,1", "0,4", "0,5", //
+            "1,0", "1,1", "1,4", "1,5", //
+            "4,0", "4,1", "4,4", "4,5", //
+            "5,0", "5,1", "5,4", "5,5" //
+    })
+    void testSk(int authFlags, int flagsOnSig) throws Exception {
+        // Determine expected outcome
+        boolean expectSuccess = true;
+        if ((flagsOnSig & 1) == 0 && (authFlags & 1) == 0) {
+            // Incoming key/signature doesn't have "user presence" flag but auth requires is (no-touch-required not set)
+            expectSuccess = false;
+        }
+        if ((authFlags & 4) != 0 && (flagsOnSig & 4) == 0) {
+            // auth has verify-required but incoming key/signature doesn't.
+            expectSuccess = false;
+        }
+
+        // Generate a "fake" SK EC key. "Fake" because we actually use a normal EC key as basis, so that we have the
+        // private key
+        // and can generate a signature.
+        KeyPairGenerator generator = SecurityUtils.getKeyPairGenerator("EC");
+        generator.initialize(256);
+        KeyPair pair = generator.generateKeyPair();
+        ECPublicKey ecPubKey = ValidateUtils.checkInstanceOf(pair.getPublic(), ECPublicKey.class, "Expected an ECPublicKey");
+        SkEcdsaPublicKey sk = new SkEcdsaPublicKey("ssh", false, false, ecPubKey);
+
+        MockSession session = createSession();
+        // Give it a session ID since it is part of the signed data.
+        byte[] id = new byte[32];
+        ThreadLocalRandom.current().nextBytes(id);
+        session.setSessionId(id);
+
+        // Generate an AuthorizedKeyEntry, and set an authenticator on the mock session.
+        String entryLine = "";
+        switch (authFlags & 5) {
+            case 0:
+                break;
+            case 1:
+                entryLine = "no-touch-required ";
+                break;
+            case 4:
+                entryLine = "verify-required ";
+                break;
+            case 5:
+                entryLine = "no-touch-required,verify-required ";
+                break;
+            default:
+                fail("Invalid authFlags " + authFlags);
+                break;
+        }
+        entryLine += PublicKeyEntry.toString(sk);
+        AuthorizedKeyEntry entry = AuthorizedKeyEntry.parseAuthorizedKeyEntry(entryLine);
+        AuthorizedKeyEntriesPublickeyAuthenticator authenticator = new AuthorizedKeyEntriesPublickeyAuthenticator("test",
+                session, Collections.singleton(entry), PublicKeyEntryResolver.FAILING);
+        session.setPublickeyAuthenticator(authenticator);
+
+        // Create the UserAuthPublickey object under test; give it the signature factory we need.
+        UserAuthPublicKey pubkeyAuth = new UserAuthPublicKey(
+                Collections.singletonList(BuiltinSignatures.sk_ecdsa_sha2_nistp256));
+
+        // Create a buffer with a full properly signed authentication request.
+        ByteArrayBuffer buffer = createRequest(id, (byte) flagsOnSig, sk, pair.getPrivate());
+
+        String userName = buffer.getString();
+        String serviceName = buffer.getString();
+        buffer.getString(); // Skip method name
+
+        // Finally try to authenticate and check the result.
+        try {
+            Boolean result = pubkeyAuth.auth(session, userName, serviceName, buffer);
+            assertEquals(expectSuccess, result.booleanValue());
+        } catch (SignatureException e) {
+            if (!"Key verification failed".equals(e.getMessage())) {
+                throw e;
+            }
+            assertFalse(expectSuccess);
+        }
+    }
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    private MockSession createSession() throws Exception {
+        // Create a mock ServerSession. We can't simple mock the server session since the authenticator might want to
+        // set an attribute on it.
+        ServerFactoryManager manager = Mockito.mock(ServerFactoryManager.class);
+        Factory<? extends Random> randomFactory = new SingletonRandomFactory(JceRandomFactory.INSTANCE);
+        Mockito.when(manager.getRandomFactory()).thenReturn((Factory) randomFactory);
+        return new MockSession(manager, Mockito.mock(IoSession.class));
+    }
+
+    private ByteArrayBuffer createRequest(byte[] sessionId, byte flagsOnSig, SkEcdsaPublicKey sk, PrivateKey priv)
+            throws Exception {
+        ByteArrayBuffer payload = new ByteArrayBuffer();
+        payload.putString("testuser");
+        payload.putString(AbstractUserAuthServiceFactory.DEFAULT_NAME);
+        payload.putString(UserAuthPublicKey.NAME);
+        payload.putBoolean(true); // With signature
+        payload.putString(sk.getKeyType()); // Algorithm
+        payload.putPublicKey(sk);
+
+        MessageDigest md = SecurityUtils.getMessageDigest("SHA-256");
+        byte[] uint = new byte[4];
+        BufferUtils.putUInt(sessionId.length, uint);
+        md.update(uint);
+        md.update(sessionId);
+        md.update(SshConstants.SSH_MSG_USERAUTH_REQUEST);
+        byte[] sigBlobHash = md.digest(payload.getCompactData());
+
+        byte[] appHash = md.digest(sk.getAppName().getBytes(StandardCharsets.UTF_8));
+
+        Signature signer = BuiltinSignatures.nistp256.create();
+        signer.initSigner(null, priv);
+        signer.update(null, appHash);
+        uint[0] = flagsOnSig;
+        signer.update(null, uint, 0, 1);
+        BufferUtils.putUInt(42, uint); // Counter
+        signer.update(null, uint);
+        // Extensions only for webauthn, in which case they would also be in the skSignature below.
+        signer.update(null, sigBlobHash);
+        byte[] rawSignature = signer.sign(null);
+
+        ByteArrayBuffer skSignature = new ByteArrayBuffer();
+        skSignature.putString(sk.getKeyType());
+        skSignature.putBytes(rawSignature);
+        skSignature.putByte(flagsOnSig);
+        skSignature.putUInt(42); // Counter
+        // Webauthn stuff would follow.
+
+        payload.putBytes(skSignature.getCompactData());
+        return payload;
+    }
+
+    private static class MockSession extends ServerSessionImpl {
+
+        MockSession(ServerFactoryManager server, IoSession ioSession) throws Exception {
+            super(server, ioSession);
+        }
+
+        void setSessionId(byte[] id) {
+            sessionId = id.clone();
+        }
+    }
+}


### PR DESCRIPTION
Respect server-side attributes that may be set in an `authorized_keys` file: `no-touch-required` and `verify-required`. These flags exist _only_ server-side; the public keys received in an SSH_MSG_USERAUTH packet do not have them.

* Ensure that we do _not_ consider these flags when matching public keys received against the `authorized_keys` file.
* Ensure that for signature verification, we _do_ use a key that does carry these flags (i.e., created from the matching `AuthorizedKeyEntry`) so that we can properly check the flags in the signature.

Also throw an exception if there is bogus trailing data after the signature in the packet.