### PR TITLE
GH-875: Update Apache Parent POM

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,10 +21,11 @@
 * [Version 2.13.2 to 2.14.0](./docs/changes/2.14.0.md)
 * [Version 2.14.0 to 2.15.0](./docs/changes/2.15.0.md)
 * [Version 2.15.0 to 2.16.0](./docs/changes/2.16.0.md)
+* [Version 2.16.0 to 2.17.0](./docs/changes/2.17.0.md)
 
 # Latest Version
 
-* **[Version 2.16.0 to 2.17.0](./docs/changes/2.17.0.md)**
+* **[Version 2.17.0 to 2.17.1](./docs/changes/2.17.1.md)**
 
 # Planned for Next Version
 

--- a/docs/changes/2.17.1.md
+++ b/docs/changes/2.17.1.md
@@ -1,0 +1,19 @@
+# Introduced in 2.17.1
+
+No code changes; only a POM update to fix a deployment problem with the Maven release of 2.17.0.
+
+For the real changes since version 2.16.0 see the [2.17.0 change notes](./2.17.0.md).
+
+## Bug Fixes
+
+* [GH-875](https://github.com/apache/mina-sshd/issues/875) Use Apache Parent POM 36
+
+## New Features
+
+None.
+
+## Potential Compatibility Issues
+
+None.
+
+## Major Code Re-factoring

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache</groupId>
         <artifactId>apache</artifactId>
-        <version>35</version>
+        <version>36</version>
     </parent>
 
     <groupId>org.apache.sshd</groupId>


### PR DESCRIPTION
From version 35 to 36.

Fixes #875. (When the release will be built.)