### PR TITLE
GH-905 Implement authorized_keys from and expiry-time checks

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -37,6 +37,7 @@
 
 ## New Features
 
+* [GH-905](https://github.com/apache/mina-sshd/issues/905) Implement the "from" and "expiry-time" options in `authorized_keys` handling in public key authentication
 
 ## Potential Compatibility Issues
 

--- a/sshd-core/src/main/java/org/apache/sshd/server/auth/pubkey/AuthorizedKeyEntriesPublickeyAuthenticator.java
+++ b/sshd-core/src/main/java/org/apache/sshd/server/auth/pubkey/AuthorizedKeyEntriesPublickeyAuthenticator.java
@@ -19,8 +19,18 @@
 package org.apache.sshd.server.auth.pubkey;
 
 import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import java.security.GeneralSecurityException;
 import java.security.PublicKey;
+import java.time.DateTimeException;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -28,11 +38,14 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Stream;
 
+import org.apache.sshd.client.config.hosts.HostPatternValue;
+import org.apache.sshd.client.config.hosts.HostPatternsHolder;
 import org.apache.sshd.common.AttributeRepository;
 import org.apache.sshd.common.config.keys.AuthorizedKeyEntry;
 import org.apache.sshd.common.config.keys.KeyUtils;
 import org.apache.sshd.common.config.keys.OpenSshCertificate;
 import org.apache.sshd.common.config.keys.PublicKeyEntryResolver;
+import org.apache.sshd.common.net.InetAddressRange;
 import org.apache.sshd.common.util.GenericUtils;
 import org.apache.sshd.common.util.MapEntryUtils;
 import org.apache.sshd.common.util.logging.AbstractLoggingBean;
@@ -100,12 +113,9 @@ public class AuthorizedKeyEntriesPublickeyAuthenticator extends AbstractLoggingB
                 if (log.isDebugEnabled()) {
                     log.debug("authenticate({})[{}] match found", username, session);
                 }
-                // TODO: the entry might have an "expiry-time" option.
-                // See https://man.openbsd.org/sshd.8#expiry-time=_timespec_
-                // (Certificate expiration as stored in the certificate itself has been checked already.)
-                // TODO: the entry might have a "from" option limiting possible source addresses by IP, hostnames,
-                // patterns, or CIDRs.
-                // See https://man.openbsd.org/sshd.8#from=_pattern-list_
+                if (!matchesLoginOptions(entry, username, session)) {
+                    continue;
+                }
                 if (isCert && !matchesPrincipals(entry, username, (OpenSshCertificate) key, session)) {
                     continue;
                 }
@@ -120,6 +130,123 @@ public class AuthorizedKeyEntriesPublickeyAuthenticator extends AbstractLoggingB
             log.debug("authenticate({})[{}] no match found", username, session);
         }
         return false;
+    }
+
+    protected boolean matchesLoginOptions(AuthorizedKeyEntry entry, String username, ServerSession session) {
+        Map<String, String> options = entry.getLoginOptions();
+        if (MapEntryUtils.isEmpty(options)) {
+            return true;
+        }
+        if (!matchesExpiryTime(username, session, options.get("expiry-time"))) {
+            return false;
+        }
+        return matchesFrom(username, session, options.get("from"));
+    }
+
+    protected boolean matchesExpiryTime(String username, ServerSession session, String expiryTime) {
+        if (GenericUtils.isEmpty(expiryTime)) {
+            return true;
+        }
+        try {
+            Instant expiry = parseExpiryTime(expiryTime);
+            if (Instant.now().isBefore(expiry)) {
+                return true;
+            }
+            log.debug("authenticate({})[{}] authorized key rejected, expiry-time has passed: {}", username, session,
+                    expiryTime);
+        } catch (DateTimeException | IllegalArgumentException e) {
+            log.debug("authenticate({})[{}] authorized key rejected, invalid expiry-time: {}", username, session,
+                    expiryTime, e);
+        }
+        return false;
+    }
+
+    protected Instant parseExpiryTime(String expiryTime) {
+        String value = GenericUtils.trimToEmpty(expiryTime);
+        boolean utc = value.endsWith("Z");
+        if (utc) {
+            value = value.substring(0, value.length() - 1);
+        }
+        ZoneId zone = utc ? ZoneOffset.UTC : ZoneId.systemDefault();
+        switch (value.length()) {
+            case 8:
+                return LocalDate.parse(value, DateTimeFormatter.BASIC_ISO_DATE).atStartOfDay(zone).toInstant();
+            case 12:
+                return LocalDateTime.parse(value, DateTimeFormatter.ofPattern("yyyyMMddHHmm")).atZone(zone).toInstant();
+            case 14:
+                return LocalDateTime.parse(value, DateTimeFormatter.ofPattern("yyyyMMddHHmmss")).atZone(zone).toInstant();
+            default:
+                throw new IllegalArgumentException("Unsupported expiry-time format: " + expiryTime);
+        }
+    }
+
+    protected boolean matchesFrom(String username, ServerSession session, String from) {
+        if (GenericUtils.isEmpty(from)) {
+            return true;
+        }
+        InetSocketAddress remote = resolveClientAddress(session);
+        if (remote == null) {
+            log.debug("authenticate({})[{}] authorized key rejected, no client address for from={}", username, session, from);
+            return false;
+        }
+        InetAddress remoteAddress = remote.getAddress();
+        String remoteHostAddress = (remoteAddress == null) ? remote.getHostString() : remoteAddress.getHostAddress();
+        String remoteCanonicalHostName = (remoteAddress == null)
+                ? remote.getHostString()
+                : remoteAddress.getCanonicalHostName();
+        boolean matchFound = false;
+
+        for (String pattern : from.split(",")) {
+            try {
+                String candidate = GenericUtils.trimToEmpty(pattern);
+                if (GenericUtils.isEmpty(candidate)) {
+                    continue;
+                }
+                boolean negated = candidate.charAt(0) == HostPatternsHolder.NEGATION_CHAR_PATTERN;
+                String rawPattern = negated ? candidate.substring(1) : candidate;
+                if (GenericUtils.isEmpty(rawPattern)) {
+                    return false;
+                }
+                boolean matched;
+                if (InetAddressRange.isCIDR(rawPattern)) {
+                    matched = (remoteAddress != null) && InetAddressRange.fromCIDR(rawPattern).contains(remoteAddress);
+                } else {
+                    HostPatternValue hostPattern = HostPatternsHolder.toPattern(candidate);
+                    matched = HostPatternsHolder.isHostMatch(remoteHostAddress, hostPattern.getPattern())
+                            || HostPatternsHolder.isHostMatch(remoteCanonicalHostName, hostPattern.getPattern());
+                }
+                if (!matched) {
+                    continue;
+                }
+                if (negated) {
+                    log.debug("authenticate({})[{}] authorized key rejected, client address matched negated from pattern: {}",
+                            username, session, candidate);
+                    return false;
+                }
+                matchFound = true;
+            } catch (RuntimeException e) {
+                log.debug("authenticate({})[{}] authorized key rejected, invalid from pattern: {}", username, session,
+                        pattern, e);
+                return false;
+            }
+        }
+
+        if (!matchFound) {
+            log.debug("authenticate({})[{}] authorized key rejected, client address did not match from={}", username,
+                    session, from);
+        }
+        return matchFound;
+    }
+
+    protected InetSocketAddress resolveClientAddress(ServerSession session) {
+        if (session == null) {
+            return null;
+        }
+        SocketAddress address = session.getClientAddress();
+        if (!(address instanceof InetSocketAddress)) {
+            address = session.getRemoteAddress();
+        }
+        return (address instanceof InetSocketAddress) ? (InetSocketAddress) address : null;
     }
 
     protected boolean matchesPrincipals(

--- a/sshd-core/src/test/java/org/apache/sshd/server/auth/AuthorizedKeyEntriesPublickeyAuthenticatorTest.java
+++ b/sshd-core/src/test/java/org/apache/sshd/server/auth/AuthorizedKeyEntriesPublickeyAuthenticatorTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.sshd.server.auth;
 
+import java.net.InetSocketAddress;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.interfaces.ECPublicKey;
@@ -30,11 +31,14 @@ import org.apache.sshd.common.config.keys.PublicKeyEntryResolver;
 import org.apache.sshd.common.config.keys.u2f.SkEcdsaPublicKey;
 import org.apache.sshd.common.util.ValidateUtils;
 import org.apache.sshd.server.auth.pubkey.AuthorizedKeyEntriesPublickeyAuthenticator;
+import org.apache.sshd.server.session.ServerSession;
 import org.apache.sshd.util.test.BaseTestSupport;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mockito;
 
 @Tag("NoIoTestCase")
 class AuthorizedKeyEntriesPublickeyAuthenticatorTest extends BaseTestSupport {
@@ -67,5 +71,84 @@ class AuthorizedKeyEntriesPublickeyAuthenticatorTest extends BaseTestSupport {
         AuthorizedKeyEntriesPublickeyAuthenticator auth = new AuthorizedKeyEntriesPublickeyAuthenticator("test", null,
                 Collections.singletonList(entry), PublicKeyEntryResolver.FAILING);
         assertTrue(auth.authenticate("user", pubKey, null));
+    }
+
+    @Test
+    void fromAllowsMatchingAddress() throws Exception {
+        KeyPair pair = generateKeyPair();
+        ServerSession session = session(new InetSocketAddress("127.0.0.1", 12345));
+
+        assertTrue(authenticate("from=\"127.0.0.1\"", pair, session));
+    }
+
+    @Test
+    void fromRejectsDifferentAddress() throws Exception {
+        KeyPair pair = generateKeyPair();
+        ServerSession session = session(new InetSocketAddress("203.0.113.10", 12345));
+
+        assertFalse(authenticate("from=\"127.0.0.1\"", pair, session));
+    }
+
+    @Test
+    void fromAllowsMatchingCidr() throws Exception {
+        KeyPair pair = generateKeyPair();
+        ServerSession session = session(new InetSocketAddress("192.0.2.25", 12345));
+
+        assertTrue(authenticate("from=\"192.0.2.0/24\"", pair, session));
+    }
+
+    @Test
+    void fromRejectsNegatedAddress() throws Exception {
+        KeyPair pair = generateKeyPair();
+        ServerSession session = session(new InetSocketAddress("203.0.113.10", 12345));
+
+        assertFalse(authenticate("from=\"*,!203.0.113.10\"", pair, session));
+    }
+
+    @Test
+    void fromRejectsInvalidPattern() throws Exception {
+        KeyPair pair = generateKeyPair();
+        ServerSession session = session(new InetSocketAddress("203.0.113.10", 12345));
+
+        assertFalse(authenticate("from=\"203.0.113.0/33\"", pair, session));
+    }
+
+    @Test
+    void expiryTimeAllowsFutureTime() throws Exception {
+        KeyPair pair = generateKeyPair();
+
+        assertTrue(authenticate("expiry-time=\"29991231235959Z\"", pair, null));
+    }
+
+    @Test
+    void expiryTimeRejectsPastTime() throws Exception {
+        KeyPair pair = generateKeyPair();
+
+        assertFalse(authenticate("expiry-time=\"19700101000000Z\"", pair, null));
+    }
+
+    private static boolean authenticate(String options, KeyPair pair, ServerSession session) throws Exception {
+        String line = options;
+        if (!line.isEmpty()) {
+            line += ' ';
+        }
+        line += PublicKeyEntry.toString(pair.getPublic());
+        AuthorizedKeyEntry entry = AuthorizedKeyEntry.parseAuthorizedKeyEntry(line);
+        AuthorizedKeyEntriesPublickeyAuthenticator auth = new AuthorizedKeyEntriesPublickeyAuthenticator("test", session,
+                Collections.singletonList(entry), PublicKeyEntryResolver.FAILING);
+        return auth.authenticate("user", pair.getPublic(), session);
+    }
+
+    private static KeyPair generateKeyPair() throws Exception {
+        KeyPairGenerator gen = KeyPairGenerator.getInstance("EC");
+        gen.initialize(256);
+        return gen.generateKeyPair();
+    }
+
+    private static ServerSession session(InetSocketAddress remote) {
+        ServerSession session = Mockito.mock(ServerSession.class);
+        Mockito.when(session.getClientAddress()).thenReturn(remote);
+        Mockito.when(session.getRemoteAddress()).thenReturn(remote);
+        return session;
     }
 }


### PR DESCRIPTION
This PR implements the missing authorized_keys option checks tracked in GH-905.

Changes:
- Enforce the expiry-time option before accepting a matching authorized_keys entry.
- Enforce the from option using the client address, with support for address/hostname patterns, negation, and CIDR ranges.
- Prefer ServerSession#getClientAddress(), falling back to getRemoteAddress().
- Reject invalid from patterns and invalid expiry-time values fail-closed.
- Add unit tests for matching from, rejected from, CIDR, negation, invalid from, future expiry-time, and expired keys.

Tests:
- .\mvnw.cmd -pl sshd-core -am -Dtest=AuthorizedKeyEntriesPublickeyAuthenticatorTest '-Dsurefire.failIfNoSpecifiedTests=false' test