### PR TITLE
PROTOCOL.certkeys link to upstream is replaced with the new upstream link

### DIFF
--- a/docs/server-setup.md
+++ b/docs/server-setup.md
@@ -37,7 +37,7 @@ the host keys are modified. **Note**: saving key files in PEM format requires  t
 supporting artifacts be available in the code's classpath.
 
 * `HostKeyCertificateProvider` - used for OpenSSH public-key certificate authentication system
-as defined in [this document](https://github.com/openssh/openssh-portable/blob/master/PROTOCOL.certkeys)
+as defined in [this document](https://datatracker.ietf.org/doc/draft-miller-ssh-cert/)
 
 * `ShellFactory` - That's the part one usually has to write to customize the SSHD server. The shell factory will
 be used to create a new shell each time a user logs in and wants to run an interactive shell. SSHD provides a simple

--- a/docs/standards.md
+++ b/docs/standards.md
@@ -36,7 +36,7 @@
 
 * [OpenSSH support for U2F/FIDO security keys](https://github.com/openssh/openssh-portable/blob/master/PROTOCOL.u2f)
     * **Note:** the server side supports these keys by default. The client side requires specific initialization
-* [OpenSSH public-key certificate authentication system for use by SSH](https://github.com/openssh/openssh-portable/blob/master/PROTOCOL.certkeys)
+* [OpenSSH public-key certificate authentication system for use by SSH](https://datatracker.ietf.org/doc/draft-miller-ssh-cert/)
 * [OpenSSH 1.9 transport: strict key exchange extension](https://github.com/openssh/openssh-portable/blob/master/PROTOCOL)
 * [(Some) OpenSSH SFTP extensions](https://github.com/openssh/openssh-portable/blob/master/PROTOCOL)
 


### PR DESCRIPTION
Documentation link for the old PROTOCOL.certkeys in openssh-github points to the same place as the upstream project was changed to.

This just replicates the https://github.com/openssh/openssh-portable/commit/928f8dc commit for the documentation in this project, as all the replaced places were dead links.