### PR TITLE
GH-656: shrink ChannelPipedInputStream buffer after all data is read

### DIFF
--- a/sshd-core/src/main/java/org/apache/sshd/common/channel/ChannelPipedInputStream.java
+++ b/sshd-core/src/main/java/org/apache/sshd/common/channel/ChannelPipedInputStream.java
@@ -153,7 +153,9 @@ public class ChannelPipedInputStream extends InputStream implements ChannelPiped
                 len = buffer.available();
             }
             buffer.getRawBytes(b, off, len);
-            if ((buffer.rpos() > localWindow.getPacketSize()) || (buffer.available() == 0)) {
+            if (buffer.available() == 0) {
+                buffer = new ByteArrayBuffer();
+            } else if (buffer.rpos() > localWindow.getPacketSize()) {
                 buffer.compact();
             }
         } finally {
@@ -170,6 +172,9 @@ public class ChannelPipedInputStream extends InputStream implements ChannelPiped
         lock.lock();
         try {
             writerClosed.set(true);
+            if (buffer != null && buffer.available() == 0) {
+                buffer = new ByteArrayBuffer();
+            }
             dataAvailable.signalAll();
         } finally {
             lock.unlock();

--- a/sshd-core/src/test/java/org/apache/sshd/common/channel/ChannelPipedInputStreamTest.java
+++ b/sshd-core/src/test/java/org/apache/sshd/common/channel/ChannelPipedInputStreamTest.java
@@ -19,11 +19,13 @@
 package org.apache.sshd.common.channel;
 
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
 
 import org.apache.sshd.common.PropertyResolverUtils;
+import org.apache.sshd.common.util.buffer.ByteArrayBuffer;
 import org.apache.sshd.util.test.BaseTestSupport;
 import org.apache.sshd.util.test.BogusChannel;
 import org.junit.jupiter.api.MethodOrderer.MethodName;
@@ -61,6 +63,34 @@ public class ChannelPipedInputStreamTest extends BaseTestSupport {
     }
 
     @Test
+    void bufferShrinksAfterAllDataRead() throws Exception {
+        try (ChannelPipedInputStream stream = createTestStream()) {
+            int dataLen = 64 * 1024;
+            byte[] data = new byte[dataLen];
+            Arrays.fill(data, (byte) 'x');
+            stream.receive(data, 0, data.length);
+            stream.eof();
+
+            ByteArrayBuffer buffer = getInternalBuffer(stream);
+            assertEquals(dataLen, buffer.array().length, "Buffer should grow to hold received data");
+
+            byte[] readBuf = new byte[dataLen];
+            int totalRead = 0;
+            while (totalRead < dataLen) {
+                int n = stream.read(readBuf, totalRead, dataLen - totalRead);
+                if (n < 0) {
+                    fail("Unexpected EOF before all data read");
+                }
+                totalRead += n;
+            }
+            assertEquals(-1, stream.read(), "Unexpectedly not at EOF");
+
+            assertEquals(ByteArrayBuffer.DEFAULT_SIZE, getInternalBuffer(stream).array().length,
+                    "Buffer should shrink after all data has been read");
+        }
+    }
+
+    @Test
     void idempotentClose() throws IOException {
         try (ChannelPipedInputStream stream = createTestStream()) {
             byte[] b = getCurrentTestName().getBytes(StandardCharsets.UTF_8);
@@ -78,6 +108,12 @@ public class ChannelPipedInputStreamTest extends BaseTestSupport {
         LocalWindow window = new LocalWindow(channel, true);
         window.init(PropertyResolverUtils.toPropertyResolver(Collections.emptyMap()));
         return new ChannelPipedInputStream(channel, window);
+    }
+
+    private static ByteArrayBuffer getInternalBuffer(ChannelPipedInputStream stream) throws Exception {
+        Field f = ChannelPipedInputStream.class.getDeclaredField("buffer");
+        f.setAccessible(true);
+        return (ByteArrayBuffer) f.get(stream);
     }
 
     private static void assertStreamEquals(byte[] expected, byte[] read) {


### PR DESCRIPTION
Fixes #656

## Summary
- When all piped data has been consumed, replace the internal `ByteArrayBuffer` with a fresh default-sized buffer instead of calling `compact()`, which only resets positions and leaves the large backing array allocated
- On `eof()` with no unread data, apply the same shrink so cached SSH sessions do not retain ~512 KB per channel after command completion

## Test plan
- [x] Added `bufferShrinksAfterAllDataRead` regression test (64 KiB payload; asserts backing array returns to `ByteArrayBuffer.DEFAULT_SIZE` after drain + EOF)
- [x] Existing `ChannelPipedInputStreamTest` cases pass
- [x] Command: `mvn -pl sshd-core -am -DskipTests install -q && mvn -pl sshd-core -Dtest=ChannelPipedInputStreamTest test` (Java 21, Maven 3.9.16)

Made with [Cursor](https://cursor.com)