### PR TITLE
fix: negate followLinks flag for checkSymlinkState

### DIFF
--- a/sshd-sftp/src/main/java/org/apache/sshd/sftp/server/AbstractSftpSubsystemHelper.java
+++ b/sshd-sftp/src/main/java/org/apache/sshd/sftp/server/AbstractSftpSubsystemHelper.java
@@ -1717,7 +1717,7 @@ public abstract class AbstractSftpSubsystemHelper
         LinkOption[] options = accessor.resolveFileAccessLinkOptions(
                 this, resolvedPath, SftpConstants.SSH_FXP_REMOVE, "", false);
         WithFileAttributeCache.withAttributeCache(resolvedPath, p -> {
-            Boolean status = checkSymlinkState(p, followLinks, options);
+            Boolean status = checkSymlinkState(p, !followLinks, options);
             if (status == null) {
                 throw signalRemovalPreConditionFailure(id, path, p,
                         new AccessDeniedException(p.toString(), p.toString(), "Cannot determine existence of remove candidate"),

--- a/sshd-sftp/src/main/java/org/apache/sshd/sftp/server/SftpSubsystem.java
+++ b/sshd-sftp/src/main/java/org/apache/sshd/sftp/server/SftpSubsystem.java
@@ -845,7 +845,7 @@ public class SftpSubsystem
                 this, file, SftpConstants.SSH_FXP_FSTAT, "", true);
 
         boolean followLinks = resolvePathResolutionFollowLinks(SftpConstants.SSH_FXP_FSTAT, handle, file);
-        return resolveFileAttributes(file, flags, followLinks, options);
+        return resolveFileAttributes(file, flags, !followLinks, options);
     }
 
     @Override

--- a/sshd-sftp/src/test/java/org/apache/sshd/sftp/client/SftpVersionsTest.java
+++ b/sshd-sftp/src/test/java/org/apache/sshd/sftp/client/SftpVersionsTest.java
@@ -49,6 +49,7 @@ import org.apache.sshd.client.session.ClientSession;
 import org.apache.sshd.common.util.GenericUtils;
 import org.apache.sshd.common.util.MapEntryUtils;
 import org.apache.sshd.common.util.MapEntryUtils.NavigableMapBuilder;
+import org.apache.sshd.common.util.OsUtils;
 import org.apache.sshd.common.util.io.IoUtils;
 import org.apache.sshd.server.channel.ChannelSession;
 import org.apache.sshd.server.command.Command;
@@ -70,6 +71,7 @@ import org.apache.sshd.sftp.server.SftpSubsystem;
 import org.apache.sshd.sftp.server.SftpSubsystemEnvironment;
 import org.apache.sshd.sftp.server.SftpSubsystemFactory;
 import org.apache.sshd.util.test.CommonTestSupportUtils;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.MethodOrderer.MethodName;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -566,6 +568,91 @@ public class SftpVersionsTest extends AbstractSftpClientTestSupport {
                     assertTrue(value, "Bad end-of-list value");
                 }
             }
+        }
+    }
+
+    @MethodSource("parameters")
+    @ParameterizedTest(name = "version={0}")
+    public void sftpRemoveFileWithSymlinkInPath(int version) throws Exception {
+        Assumptions.assumeFalse(OsUtils.isWin32(), "Symlinks not reliably supported on Windows");
+
+        initSftpVersionsTest(version);
+        Path targetPath = detectTargetFolder();
+        Path lclSftp = CommonTestSupportUtils.resolve(
+                targetPath,
+                SftpConstants.SFTP_SUBSYSTEM_NAME,
+                getClass().getSimpleName());
+        Path lclParent = assertHierarchyTargetFolderExists(lclSftp);
+        String testFileName = "test-file.txt";
+
+        Path actualDir = lclParent.resolve("actual-dir-" + getTestedVersion());
+        CommonTestSupportUtils.deleteRecursive(actualDir);
+        Files.createDirectories(actualDir);
+
+        Path symlinkDir = lclParent.resolve("symlink-dir-" + getTestedVersion());
+        Files.deleteIfExists(symlinkDir);
+        Files.createSymbolicLink(symlinkDir, actualDir);
+
+        Path fileViaSymlink = symlinkDir.resolve(testFileName);
+        Files.write(fileViaSymlink, "test content".getBytes(StandardCharsets.UTF_8));
+
+        assertTrue(Files.exists(fileViaSymlink), "File should exist via symlink path");
+        assertTrue(Files.exists(actualDir.resolve(testFileName)), "File should exist in actual directory");
+
+        Path parentPath = targetPath.getParent();
+        String remotePath = CommonTestSupportUtils.resolveRelativeRemotePath(parentPath, fileViaSymlink);
+
+        try (ClientSession session = createAuthenticatedClientSession();
+             SftpClient sftp = createSftpClient(session, getTestedVersion())) {
+            sftp.remove(remotePath);
+
+            assertFalse(Files.exists(fileViaSymlink), "File should be deleted via symlink path");
+            assertFalse(Files.exists(actualDir.resolve(testFileName)), "File should be deleted from actual directory");
+        } finally {
+            Files.deleteIfExists(symlinkDir);
+            CommonTestSupportUtils.deleteRecursive(actualDir);
+        }
+    }
+
+    @MethodSource("parameters")
+    @ParameterizedTest(name = "version={0}")
+    public void sftpFStatWithSymlinkInPath(int version) throws Exception {
+        Assumptions.assumeFalse(OsUtils.isWin32(), "Symlinks not reliably supported on Windows");
+
+        initSftpVersionsTest(version);
+        Path targetPath = detectTargetFolder();
+        Path lclSftp = CommonTestSupportUtils.resolve(targetPath,
+                SftpConstants.SFTP_SUBSYSTEM_NAME, getClass().getSimpleName());
+        Path lclParent = assertHierarchyTargetFolderExists(lclSftp);
+
+        Path actualDir = lclParent.resolve("actual-fstat-" + getTestedVersion());
+        CommonTestSupportUtils.deleteRecursive(actualDir);
+        Files.createDirectories(actualDir);
+
+        Path symlinkDir = lclParent.resolve("symlink-fstat-" + getTestedVersion());
+        Files.deleteIfExists(symlinkDir);
+        Files.createSymbolicLink(symlinkDir, actualDir);
+
+        Path testFile = symlinkDir.resolve("test.txt");
+        String content = getCurrentTestName();
+        Files.write(testFile, content.getBytes(StandardCharsets.UTF_8));
+
+        Path parentPath = targetPath.getParent();
+        String remotePath = CommonTestSupportUtils.resolveRelativeRemotePath(parentPath, testFile);
+
+        try (ClientSession session = createAuthenticatedClientSession();
+             SftpClient sftp = createSftpClient(session, getTestedVersion())) {
+            try (SftpClient.CloseableHandle handle = sftp.open(remotePath, SftpClient.OpenMode.Read)) {
+                Attributes attrs = sftp.stat(handle);
+
+                assertNotNull(attrs, "Attributes should be retrieved");
+                assertEquals(content.length(), attrs.getSize(), "File size mismatch");
+                assertTrue(attrs.isRegularFile(), "Should be a regular file");
+            }
+        } finally {
+            Files.deleteIfExists(testFile);
+            Files.deleteIfExists(symlinkDir);
+            CommonTestSupportUtils.deleteRecursive(actualDir);
         }
     }
 


### PR DESCRIPTION
I'm using sshd-sftp as a custom SFTP server for its great virtual file system capabilities (it allows me to easily create a virtual space for each user). Each user directory contains symlinks (essentially "shares") to folders outside of the virtual file system.

After upgrading to 2.16.0 I noticed that file deletion did not work anymore. It kept giving me a `NoSuchFileException` "Removal candidate not found".

In `doRemoveFile` it seems like `followLinks` is missing a `!` before being passed to `checkSymlinkState`. This was done correctly in other methods such as `doRemoveDirectory`.